### PR TITLE
Closed Campaigns

### DIFF
--- a/app/models/Campaign.js
+++ b/app/models/Campaign.js
@@ -4,6 +4,7 @@ const fs = require('fs');
 const mongoose = require('mongoose');
 const logger = require('heroku-logger');
 const gambitCampaigns = require('../../lib/gambit-campaigns');
+const activeStatus = 'active';
 
 /**
  * Schema.
@@ -83,7 +84,7 @@ campaignSchema.statics.findRandomCampaignNotEqualTo = function (campaignId) {
     .aggregate([
       {
         $match: {
-          status: 'active',
+          status: activeStatus,
           _id: { $ne: campaignId },
         },
       },
@@ -95,16 +96,6 @@ campaignSchema.statics.findRandomCampaignNotEqualTo = function (campaignId) {
     ])
     .exec()
     .then(campaigns => this.findById(campaigns[0]._id));
-};
-
-/**
- * Returns all Campaigns with active status.
- * @return {Promise}
- */
-campaignSchema.statics.findAllActive = function () {
-  logger.debug('Campaign.findAllActive');
-
-  return this.find({ status: 'active' });
 };
 
 /**
@@ -137,7 +128,7 @@ campaignSchema.statics.sync = function () {
         this.fetchCampaign(campaignId);
       });
 
-      return this.findAllActive();
+      return this.find({ status: activeStatus });
     })
     .then((activeCache) => {
       activeCache.forEach((campaign) => {

--- a/app/models/Campaign.js
+++ b/app/models/Campaign.js
@@ -4,6 +4,7 @@ const fs = require('fs');
 const mongoose = require('mongoose');
 const logger = require('heroku-logger');
 const gambitCampaigns = require('../../lib/gambit-campaigns');
+
 const activeStatus = 'active';
 
 /**
@@ -137,6 +138,8 @@ campaignSchema.statics.sync = function () {
 
         if (!updated[campaignId]) {
           logger.debug('close campaign', { campaignId });
+          // TODO: Fetch Campaign to get latest messages, blocked by Gambit Campaigns API bug.
+          // @see https://github.com/DoSomething/gambit/issues/951
           campaign.status = 'closed'; // eslint-disable-line no-param-reassign
           campaign.save();
         }

--- a/app/models/Campaign.js
+++ b/app/models/Campaign.js
@@ -14,7 +14,10 @@ const campaignSchema = new mongoose.Schema({
   status: String,
   keywords: [String],
   topic: String,
-  externalSignupMenuMessage: String,
+  messages: {
+    campaignClosedMessage: String,
+    externalSignupMenuMessage: String,
+  },
 }, { timestamps: true });
 
 /**
@@ -39,11 +42,12 @@ function parseGambitCampaign(gambitCampaign) {
   const result = {
     title: gambitCampaign.title,
     status: gambitCampaign.status,
+    messages: {},
   };
 
   const templates = Object.keys(gambitCampaign.messages);
   templates.forEach((template) => {
-    result[template] = gambitCampaign.messages[template].rendered;
+    result.messages[template] = gambitCampaign.messages[template].rendered;
   });
 
   result.keywords = gambitCampaign.keywords.map(keywordObject => keywordObject.keyword);
@@ -168,6 +172,12 @@ campaignSchema.virtual('declinedContinueMessage').get(function () {
 
 campaignSchema.virtual('askContinueMessage').get(function () {
   return `Ready to get back to ${this.title}?`;
+});
+
+campaignSchema.virtual('isClosed').get(function () {
+  const result = this.status === 'closed';
+
+  return result;
 });
 
 campaignSchema.virtual('invalidSignupResponseMessage').get(function () {

--- a/app/models/Campaign.js
+++ b/app/models/Campaign.js
@@ -66,10 +66,9 @@ campaignSchema.statics.fetchCampaign = function (campaignId) {
     .then((response) => {
       const campaign = parseGambitCampaign(response);
       campaign.topic = getTopicForCampaignId(campaignId);
-      const query = { _id: campaignId };
 
-      return this.findOneAndUpdate(query, campaign, { upsert: true })
-        .then(() => logger.debug('campaign updated', query));
+      return this.findOneAndUpdate({ _id: campaignId }, campaign, { upsert: true })
+        .then(() => logger.debug('campaign updated', { campaignId }));
     })
     .catch(err => logger.error('Campaign.fetchCampaign', err));
 };

--- a/app/models/Campaign.js
+++ b/app/models/Campaign.js
@@ -16,7 +16,7 @@ const campaignSchema = new mongoose.Schema({
   status: String,
   keywords: [String],
   topic: String,
-  messages: {
+  templates: {
     campaignClosedMessage: String,
     externalSignupMenuMessage: String,
   },
@@ -44,12 +44,12 @@ function parseGambitCampaign(gambitCampaign) {
   const result = {
     title: gambitCampaign.title,
     status: gambitCampaign.status,
-    messages: {},
+    templates: {},
   };
 
   const templates = Object.keys(gambitCampaign.messages);
   templates.forEach((template) => {
-    result.messages[template] = gambitCampaign.messages[template].rendered;
+    result.templates[template] = gambitCampaign.messages[template].rendered;
   });
 
   result.keywords = gambitCampaign.keywords.map(keywordObject => keywordObject.keyword);
@@ -70,7 +70,7 @@ campaignSchema.statics.fetchCampaign = function (campaignId) {
       return this.findOneAndUpdate({ _id: campaignId }, campaign, { upsert: true })
         .then(() => logger.debug('campaign updated', { campaignId }));
     })
-    .catch(err => logger.error('Campaign.fetchCampaign', err));
+    .catch(err => logger.error('Campaign.fetchCampaign', { err }));
 };
 
 /**

--- a/app/models/Campaign.js
+++ b/app/models/Campaign.js
@@ -76,11 +76,23 @@ campaignSchema.statics.fetchCampaign = function (campaignId) {
  * Returns a random Campaign model.
  * @return {Promise}
  */
