### PR TITLE
Slack support for POST /send-message

### DIFF
--- a/app/routes/send-message.js
+++ b/app/routes/send-message.js
@@ -5,15 +5,17 @@ const helpers = require('../../lib/helpers');
 
 const router = express.Router();
 
-const paramsMiddleware = require('../../lib/middleware/send-message/params');
+const supportParamsMiddleware = require('../../lib/middleware/send-message/params-support');
+const campaignParamsMiddleware = require('../../lib/middleware/send-message/params-campaign');
 const getConversationMiddleware = require('../../lib/middleware/conversation-get');
 const createConversationMiddleware = require('../../lib/middleware/conversation-create');
-
 const campaignMiddleware = require('../../lib/middleware/send-message/campaign');
 const supportMiddleware = require('../../lib/middleware/send-message/support');
 const outboundMessageMiddleware = require('../../lib/middleware/send-message/message-outbound');
 
-router.use(paramsMiddleware());
+router.use(supportParamsMiddleware());
+router.use(campaignParamsMiddleware());
+
 router.use(getConversationMiddleware());
 router.use(createConversationMiddleware());
 

--- a/documentation/endpoints/send-message.md
+++ b/documentation/endpoints/send-message.md
@@ -3,9 +3,21 @@
 ```
 POST /api/v1/send-message
 ```
-Sends a message to User. 
+Sends either a Support or Campaign outbound message in a Conversation.
 
