### PR TITLE
Support passing a From number to Twilio Messages API

### DIFF
--- a/app/models/Conversation.js
+++ b/app/models/Conversation.js
@@ -186,7 +186,7 @@ conversationSchema.methods.sendMessage = function (message) {
   if (this.medium === 'slack') {
     slack.postMessage(this.slackChannel, messageText);
   }
-  if (this.medium === 'twilio') {
+  if (this.medium === 'sms') {
     twilio.postMessage(this.userId, messageText);
   }
   if (this.medium === 'facebook') {

--- a/config/lib/twilio.js
+++ b/config/lib/twilio.js
@@ -1,0 +1,8 @@
+'use strict';
+
+module.exports = {
+  accountSid: process.env.TWILIO_ACCOUNT_SID,
+  authToken: process.env.TWILIO_AUTH_TOKEN,
+  fromNumber: process.env.TWILIO_FROM_NUMBER,
+  messagingServiceSid: process.env.TWILIO_MESSAGING_SERVICE_SID,
+};

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -1,4 +1,4 @@
-## Chatbot
+## Receive Message
 
 ```
 POST /api/v1/receive-message
@@ -12,7 +12,8 @@ Receives a message and sends a reply (or forwards it, when appropriate).
 
 Name | Type | Description
 --- | --- | ---
-`phone` | `string` | 
+`From` | `string` | Sender's phone number (included when we receive a Twilio message)
+`Body` | `string` | Incoming message (included when we receive a Twilio message)
 `slackId` | `string` | 
 `slackChannel` | `string` | 
 `facebookId` | `string` | 

--- a/lib/middleware/receive-message/params.js
+++ b/lib/middleware/receive-message/params.js
@@ -9,18 +9,6 @@ module.exports = function params() {
     const body = req.body;
     req.inboundMessageText = body.text;
 
-    if (req.query.medium === 'mobilecommons') {
-      req.platform = 'mobilecommons';
-      req.userId = body.phone;
-
-      const keyword = req.body.keyword;
-      if (keyword) {
-        req.inboundMessageText = keyword;
-      }
-
-      return next();
-    }
-
     if (body.slackId) {
       req.platform = 'slack';
       req.userId = body.slackId;
@@ -29,9 +17,10 @@ module.exports = function params() {
       return next();
     }
 
-    if (body.phone) {
-      req.platform = 'twilio';
-      req.userId = body.phone;
+    if (body.MessageSid) {
+      req.platform = 'sms';
+      req.userId = req.body.From;
+      req.inboundMessageText = req.body.Body;
 
       return next();
     }

--- a/lib/middleware/receive-message/params.js
+++ b/lib/middleware/receive-message/params.js
@@ -19,8 +19,8 @@ module.exports = function params() {
 
     if (body.MessageSid) {
       req.platform = 'sms';
-      req.userId = req.body.From;
-      req.inboundMessageText = req.body.Body;
+      req.userId = body.From;
+      req.inboundMessageText = body.Body;
 
       return next();
     }

--- a/lib/middleware/receive-message/params.js
+++ b/lib/middleware/receive-message/params.js
@@ -21,6 +21,8 @@ module.exports = function params() {
       req.platform = 'sms';
       req.userId = body.From;
       req.inboundMessageText = body.Body;
+      // TODO: We need to save attachments here if we're ditching Gambit Adapters and Blink is
+      // posting directly to this /receive-message route.
 
       return next();
     }

--- a/lib/twilio.js
+++ b/lib/twilio.js
@@ -3,15 +3,21 @@
 const accountSid = process.env.TWILIO_ACCOUNT_SID;
 const authToken = process.env.TWILIO_AUTH_TOKEN;
 const messagingServiceSid = process.env.TWILIO_MESSAGING_SERVICE_SID;
+const fromNumber = process.env.TWILIO_FROM_NUMBER;
 
 const client = require('twilio')(accountSid, authToken);
 
 module.exports.postMessage = function (phone, messageText) {
   const payload = {
     to: phone,
-    messagingServiceSid,
     body: messageText,
   };
+
+  if (messagingServiceSid) {
+    payload.messagingServiceSid = messagingServiceSid;
+  } else {
+    payload.from = fromNumber;
+  }
 
   return client.messages.create(payload);
 };

--- a/lib/twilio.js
+++ b/lib/twilio.js
@@ -1,11 +1,8 @@
 'use strict';
 
-const accountSid = process.env.TWILIO_ACCOUNT_SID;
-const authToken = process.env.TWILIO_AUTH_TOKEN;
-const messagingServiceSid = process.env.TWILIO_MESSAGING_SERVICE_SID;
-const fromNumber = process.env.TWILIO_FROM_NUMBER;
+const config = require('../config/lib/twilio');
 
-const client = require('twilio')(accountSid, authToken);
+const client = require('twilio')(config.accountSid, config.authToken);
 
 module.exports.postMessage = function (phone, messageText) {
   const payload = {
@@ -13,10 +10,10 @@ module.exports.postMessage = function (phone, messageText) {
     body: messageText,
   };
 
-  if (messagingServiceSid) {
-    payload.messagingServiceSid = messagingServiceSid;
+  if (config.messagingServiceSid) {
+    payload.messagingServiceSid = config.messagingServiceSid;
   } else {
-    payload.from = fromNumber;
+    payload.from = config.fromNumber;
   }
 
   return client.messages.create(payload);


### PR DESCRIPTION
* Adds optional `TWILIO_FROM_NUMBER` config variable to post a message using a [From number instead of a Messaging Service Sid](https://www.twilio.com/docs/api/rest/sending-messages#post-parameters-conditional). This allows us to post messages using our Mobile Commons Twilio API credentials by passing our shortcode or test longcode as the `From`.
    * Adds `/config/lib/twilio` to define Twilio config vars 

* Removes check for a `mobilecommons` query parameter, as we don't need an mData (#40) to post Mobile Commons messages to Conversations API per https://github.com/DoSomething/blink/pull/97

* Creates Conversation with medium `sms` instead of `twilio` for SMS Conversations

* `/receive-message` sets our Conversation medium as SMS by checking for expected Twilio parameters, so we're ready for Blink to sending messages received by our Mobile Commons test number: https://github.com/DoSomething/blink/issues/102
    * This essentially deprecates our Twilio route in Gambit Adapters, as Blink is posting directly to Conversations (not Adapters). I think this makes sense to do, since Conversations API will return an error if for whatever reason it can't process the message it receives. 