-campaignSchema.statics.getRandomCampaign = function () {
-  logger.debug('Campaign.getRandomCampaign');
+campaignSchema.statics.findRandomCampaignNotEqualTo = function (campaignId) {
+  logger.debug('Campaign.findRandomCampaignNotEqualTo', { campaignId });
 
   return this
-    .aggregate([{ $sample: { size: 1 } }])
+    .aggregate([
+      {
+        $match: {
+          status: 'active',
+          _id: { $ne: campaignId },
+        },
+      },
+      {
+        $sample: {
+          size: 1,
+        },
+      },
+    ])
     .exec()
     .then(campaigns => this.findById(campaigns[0]._id));
 };

--- a/app/routes/receive-message.js
+++ b/app/routes/receive-message.js
@@ -19,6 +19,7 @@ const pausedMiddleware = require('../../lib/middleware/receive-message/conversat
 const sendAskSignupMiddleware = require('../../lib/middleware/receive-message/send-ask-signup');
 const campaignKeywordMiddleware = require('../../lib/middleware/receive-message/campaign-keyword');
 const currentCampaignMiddleware = require('../../lib/middleware/receive-message/campaign-current');
+const closedCampaignMiddleware = require('../../lib/middleware/receive-message/campaign-closed');
 const parseAskSignupMiddleware = require('../../lib/middleware/receive-message/parse-ask-signup-answer');
 const parseAskContinueMiddleware = require('../../lib/middleware/receive-message/parse-ask-continue-answer');
 const sendAskContinueMiddleware = require('../../lib/middleware/receive-message/send-ask-continue');
@@ -47,6 +48,7 @@ router.use(sendAskSignupMiddleware());
 // If Campaign keyword, set keyword Campaign.
 router.use(campaignKeywordMiddleware());
 router.use(currentCampaignMiddleware());
+router.use(closedCampaignMiddleware());
 
 // Check for yes/no/invalid responses to sent Ask Signup/Continue messages:
 router.use(parseAskSignupMiddleware());

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -17,7 +17,8 @@ Endpoint | Functionality
 `GET /api/v1/conversations/:id` | Retrieve a Conversation
 `GET /api/v1/messages` | Retrieve all Messages
 `GET /api/v1/messages/:id` | Retrieve a Message
-
+`GET /api/v1/campaigns` | Retrieve all cached Campaigns
+`GET /api/v1/campaigns/:id` | Retrieve a cached Campaign
 
 ### Query paramters
 
@@ -25,7 +26,7 @@ See https://florianholzapfel.github.io/express-restify-mongoose/ for querying th
 
 ### Filtering
 * https://gambit-conversations-staging.herokuapp.com/api/v1/messages?query={"platform":"slack"}
-* https://gambit-conversations-staging.herokuapp.com/api/v1/messages?query={"date":{"$gt":"2017-06-24T00:34:11.114Z"}}
+* https://gambit-conversations-staging.herokuapp.com/api/v1/messages?query={"createdAt":{"$gt":"2017-06-24T00:34:11.114Z"}}
 
 ### Sort
-* https://gambit-conversations-staging.herokuapp.com/api/v1/messages?sort=-date
+* https://gambit-conversations-staging.herokuapp.com/api/v1/messages?sort=-createdAt

--- a/lib/gambit-campaigns.js
+++ b/lib/gambit-campaigns.js
@@ -7,13 +7,12 @@ const uri = process.env.DS_GAMBIT_CAMPAIGNS_API_BASEURI;
 const apiKey = process.env.DS_GAMBIT_CAMPAIGNS_API_KEY;
 
 module.exports.get = function (endpoint) {
-  return superagent
-    .get(`${uri}/${endpoint}`)
-    .then(response => response.body.data)
-    .catch((/* err */) => {
-      // TODO console.log has to be replaced by other development logging library: Winston?
-      // console.log(`gambit response:${err.message}`);
-    });
+  const url = `${uri}/${endpoint}`;
+  logger.trace('gambitCampaigns.get', { url });
+
+  return superagent.get(url)
+    .then(res => res.body.data)
+    .catch(err => err);
 };
 
 module.exports.post = function (endpoint, data) {
@@ -23,6 +22,10 @@ module.exports.post = function (endpoint, data) {
     .send(data)
     .then(response => response.body)
     .catch(err => logger.error(err));
+};
+
+module.exports.getActiveCampaigns = function () {
+  return this.get('campaigns');
 };
 
 module.exports.postSignupMessage = function (data) {

--- a/lib/middleware/receive-message/campaign-closed.js
+++ b/lib/middleware/receive-message/campaign-closed.js
@@ -12,8 +12,6 @@ module.exports = function checkCampaignIsClosed() {
 
     if (req.campaign.isClosed) {
       req.reply.template = 'campaignClosedMessage';
-    } else {
-      req.reply.template = 'gambit';
     }
 
     return next();

--- a/lib/middleware/receive-message/campaign-closed.js
+++ b/lib/middleware/receive-message/campaign-closed.js
@@ -1,0 +1,21 @@
+'use strict';
+
+module.exports = function checkCampaignIsClosed() {
+  return (req, res, next) => {
+    if (req.reply.template) {
+      return next();
+    }
+
+    if (!req.campaign) {
+      return next();
+    }
+
+    if (req.campaign.isClosed) {
+      req.reply.template = 'campaignClosedMessage';
+    } else {
+      req.reply.template = 'gambit';
+    }
+
+    return next();
+  };
+};

--- a/lib/middleware/receive-message/campaign-keyword.js
+++ b/lib/middleware/receive-message/campaign-keyword.js
@@ -17,8 +17,6 @@ module.exports = function getCampaignForKeyword() {
 
         req.campaign = campaign;
         req.keyword = req.userCommand;
-        // Gambit to handle the Confirmation/Continue reply.
-        req.reply.template = 'gambit';
 
         return next();
       });

--- a/lib/middleware/receive-message/send-ask-signup.js
+++ b/lib/middleware/receive-message/send-ask-signup.js
@@ -15,7 +15,7 @@ module.exports = function getCampaignMenu() {
 
     // Find a random Campaign to prompt for Signup.
     // Eventually query Signups to find Campaigns that are new to User, within their interests, etc.
-    return Campaigns.getRandomCampaign()
+    return Campaigns.findRandomCampaignNotEqualTo(req.conversation.campaignId)
       .then((campaign) => {
         req.campaign = campaign;
         req.conversation.setCampaign(campaign);

--- a/lib/middleware/receive-message/send-campaign-message.js
+++ b/lib/middleware/receive-message/send-campaign-message.js
@@ -15,7 +15,7 @@ module.exports = function renderReplyText() {
       if (virtualProperty) {
         req.reply.text = virtualProperty;
       } else {
-        req.reply.text = req.campaign.messages[req.reply.template];
+        req.reply.text = req.campaign.templates[req.reply.template];
       }
       if (req.reply.text) {
         return next();

--- a/lib/middleware/receive-message/send-campaign-message.js
+++ b/lib/middleware/receive-message/send-campaign-message.js
@@ -9,9 +9,17 @@ module.exports = function renderReplyText() {
     }
 
     if (req.campaign) {
-      req.reply.text = req.campaign[req.reply.template];
-
-      return next();
+      // This virtualProperty check will be deprecated once we add new Contentful fields.
+      // @see https://github.com/DoSomething/gambit-conversations/issues/67
+      const virtualProperty = req.campaign[req.reply.template];
+      if (virtualProperty) {
+        req.reply.text = virtualProperty;
+      } else {
+        req.reply.text = req.campaign.messages[req.reply.template];
+      }
+      if (req.reply.text) {
+        return next();
+      }
     }
 
     // TODO: Set this as a config variable.

--- a/lib/middleware/send-message/campaign.js
+++ b/lib/middleware/send-message/campaign.js
@@ -20,7 +20,7 @@ module.exports = function sendCampaignMessage() {
         }
 
         req.conversation.setCampaign(campaign);
-        req.sendMessageText = campaign.messages[req.outboundTemplate];
+        req.sendMessageText = campaign.templates[req.outboundTemplate];
 
         return next();
       });

--- a/lib/middleware/send-message/campaign.js
+++ b/lib/middleware/send-message/campaign.js
@@ -14,10 +14,13 @@ module.exports = function sendCampaignMessage() {
         if (!campaign) {
           return helpers.sendResponseWithStatusCode(res, 404, 'Campaign not found.');
         }
-        // TODO: If Campaign is closed, send error.
+
+        if (campaign.isClosed) {
+          return helpers.sendResponseWithStatusCode(res, 422, 'Campaign is closed.');
+        }
 
         req.conversation.setCampaign(campaign);
-        req.sendMessageText = campaign[req.outboundTemplate];
+        req.sendMessageText = campaign.messages[req.outboundTemplate];
 
         return next();
       });

--- a/lib/rivescript.js
+++ b/lib/rivescript.js
@@ -2,7 +2,6 @@
 
 const RiveScript = require('rivescript');
 const logger = require('heroku-logger');
-const Campaigns = require('../app/models/Campaign');
 const config = require('../config/lib/rivescript');
 
 const defaultTopic = 'random';
@@ -15,11 +14,6 @@ function loadingDone(/* batchNumber */) {
 
   brain.sortReplies();
   brain.ready = true;
-
-  // TODO: Move this into our server.
-  if (process.env.DS_GAMBIT_CAMPAIGNS_SYNC) {
-    Campaigns.fetchIndex();
-  }
 }
 
 function loadingError(error) {

--- a/server.js
+++ b/server.js
@@ -30,9 +30,14 @@ mongoose.connect(config.dbUri, {
 
 const ConversationModel = require('./app/models/Conversation');
 const MessageModel = require('./app/models/Message');
+const CampaignModel = require('./app/models/Campaign');
 
 restify.serve(app, ConversationModel);
 restify.serve(app, MessageModel);
+
+if (process.env.DS_GAMBIT_CAMPAIGNS_SYNC) {
+  CampaignModel.sync();
+}
 
 const db = mongoose.connection;
 db.on('error', () => {

--- a/server.js
+++ b/server.js
@@ -34,6 +34,7 @@ const CampaignModel = require('./app/models/Campaign');
 
 restify.serve(app, ConversationModel);
 restify.serve(app, MessageModel);
+restify.serve(app, CampaignModel);
 
 if (process.env.DS_GAMBIT_CAMPAIGNS_SYNC) {
   CampaignModel.sync();


### PR DESCRIPTION
* Adds check on app startup for whether a Campaign has closed, and updates status (#37)
* Adds Campaign Closed middleware to return the Campaign's `campaignClosedMessage` when status is `'closed'`
* Filters Campaign Menu selection by `active` status and not equal to the Conversation current Campaign - fixes #66 
* Adds a `GET /campaigns/` resource via [Express Restify Mongoose](https://www.npmjs.com/package/express-restify-mongoose) to expose cached Campaign data

Testing is a little tricky as we reply on whether a Campaign has a published Keyword in Contentful and its Phoenix Campaign status. This branch can can be tested by unpublishing a Thor keyword and starting app when `DS_GAMBIT_CAMPAIGNS_SYNC`, or by publishing a Thor keyword for a Closed Campaign, as I've done for a DADBOT keyword:

<img width="523" alt="screen shot 2017-08-23 at 5 24 23 pm" src="https://user-images.githubusercontent.com/1236811/29644026-f763627c-8827-11e7-818c-197d35eb24ff.png">