-## Input
+## Support
+
+Sending Support messages requires a `x-front-signature` header. See [Support wiki](https://github.com/DoSomething/gambit-conversations/wiki/Support). 
+
+## Campaign
+
+Sends an outbound Campaign message for a given `campaignId` and message `template`, and updates the Conversation accordingly.
+
+Supported templates:
+
+* `externalSignupMenuMessage` -- Used to send SMS confirmation messages for web signups.
+
+### Input
 
 Name | Type | Description
 --- | --- | ---

--- a/documentation/endpoints/send-message.md
+++ b/documentation/endpoints/send-message.md
@@ -10,6 +10,7 @@ Sends a message to User.
 Name | Type | Description
 --- | --- | ---
 `phone` | `string` | Phone number of User to send outbound message to
+`slackId` | `string` | Slack Id of User to send outbound message to
 `campaignId` | `number` | Campaign Id of outbound message
 `template` | `string` | Campaign message template to send
 

--- a/lib/middleware/import-message/params.js
+++ b/lib/middleware/import-message/params.js
@@ -23,7 +23,7 @@ module.exports = function params() {
       req.messageFields = body.fields;
       req.outboundTemplate = 'askSignupMessage';
     } else {
-      const error = new UnprocessibleEntityError('Invalid medium');
+      const error = new UnprocessibleEntityError('Invalid medium.');
       return helpers.sendGenericErrorResponse(res, error);
     }
     return next();

--- a/lib/middleware/send-message/campaign.js
+++ b/lib/middleware/send-message/campaign.js
@@ -5,7 +5,7 @@ const helpers = require('../../helpers');
 
 module.exports = function sendCampaignMessage() {
   return (req, res, next) => {
-    if (req.outboundTemplate) {
+    if (req.outboundTemplate === 'support') {
       return next();
     }
 
@@ -17,7 +17,6 @@ module.exports = function sendCampaignMessage() {
         // TODO: If Campaign is closed, send error.
 
         req.conversation.setCampaign(campaign);
-        req.outboundTemplate = req.body.template;
         req.sendMessageText = campaign[req.outboundTemplate];
 
         return next();

--- a/lib/middleware/send-message/params-campaign.js
+++ b/lib/middleware/send-message/params-campaign.js
@@ -1,0 +1,44 @@
+'use strict';
+
+const helpers = require('../../helpers');
+const UnprocessibleEntityError = require('../../../app/exceptions/UnprocessibleEntityError');
+
+module.exports = function campaignParams() {
+  return (req, res, next) => {
+    if (req.outboundTemplate === 'support') {
+      return next();
+    }
+
+    const body = req.body;
+    let error;
+
+    req.campaignId = body.campaignId;
+    if (!req.campaignId) {
+      error = new UnprocessibleEntityError('Missing required campaignId.');
+      return helpers.sendGenericErrorResponse(res, error);
+    }
+
+    req.outboundTemplate = body.template;
+    if (!req.outboundTemplate) {
+      error = new UnprocessibleEntityError('Missing required template.');
+      return helpers.sendGenericErrorResponse(res, error);
+    }
+
+    if (body.phone) {
+      req.userId = body.phone;
+      req.platform = 'sms';
+
+      return next();
+    }
+
+    if (body.slackId) {
+      req.platform = 'slack';
+      req.userId = body.slackId;
+
+      return next();
+    }
+
+    error = new UnprocessibleEntityError('Missing required phone or slackId.');
+    return helpers.sendGenericErrorResponse(res, error);
+  };
+};

--- a/lib/middleware/send-message/params-support.js
+++ b/lib/middleware/send-message/params-support.js
@@ -11,37 +11,24 @@ const helpers = require('../../helpers');
  * @param {string} signature
  * @return {boolean}
  */
-function validateFrontSignature(data, signature) {
+function isValidFrontSignature(data, signature) {
   const apiSecret = process.env.FRONT_API_SECRET;
   const hash = crypto.createHmac('sha1', apiSecret).update(JSON.stringify(data)).digest('base64');
 
   return hash === signature;
 }
 
-module.exports = function params() {
+module.exports = function supportParams() {
   return (req, res, next) => {
     const body = req.body;
     logger.debug('send-message request.params', body);
 
-    // TODO: If we have a phone or slackId, campaignId and template params are required.
-    req.campaignId = body.campaignId;
-
-    if (body.phone) {
-      req.userId = body.phone;
-      req.platform = 'sms';
-
-      return next();
-    }
-
-    if (body.slackId) {
-      req.platform = 'slack';
-      req.userId = body.slackId;
-
-      return next();
-    }
-
     const frontSignature = req.headers['x-front-signature'];
-    if (frontSignature && !validateFrontSignature(body, frontSignature)) {
+    if (!frontSignature) {
+      return next();
+    }
+
+    if (!isValidFrontSignature(body, frontSignature)) {
       return helpers.sendResponseWithStatusCode(res, 401, 'X-Front-Signature is not valid.');
     }
 

--- a/lib/middleware/send-message/params.js
+++ b/lib/middleware/send-message/params.js
@@ -20,26 +20,37 @@ function validateFrontSignature(data, signature) {
 
 module.exports = function params() {
   return (req, res, next) => {
-    logger.debug('send-message request.params', req.body);
+    const body = req.body;
+    logger.debug('send-message request.params', body);
 
-    if (req.body.phone) {
-      req.userId = req.body.phone;
-      req.campaignId = req.body.campaignId;
+    // TODO: If we have a phone or slackId, campaignId and template params are required.
+    req.campaignId = body.campaignId;
+
+    if (body.phone) {
+      req.userId = body.phone;
       req.platform = 'sms';
+
+      return next();
+    }
+
+    if (body.slackId) {
+      req.platform = 'slack';
+      req.userId = body.slackId;
+
       return next();
     }
 
     const frontSignature = req.headers['x-front-signature'];
-    if (frontSignature && !validateFrontSignature(req.body, frontSignature)) {
+    if (frontSignature && !validateFrontSignature(body, frontSignature)) {
       return helpers.sendResponseWithStatusCode(res, 401, 'X-Front-Signature is not valid.');
     }
 
-    req.sendMessageText = req.body.text;
-    const recipients = req.body.recipients;
+    req.sendMessageText = body.text;
+    const recipients = body.recipients;
     const toRecipient = recipients.find(recipient => recipient.role === 'to');
     req.userId = toRecipient.handle;
     req.outboundTemplate = 'support';
-    req.frontConversationUrl = req.body._links.related.conversation;
+    req.frontConversationUrl = body._links.related.conversation;
 
     return next();
   };


### PR DESCRIPTION
* Fixes #77 --pass a `slackId` body parameter instead of `phone` to deliver an External Signup Menu Message over Slack.

* Adds checks for required Campaign parameters

* Splits `params` into `params-support` and `params-campaign`, adds documentation for each

Test request:
```
curl -X "POST" "http://localhost:5100/api/v1/send-message" \
     -H "Content-Type: application/json; charset=utf-8" \
     -u puppet:totallysecret \
     -d $'{
  "slackId": "[your slack Id]",
  "campaignId": "2900",
  "template": "externalSignupMenuMessage"
}'
```

