### PR TITLE
Simple implementation to receive and reply to Mobile Commons messages 

### DIFF
--- a/lib/middleware/receive-message/message-inbound.js
+++ b/lib/middleware/receive-message/message-inbound.js
@@ -4,6 +4,9 @@ const helpers = require('../../helpers');
 
 module.exports = function createInboundMessage() {
   return (req, res, next) => {
+    if (req.inboundMessageText) {
+      req.userCommand = req.inboundMessageText.trim();
+    }
     req.conversation.createInboundMessage(req.inboundMessageText)
       .then((message) => {
         req.inboundMessage = message;

--- a/lib/middleware/receive-message/params.js
+++ b/lib/middleware/receive-message/params.js
@@ -7,26 +7,44 @@ module.exports = function params() {
     logger.debug('POST /receive-message req.body', req.body);
 
     const body = req.body;
+    req.inboundMessageText = body.text;
+
+    if (req.query.medium === 'mobilecommons') {
+      req.platform = 'mobilecommons';
+      req.userId = body.phone;
+
+      const keyword = req.body.keyword;
+      if (keyword) {
+        req.inboundMessageText = keyword;
+      }
+
+      return next();
+    }
+
     if (body.slackId) {
       req.platform = 'slack';
       req.userId = body.slackId;
       req.slackChannel = body.slackChannel;
-    } else if (body.phone) {
+
+      return next();
+    }
+
+    if (body.phone) {
       req.platform = 'twilio';
       req.userId = body.phone;
-    } else if (body.facebookId) {
+
+      return next();
+    }
+
+    if (body.facebookId) {
       req.platform = 'facebook';
       req.userId = body.facebookId;
-    } else {
-      req.userId = body.userId;
-      req.platform = 'api';
-    }
-    // TODO: Add default for API / Consolebot.
 
-    req.inboundMessageText = body.text;
-    if (req.inboundMessageText) {
-      req.userCommand = req.inboundMessageText.trim();
+      return next();
     }
+
+    req.userId = body.userId;
+    req.platform = 'api';
 
     return next();
   };


### PR DESCRIPTION
I've created a new mData that posts to `/receive-message?medium=mobilecommons` and sends the Conversations API response back to the User via Mobile Commons.

This branch adds a check for a `medium` query parameter. When set to `mobilecommons`, set our `req.userId` to the `req.body.phone`, and set our `req.inboundMessageText` as the `req.body.keyword` if it exists.

An mData can be configured to render the response from its Web Service URL with Liquid -- the Gambit Conversations mData sends the [`reply.text` response of its POST `/receive-message` request](https://github.com/DoSomething/gambit-conversations/tree/master/documentation#response).

<img width="554" alt="screen shot 2017-07-26 at 5 10 09 pm" src="https://user-images.githubusercontent.com/1236811/28648814-66ffd854-7225-11e7-8bc2-769f6b2720a9.png">


We can also customize the parameters the mData sends. What's really nice about this approach is we only get the parameters we define, not the entire mData payload:


<img width="449" alt="screen shot 2017-07-26 at 5 10 22 pm" src="https://user-images.githubusercontent.com/1236811/28648810-64b224c6-7225-11e7-84e1-bffd44783a02.png">

A kicker here is we're cutting Blink out of the picture, since the mData is waiting on the request to the Conversations API to send the reply back. Looking to investigate if it's possible to use our Mobile Commons Twilio API creds for sending the reply back, like how we do for our current Gambit Campaigns `chatbot` endpoint, vs relying on the mData waiting for a response to send.