### PR TITLE
Slack photo command

### DIFF
--- a/lib/middleware/receive-message/params.js
+++ b/lib/middleware/receive-message/params.js
@@ -60,6 +60,7 @@ module.exports = function params() {
       req.platform = 'slack';
       req.platformUserId = body.slackId;
       req.slackChannel = body.slackChannel;
+      req.mediaUrl = body.mediaUrl;
 
       return next();
     }


### PR DESCRIPTION
Fixes #93 -- Restores sending `photo` to our Gambit Slack app to mock sending a message with an image attachment (refs https://github.com/DoSomething/gambit-conversations/pull/68#pullrequestreview-59354929)