### PR TITLE
External Signup Confirmations via POST /send-message

### DIFF
--- a/app/models/Campaign.js
+++ b/app/models/Campaign.js
@@ -43,7 +43,9 @@ function parseGambitCampaign(gambitCampaign) {
   };
 
   const templates = Object.keys(gambitCampaign.messages);
-  templates.map(template => result[template] = gambitCampaign.messages[template].rendered);
+  templates.forEach((template) => {
+    result[template] = gambitCampaign.messages[template].rendered;
+  });
 
   result.keywords = gambitCampaign.keywords.map(keywordObject => keywordObject.keyword);
 

--- a/app/models/Campaign.js
+++ b/app/models/Campaign.js
@@ -14,6 +14,8 @@ const campaignSchema = new mongoose.Schema({
   status: String,
   keywords: [String],
   topic: String,
+  externalSignupMenuMessage: String,
+  scheduledRelativeToSignupDateMessage: String,
 });
 
 /**
@@ -39,6 +41,9 @@ function parseGambitCampaign(gambitCampaign) {
     title: gambitCampaign.title,
     status: gambitCampaign.status,
   };
+
+  const templates = Object.keys(gambitCampaign.messages);
+  templates.map(template => result[template] = gambitCampaign.messages[template].rendered);
 
   result.keywords = gambitCampaign.keywords.map(keywordObject => keywordObject.keyword);
 
@@ -68,7 +73,7 @@ campaignSchema.statics.fetchCampaign = function (campaignId) {
       campaign.topic = getTopicForCampaignId(campaignId);
 
       return this.findOneAndUpdate({ _id: campaignId }, campaign, { upsert: true })
-        .then(() => logger.debug('Campaign.fetchCampaign', campaign));
+        .then(() => logger.trace('Campaign.fetchCampaign', campaign));
     })
     .catch(err => logger.error('Campaign.fetchCampaign', err));
 };

--- a/app/models/Conversation.js
+++ b/app/models/Conversation.js
@@ -204,16 +204,21 @@ conversationSchema.methods.createOutboundImportMessage = function (messageText, 
  * @args {object} args
  */
 conversationSchema.methods.sendMessage = function (message) {
-  logger.debug('conversation.sendMessage');
+  const loggerMessage = 'conversation.sendMessage';
+  logger.debug('conversation.sendMessage', { text: message.text });
 
   const messageText = message.text;
 
   if (this.medium === 'slack') {
     slack.postMessage(this.slackChannel, messageText);
   }
+
   if (this.medium === 'sms') {
-    twilio.postMessage(this.userId, messageText);
+    twilio.postMessage(this.userId, messageText)
+      .then(res => logger.debug(loggerMessage, res))
+      .catch(err => logger.error(loggerMessage, err));
   }
+
   if (this.medium === 'facebook') {
     facebook.postMessage(this.userId, messageText);
   }

--- a/app/models/Conversation.js
+++ b/app/models/Conversation.js
@@ -224,4 +224,14 @@ conversationSchema.methods.sendMessage = function (message) {
   }
 };
 
+/**
+ * Should we POST to Gambit Campaigns to determine how to reply to an inbound message? 
+ * @return {boolean}
+ */
+conversationSchema.methods.shouldPostToGambitCampaigns = function () {
+  const templates = ['gambit', 'externalSignupMenuMessage'];
+
+  return templates.includes(this.lastOutboundTemplate);
+};
+
 module.exports = mongoose.model('conversations', conversationSchema);

--- a/app/models/Conversation.js
+++ b/app/models/Conversation.js
@@ -215,7 +215,7 @@ conversationSchema.methods.sendMessage = function (message) {
 
   if (this.medium === 'sms') {
     twilio.postMessage(this.userId, messageText)
-      .then(res => logger.debug(loggerMessage, res))
+      .then(res => logger.debug(loggerMessage, { status: res.status }))
       .catch(err => logger.error(loggerMessage, err));
   }
 

--- a/app/routes/receive-message.js
+++ b/app/routes/receive-message.js
@@ -8,8 +8,8 @@ const router = express.Router();
 bot.getBot();
 
 const paramsMiddleware = require('../../lib/middleware/receive-message/params');
-const getConvoMiddleware = require('../../lib/middleware/conversation-get');
-const createConvoMiddleware = require('../../lib/middleware/conversation-create');
+const getConversationMiddleware = require('../../lib/middleware/conversation-get');
+const createConversationMiddleware = require('../../lib/middleware/conversation-create');
 
 const inboundMessageMiddleware = require('../../lib/middleware/receive-message/message-inbound');
 
@@ -29,9 +29,9 @@ const outboundMessageMiddleware = require('../../lib/middleware/receive-message/
 
 router.use(paramsMiddleware());
 
-// Load convo and create inbound message.
-router.use(getConvoMiddleware());
-router.use(createConvoMiddleware());
+// Load conversation and create inbound message.
+router.use(getConversationMiddleware());
+router.use(createConversationMiddleware());
 router.use(inboundMessageMiddleware());
 
 // Send our inbound message to Rivescript bot for a reply.

--- a/app/routes/send-message.js
+++ b/app/routes/send-message.js
@@ -7,12 +7,16 @@ const router = express.Router();
 
 const paramsMiddleware = require('../../lib/middleware/send-message/params');
 const getConversationMiddleware = require('../../lib/middleware/conversation-get');
+const createConversationMiddleware = require('../../lib/middleware/conversation-create');
+
 const campaignMiddleware = require('../../lib/middleware/send-message/campaign');
 // const supportMiddleware = require('../../lib/middleware/send-message/support-resolved');
 const outboundMessageMiddleware = require('../../lib/middleware/send-message/message-outbound');
 
 router.use(paramsMiddleware());
 router.use(getConversationMiddleware());
+router.use(createConversationMiddleware());
+
 router.use(campaignMiddleware());
 // router.use(supportMiddleware());
 router.use(outboundMessageMiddleware());

--- a/app/routes/send-message.js
+++ b/app/routes/send-message.js
@@ -5,14 +5,16 @@ const helpers = require('../../lib/helpers');
 
 const router = express.Router();
 
-const paramsMiddleware = require('../../lib/middleware/send-message/params');
+const campaignMiddleware = require('../../lib/middleware/send-message/campaign');
+const supportMiddleware = require('../../lib/middleware/send-message/params');
 const getConversationMiddleware = require('../../lib/middleware/conversation-get');
 const supportResolvedMiddleware = require('../../lib/middleware/send-message/support-resolved');
 const outboundMessageMiddleware = require('../../lib/middleware/send-message/message-outbound');
 
-router.use(paramsMiddleware());
 router.use(getConversationMiddleware());
-router.use(supportResolvedMiddleware());
+router.use(campaignMiddleware());
+//router.use(supportMiddleware());
+//router.use(supportResolvedMiddleware());
 router.use(outboundMessageMiddleware());
 router.post('/', (req, res) => helpers.sendResponse(req, res));
 

--- a/app/routes/send-message.js
+++ b/app/routes/send-message.js
@@ -10,7 +10,7 @@ const getConversationMiddleware = require('../../lib/middleware/conversation-get
 const createConversationMiddleware = require('../../lib/middleware/conversation-create');
 
 const campaignMiddleware = require('../../lib/middleware/send-message/campaign');
-// const supportMiddleware = require('../../lib/middleware/send-message/support-resolved');
+const supportMiddleware = require('../../lib/middleware/send-message/support');
 const outboundMessageMiddleware = require('../../lib/middleware/send-message/message-outbound');
 
 router.use(paramsMiddleware());
@@ -18,8 +18,9 @@ router.use(getConversationMiddleware());
 router.use(createConversationMiddleware());
 
 router.use(campaignMiddleware());
-// router.use(supportMiddleware());
+router.use(supportMiddleware());
 router.use(outboundMessageMiddleware());
+
 router.post('/', (req, res) => helpers.sendResponse(req, res));
 
 module.exports = router;

--- a/app/routes/send-message.js
+++ b/app/routes/send-message.js
@@ -5,16 +5,16 @@ const helpers = require('../../lib/helpers');
 
 const router = express.Router();
 
-const campaignMiddleware = require('../../lib/middleware/send-message/campaign');
-const supportMiddleware = require('../../lib/middleware/send-message/params');
+const paramsMiddleware = require('../../lib/middleware/send-message/params');
 const getConversationMiddleware = require('../../lib/middleware/conversation-get');
-const supportResolvedMiddleware = require('../../lib/middleware/send-message/support-resolved');
+const campaignMiddleware = require('../../lib/middleware/send-message/campaign');
+// const supportMiddleware = require('../../lib/middleware/send-message/support-resolved');
 const outboundMessageMiddleware = require('../../lib/middleware/send-message/message-outbound');
 
+router.use(paramsMiddleware());
 router.use(getConversationMiddleware());
 router.use(campaignMiddleware());
-//router.use(supportMiddleware());
-//router.use(supportResolvedMiddleware());
+// router.use(supportMiddleware());
 router.use(outboundMessageMiddleware());
 router.post('/', (req, res) => helpers.sendResponse(req, res));
 

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -1,183 +1,31 @@
+# Gambit Conversations
+
+This is __Gambit Conversations__, the DoSomething.org multi-platform chatbot service. 
+
 ## Authentication
-The `receive-message`, `import-message`, and `send-message` routes are protected by Basic Auth. Requests should include an Authorization header.
-
-#### Supplying basic auth headers [(Source)](https://developer.atlassian.com/cloud/jira/platform/jira-rest-api-basic-authentication/#supplying-basic-auth-headers)
-
-##### Manually
-To do this you need to perform the following steps:
-
-- Build a string of the form `name:pass`
-- Base64 encode the string
-- Supply an “Authorization” header with content “Basic ” followed by the encoded string. For example, the string `fred:fred` encodes to `ZnJlZDpmcmVk` in base64, so you would make the request as follows.
-```
-curl -D -X POST -H "Authorization: Basic ZnJlZDpmcmVk" -H "Content-Type: application/json" "http://localhost:5100/api/v1/import-message"
-```
-
-##### As part of the URL (Especially helpful for webhooks)
-Prepend the `name` and `pass` in the form `name:pass@` to the endpoint URL.
-```
-http://name:pass@localhost:5100/api/v1/import-message
-```
-
-## Receive Message
-
-```
-POST /api/v1/receive-message
-```
-
-Receives a message and sends a reply (or forwards it, when appropriate).
+See [Authentication](authentication.md) for details on authorizing your requests.
 
 
-## Input
+## Endpoints
 
-Name | Type | Description
---- | --- | ---
-`From` | `string` | Sender's phone number (included when we receive a Twilio message)
-`Body` | `string` | Incoming message (included when we receive a Twilio message)
-`slackId` | `string` |
-`slackChannel` | `string` |
-`facebookId` | `string` |
-`userId` | `string` | Northstar ID
-`text` | `string` | Incoming message sent from User.
-`mediaUrl` | `string` | Media attachment URL (currently only supports 1 attachment).
-
-## Examples
-
-### Request
-
-Example of an inbound Twilio request.
-> The user's conversation state is currently expecting a reportback picture
-
-```
-{
-  "ToCountry": "US",
-  "MediaContentType0": "image/png",
-  "ToState": "",
-  "SmsMessageSid": "MM09a8f657567f807443191c1e7exxxxxx",
-  "NumMedia": "1",
-  "ToCity": "",
-  "FromZip": "10010",
-  "SmsSid": "MM09a8f657567f807443191c1e7exxxxxx",
-  "FromState": "NY",
-  "SmsStatus": "received",
-  "FromCity": "NEW YORK",
-  "Body": "",
-  "FromCountry": "US",
-  "To": "38383",
-  "ToZip": "",
-  "NumSegments": "1",
-  "MessageSid": "MM09a8f657567f807443191c1e7exxxxxx",
-  "From": "+5555555555",
-  "MediaUrl0": "http://bit.ly/2wkfrep",
-  "ApiVersion": "2010-04-01"
-}
-```
-
-### Created message
-
-```
-{
-  "_id": ObjectId("5995cf29e4bca305f02e50b3"),
-  "updatedAt": ISODate("2017-08-17T17:15:21.865Z"),
-  "createdAt": ISODate("2017-08-17T17:15:21.865Z"),
-  "userId": "+5555555555",
-  "campaignId": 819,
-  "topic": "campaign",
-  "conversation": ObjectId("5994caf4a92890fa8a52de72"),
-  "text": "",
-  "direction": "inbound",
-  "attachments": [
-    {
-      "contentType": "image/jpeg",
-      "url": "http://placekitten.com/g/800/800"
-    }
-  ],
-  "__v": 0
-}
-```
-
-### Response
-
-```
-{
-  "reply": {
-    "__v": 0,
-    "updatedAt": "2017-08-17T17:15:22.466Z",
-    "createdAt": "2017-08-17T17:15:22.466Z",
-    "userId": "+5555555555",
-    "campaignId": 819,
-    "topic": "campaign",
-    "conversation": "5994caf4a92890fa8a52de72",
-    "text": "Got it! Now text back a caption for your photo (think Instagram)! Keep it short & sweet, under 60 characters please.",
-    "template": "gambit",
-    "direction": "outbound-reply",
-    "_id": "5995cf2ae4bca305f02e50b4",
-    "attachments": []
-  }
-}
-```
-
-### Request
-
-```
-curl -X "POST" "http://localhost:5100/api/v1/retrieve-message" \
-     -H "Content-Type: application/x-www-form-urlencoded; charset=utf-8" \
-     --data-urlencode "userId=123" \
-     --data-urlencode "text=I can haz thumb socks?" \
-```
-
-### Response
-
-Returns an Outbound Reply Message (when Conversation is not paused).
-
-```
-{
-  "reply": {
-    "__v": 0,
-    "updatedAt": "2017-08-17T17:15:22.466Z",
-    "createdAt": "2017-08-17T17:15:22.466Z",
-    "userId": "U1BBD0D4G",
-    "topic": "random",
-    "conversation": "5977aed9bb17210a72aad245",
-    "text": "Sorry, I'm not sure how to respond to that.\n\nSay MENU to find a Campaign to join.",
-    "template": "noCampaignMessage",
-    "direction": "outbound-reply",
-    "_id": "59776272230c54001125ef7c",
-    "attachments": []
-  }
-}
-```
-
-## Send Message
-
-Sends a message to User.
+Endpoint | Functionality                                           
+-------- | -------------
+`POST /api/v1/receive-message` | [Receive inbound Message](endpoints/receive-message.md)
+`POST /api/v1/send-message` | [Send outbound Message](endpoints/send-message.md)
+`POST /api/v1/import-message` | Import outbound Message
+`GET /api/v1/conversations` | Retrieve all Conversations
+`GET /api/v1/conversations/:id` | Retrieve a Conversation
+`GET /api/v1/messages` | Retrieve all Messages
+`GET /api/v1/messages/:id` | Retrieve a Message
 
 
-```
-POST /api/v1/send-message
-```
+### Query paramters
 
-## Conversations
-
-
-```
-GET /api/v1/conversations
-```
-
-## Messages
-
-```
-GET /api/v1/messages
-```
-
-
-## Query paramters
-
-See https://florianholzapfel.github.io/express-restify-mongoose/ for the GET endpoints:
+See https://florianholzapfel.github.io/express-restify-mongoose/ for querying the GET endpoints:
 
 ### Filtering
-* https://gambit-conversations-prod.herokuapp.com/api/v1/messages?query={"platform":"slack"}
-* https://gambit-conversations-prod.herokuapp.com/api/v1/messages?query={"date":{"$gt":"2017-06-24T00:34:11.114Z"}}
+* https://gambit-conversations-staging.herokuapp.com/api/v1/messages?query={"platform":"slack"}
+* https://gambit-conversations-staging.herokuapp.com/api/v1/messages?query={"date":{"$gt":"2017-06-24T00:34:11.114Z"}}
 
 ### Sort
-* https://gambit-conversations-prod.herokuapp.com/api/v1/messages?sort=-date
+* https://gambit-conversations-staging.herokuapp.com/api/v1/messages?sort=-date

--- a/documentation/authentication.md
+++ b/documentation/authentication.md
@@ -1,0 +1,25 @@
+# Authentication
+
+The `receive-message`, `import-message`, and `send-message` routes are protected by Basic Auth, using config vars:
+* `'DS_GAMBIT_CONVERSATIONS_API_BASIC_AUTH_NAME'`
+* `'DS_GAMBIT_CONVERSATIONS_API_BASIC_AUTH_PASS'`
+
+Requests should include an Authorization header.
+
+#### Supplying basic auth headers [(Source)](https://developer.atlassian.com/cloud/jira/platform/jira-rest-api-basic-authentication/#supplying-basic-auth-headers)
+
+##### Manually
+To do this you need to perform the following steps:
+
+- Build a string of the form `name:pass`
+- Base64 encode the string
+- Supply an “Authorization” header with content “Basic ” followed by the encoded string. For example, the string `fred:fred` encodes to `ZnJlZDpmcmVk` in base64, so you would make the request as follows.
+```
+curl -D -X POST -H "Authorization: Basic ZnJlZDpmcmVk" -H "Content-Type: application/json" "http://localhost:5100/api/v1/import-message"
+```
+
+##### As part of the URL (Especially helpful for webhooks)
+Prepend the `name` and `pass` in the form `name:pass@` to the endpoint URL.
+```
+http://name:pass@localhost:5100/api/v1/import-message
+```

--- a/documentation/authentication.md
+++ b/documentation/authentication.md
@@ -1,8 +1,8 @@
 # Authentication
 
 The `receive-message`, `import-message`, and `send-message` routes are protected by Basic Auth, using config vars:
-* `'DS_GAMBIT_CONVERSATIONS_API_BASIC_AUTH_NAME'`
-* `'DS_GAMBIT_CONVERSATIONS_API_BASIC_AUTH_PASS'`
+* `DS_GAMBIT_CONVERSATIONS_API_BASIC_AUTH_NAME`
+* `DS_GAMBIT_CONVERSATIONS_API_BASIC_AUTH_PASS`
 
 Requests should include an Authorization header.
 

--- a/documentation/endpoints/receive-message.md
+++ b/documentation/endpoints/receive-message.md
@@ -1,0 +1,129 @@
+# Receive Message
+
+```
+POST /api/v1/receive-message
+```
+
+Receives a message and sends a reply (or forwards it, when appropriate).
+
+
+## Input
+
+Name | Type | Description
+--- | --- | ---
+`From` | `string` | Sender's phone number (included when we receive a Twilio message)
+`Body` | `string` | Incoming message (included when we receive a Twilio message)
+`slackId` | `string` |
+`slackChannel` | `string` |
+`facebookId` | `string` |
+`userId` | `string` | Northstar ID
+`text` | `string` | Incoming message sent from User.
+`mediaUrl` | `string` | Media attachment URL (currently only supports 1 attachment).
+
+## Examples
+
+### Request
+
+Example of an inbound Twilio request.
+> The user's conversation state is currently expecting a reportback picture
+
+```
+{
+  "ToCountry": "US",
+  "MediaContentType0": "image/png",
+  "ToState": "",
+  "SmsMessageSid": "MM09a8f657567f807443191c1e7exxxxxx",
+  "NumMedia": "1",
+  "ToCity": "",
+  "FromZip": "10010",
+  "SmsSid": "MM09a8f657567f807443191c1e7exxxxxx",
+  "FromState": "NY",
+  "SmsStatus": "received",
+  "FromCity": "NEW YORK",
+  "Body": "",
+  "FromCountry": "US",
+  "To": "38383",
+  "ToZip": "",
+  "NumSegments": "1",
+  "MessageSid": "MM09a8f657567f807443191c1e7exxxxxx",
+  "From": "+5555555555",
+  "MediaUrl0": "http://bit.ly/2wkfrep",
+  "ApiVersion": "2010-04-01"
+}
+```
+
+### Created message
+
+```
+{
+  "_id": ObjectId("5995cf29e4bca305f02e50b3"),
+  "updatedAt": ISODate("2017-08-17T17:15:21.865Z"),
+  "createdAt": ISODate("2017-08-17T17:15:21.865Z"),
+  "userId": "+5555555555",
+  "campaignId": 819,
+  "topic": "campaign",
+  "conversation": ObjectId("5994caf4a92890fa8a52de72"),
+  "text": "",
+  "direction": "inbound",
+  "attachments": [
+    {
+      "contentType": "image/jpeg",
+      "url": "http://placekitten.com/g/800/800"
+    }
+  ],
+  "__v": 0
+}
+```
+
+### Response
+
+```
+{
+  "reply": {
+    "__v": 0,
+    "updatedAt": "2017-08-17T17:15:22.466Z",
+    "createdAt": "2017-08-17T17:15:22.466Z",
+    "userId": "+5555555555",
+    "campaignId": 819,
+    "topic": "campaign",
+    "conversation": "5994caf4a92890fa8a52de72",
+    "text": "Got it! Now text back a caption for your photo (think Instagram)! Keep it short & sweet, under 60 characters please.",
+    "template": "gambit",
+    "direction": "outbound-reply",
+    "_id": "5995cf2ae4bca305f02e50b4",
+    "attachments": []
+  }
+}
+```
+
+### Request
+
+```
+curl -X "POST" "http://localhost:5100/api/v1/retrieve-message" \
+     -H "Content-Type: application/x-www-form-urlencoded; charset=utf-8" \
+     --data-urlencode "userId=123" \
+     --data-urlencode "text=I can haz thumb socks?" \
+```
+
+### Response
+
+Returns an Outbound Reply Message (when Conversation is not paused).
+
+```
+{
+  "reply": {
+    "__v": 0,
+    "updatedAt": "2017-08-17T17:15:22.466Z",
+    "createdAt": "2017-08-17T17:15:22.466Z",
+    "userId": "U1BBD0D4G",
+    "topic": "random",
+    "conversation": "5977aed9bb17210a72aad245",
+    "text": "Sorry, I'm not sure how to respond to that.\n\nSay MENU to find a Campaign to join.",
+    "template": "noCampaignMessage",
+    "direction": "outbound-reply",
+    "_id": "59776272230c54001125ef7c",
+    "attachments": []
+  }
+}
+```
+

--- a/documentation/endpoints/send-message.md
+++ b/documentation/endpoints/send-message.md
@@ -1,7 +1,55 @@
 # Send Message
 
-Sends a message to User.
-
 ```
 POST /api/v1/send-message
 ```
+Sends a message to User. 
+
+## Input
+
+Name | Type | Description
+--- | --- | ---
+`phone` | `string` | Phone number of User to send outbound message to
+`campaignId` | `number` | Campaign Id of outbound message
+`template` | `string` | Campaign message template to send
+
+<details>
+<summary><strong>Example Response</strong></summary>
+
+```
+curl -X "POST" "http://localhost:5100/api/v1/send-message" \
+     -H "Content-Type: application/json; charset=utf-8" \
+     -u puppet:totallysecret \
+     -d $'{
+  "phone": "+15555550750",
+  "campaignId": "48",
+  "template": "externalSignupMenuMessage"
+}'
+```
+
+</details>
+
+
+<details>
+<summary><strong>Example Response</strong></summary>
+
+```
+{
+  "reply": {
+    "__v": 0,
+    "updatedAt": "2017-08-18T19:36:31.664Z",
+    "createdAt": "2017-08-18T19:36:31.664Z",
+    "userId": "+15555550750",
+    "campaignId": 48,
+    "topic": "campaign",
+    "conversation": "59972fac96c01d1d6b86c73c",
+    "text": "Hey - this is Freddie from DoSomething. Thanks for joining Pride Over Prejudice!\n\nA new White House executive order denies all new refugees entry to the US for 120 days and places a 90-day travel ban on six Muslim-majority nations.\n\nThe solution is simple: Post a selfie to stand in solidarity with refugees and immigrants.\n\nMake sure to take a photo of what you did! When you have Shared some Pictures, text START to share your photo.",
+    "template": "externalSignupMenuMessage",
+    "direction": "outbound-api-send",
+    "_id": "599741bf9f03df1f2c0cb5fb",
+    "attachments": []
+  }
+}
+```
+
+</details>

--- a/documentation/endpoints/send-message.md
+++ b/documentation/endpoints/send-message.md
@@ -1,0 +1,7 @@
+# Send Message
+
+Sends a message to User.
+
+```
+POST /api/v1/send-message
+```

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -53,7 +53,7 @@ module.exports.sendResponseForError = function (req, res, error) {
 
 module.exports.sendGenericErrorResponse = function (res, err) {
   let status = err.status;
-  if (! status) {
+  if (!status) {
     status = 500;
   }
   return this.sendResponseWithStatusCode(res, status, err.message);
@@ -82,7 +82,7 @@ module.exports.sendResponseWithStatusCode = function (res, code = 200, message =
 module.exports.getBroadcast = function getBroadcast(req, res) {
   return contentful.fetchBroadcast(req.broadcastId)
     .then((broadcast) => {
-      if (! broadcast) {
+      if (!broadcast) {
         return exports.sendResponseWithStatusCode(res, 404, `Broadcast ${req.broadcast_id} not found.`);
       }
 

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -68,6 +68,8 @@ module.exports.sendGenericErrorResponse = function (res, err) {
  */
 module.exports.sendResponseWithStatusCode = function (res, code = 200, message = 'OK') {
   const response = { message };
+  logger.debug('sendResponseWithStatusCode', { code, response });
+
   return res.status(code).send(response);
 };
 

--- a/lib/middleware/receive-message/send-ask-continue.js
+++ b/lib/middleware/receive-message/send-ask-continue.js
@@ -6,10 +6,7 @@ module.exports = function askContinueTemplate() {
       return next();
     }
 
-    // If lastOutboundTemplate is one of these, exit out of this middleware to post the inbound
-    // message to Gambit Campaigns later. 
-    const gambitCampaignsTemplates = ['gambit', 'externalSignupMenuMessage'];
-    if (gambitCampaignsTemplates.includes(req.conversation.lastOutboundTemplate)) {
+    if (req.conversation.shouldPostToGambitCampaigns()) {
       return next();
     }
 
@@ -17,11 +14,11 @@ module.exports = function askContinueTemplate() {
       return next();
     }
 
-    // Let's prompt User to continue Gambit conversation for their current Campaign.
+    // Let's prompt User to continue the Signup conversation for their current Campaign.
     req.reply.template = 'askContinueMessage';
 
     // Topic may be set to random from the last Rivescript reply.
-    // We set it to the Campaign topic to listen for confirmedCampaign or declinedCampaign macros.
+    // We set it to the Campaign topic to listen for confirmedCampaign, declinedCampaign macros.
     req.conversation.setTopic(req.campaign.topic);
 
     return next();

--- a/lib/middleware/receive-message/send-ask-continue.js
+++ b/lib/middleware/receive-message/send-ask-continue.js
@@ -6,8 +6,10 @@ module.exports = function askContinueTemplate() {
       return next();
     }
 
-    // If the last reply Template was Gambit, our User is already talking about their Campaign.
-    if (req.conversation.lastOutboundTemplate === 'gambit') {
+    // If lastOutboundTemplate is one of these, exit out of this middleware to post the inbound
+    // message to Gambit Campaigns later. 
+    const gambitCampaignsTemplates = ['gambit', 'externalSignupMenuMessage'];
+    if (gambitCampaignsTemplates.includes(req.conversation.lastOutboundTemplate)) {
       return next();
     }
 

--- a/lib/middleware/send-message/campaign.js
+++ b/lib/middleware/send-message/campaign.js
@@ -10,6 +10,7 @@ module.exports = function sendCampaignMessage() {
           // TODO: Send error.
           return next();
         }
+        // If Campaign is closed, send error.
 
         req.conversation.setCampaign(campaign);
         req.outboundTemplate = req.body.template;

--- a/lib/middleware/send-message/campaign.js
+++ b/lib/middleware/send-message/campaign.js
@@ -1,14 +1,14 @@
 'use strict';
 
 const Campaigns = require('../../../app/models/Campaign');
+const helpers = require('../../helpers');
 
 module.exports = function sendCampaignMessage() {
   return (req, res, next) => {
-    Campaigns.findById(req.body.campaignId)
+    Campaigns.findById(req.campaignId)
       .then((campaign) => {
         if (!campaign) {
-          // TODO: Send error.
-          return next();
+          return helpers.sendResponseWithStatusCode(res, 404, 'Campaign not found.');
         }
         // If Campaign is closed, send error.
 

--- a/lib/middleware/send-message/campaign.js
+++ b/lib/middleware/send-message/campaign.js
@@ -5,7 +5,11 @@ const helpers = require('../../helpers');
 
 module.exports = function sendCampaignMessage() {
   return (req, res, next) => {
-    Campaigns.findById(req.campaignId)
+    if (req.outboundTemplate) {
+      return next();
+    }
+
+    return Campaigns.findById(req.campaignId)
       .then((campaign) => {
         if (!campaign) {
           return helpers.sendResponseWithStatusCode(res, 404, 'Campaign not found.');

--- a/lib/middleware/send-message/campaign.js
+++ b/lib/middleware/send-message/campaign.js
@@ -1,11 +1,10 @@
 'use strict';
 
-const logger = require('heroku-logger');
+const Campaigns = require('../../../app/models/Campaign');
 
 module.exports = function sendCampaignMessage() {
   return (req, res, next) => {
-
-    return Campaigns.findById(req.body.campaignId)
+    Campaigns.findById(req.body.campaignId)
       .then((campaign) => {
         if (!campaign) {
           // TODO: Send error.

--- a/lib/middleware/send-message/campaign.js
+++ b/lib/middleware/send-message/campaign.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const logger = require('heroku-logger');
+
+module.exports = function sendCampaignMessage() {
+  return (req, res, next) => {
+
+    return Campaigns.findById(req.body.campaignId)
+      .then((campaign) => {
+        if (!campaign) {
+          // TODO: Send error.
+          return next();
+        }
+
+        req.conversation.setCampaign(campaign);
+        req.outboundTemplate = req.body.template;
+        req.sendMessageText = campaign[req.outboundTemplate];
+
+        return next();
+      });
+  };
+};

--- a/lib/middleware/send-message/campaign.js
+++ b/lib/middleware/send-message/campaign.js
@@ -14,7 +14,7 @@ module.exports = function sendCampaignMessage() {
         if (!campaign) {
           return helpers.sendResponseWithStatusCode(res, 404, 'Campaign not found.');
         }
-        // If Campaign is closed, send error.
+        // TODO: If Campaign is closed, send error.
 
         req.conversation.setCampaign(campaign);
         req.outboundTemplate = req.body.template;

--- a/lib/middleware/send-message/params.js
+++ b/lib/middleware/send-message/params.js
@@ -6,6 +6,11 @@ module.exports = function params() {
   return (req, res, next) => {
     logger.debug('send-message request.params', req.body);
 
+    if (req.body.userId) {
+      req.userId = req.body.userId;
+      return next();
+    }
+
     // TODO: Test for existence of FRONT_API_SECRET
 
     req.sendMessageText = req.body.text;

--- a/lib/middleware/send-message/params.js
+++ b/lib/middleware/send-message/params.js
@@ -6,8 +6,10 @@ module.exports = function params() {
   return (req, res, next) => {
     logger.debug('send-message request.params', req.body);
 
-    if (req.body.userId) {
-      req.userId = req.body.userId;
+    if (req.body.phone) {
+      req.userId = req.body.phone;
+      req.campaignId = req.body.campaignId;
+      req.platform = 'sms';
       return next();
     }
 

--- a/lib/middleware/send-message/params.js
+++ b/lib/middleware/send-message/params.js
@@ -1,6 +1,22 @@
 'use strict';
 
+const crypto = require('crypto');
 const logger = require('heroku-logger');
+const helpers = require('../../helpers');
+
+/**
+ * Validates incoming Front request.
+ * @see https://dev.frontapp.com/#checking-data-integrity
+ * @param {object} data
+ * @param {string} signature
+ * @return {boolean}
+ */
+function validateFrontSignature(data, signature) {
+  const apiSecret = process.env.FRONT_API_SECRET;
+  const hash = crypto.createHmac('sha1', apiSecret).update(JSON.stringify(data)).digest('base64');
+
+  return hash === signature;
+}
 
 module.exports = function params() {
   return (req, res, next) => {
@@ -13,13 +29,16 @@ module.exports = function params() {
       return next();
     }
 
-    // TODO: Test for existence of FRONT_API_SECRET
+    const frontSignature = req.headers['x-front-signature'];
+    if (frontSignature && !validateFrontSignature(req.body, frontSignature)) {
+      return helpers.sendResponseWithStatusCode(res, 401, 'X-Front-Signature is not valid.');
+    }
 
     req.sendMessageText = req.body.text;
     const recipients = req.body.recipients;
     const toRecipient = recipients.find(recipient => recipient.role === 'to');
     req.userId = toRecipient.handle;
-    req.outboundTemplate = 'front';
+    req.outboundTemplate = 'support';
     req.frontConversationUrl = req.body._links.related.conversation;
 
     return next();

--- a/lib/middleware/send-message/support.js
+++ b/lib/middleware/send-message/support.js
@@ -3,9 +3,13 @@
 const logger = require('heroku-logger');
 const front = require('../../front');
 
-module.exports = function resolveSupportRequest() {
+module.exports = function sendSupportMessage() {
   return (req, res, next) => {
-    front.get(req.frontConversationUrl)
+    if (req.campaignId) {
+      return next();
+    }
+
+    return front.get(req.frontConversationUrl)
       .then((frontConversation) => {
         // If the Front agent has archived this conversation, our Support Request has been resolved.
         if (frontConversation.status === 'archived') {


### PR DESCRIPTION
Closes #47

* Supports sending an outbound External Signup Menu message (e.g. a Web Signup confirmation) by posting to the `/send-message` and passing a `phone`, `campaignId` and `template` set to `externalSignupMenuMessage`.

* Updates documentation with a example request, and splits it out into multiple files.

TODO, but not necessary for merge:
* Add Slack support for sending outbound Campaign template message
* Add Front documentation
