### PR TITLE
Campaign Menu, Continue templates

### DIFF
--- a/app/models/Campaign.js
+++ b/app/models/Campaign.js
@@ -17,8 +17,14 @@ const campaignSchema = new mongoose.Schema({
   keywords: [String],
   topic: String,
   templates: {
+    askContinueMessage: String,
+    askSignupMessage: String,
     campaignClosedMessage: String,
+    declinedContinueMessage: String,
+    declinedSignupMessage: String,
     externalSignupMenuMessage: String,
+    invalidContinueResponseMessage: String,
+    invalidSignupResponseMessage: String,
   },
 }, { timestamps: true });
 
@@ -148,33 +154,11 @@ campaignSchema.statics.sync = function () {
 
 /**
  * Virtual properties.
- * @TODO: Define these as fields on Gambit Campaigns upon signoff.
  */
 
 /* eslint-disable prefer-arrow-callback */
 // Disabling for these virtual properties because arrow functions are not a shortcut for function().
 // @see https://github.com/Automattic/mongoose/issues/4143
-
-// Even though this field exists on a Gambit Campaign, we're overriding it here because the copy
-// should prompt the User to text MENU back to find a new Campaign to do (doesn't exist on prod)
-campaignSchema.virtual('declinedSignupMessage').get(function () {
-  return 'OK. Text MENU if you\'d like to find a different Campaign to join.';
-});
-
-campaignSchema.virtual('askSignupMessage').get(function () {
-  const strings = ['Wanna', 'Down to', 'Want to'];
-  const randomPrompt = strings[Math.floor(Math.random() * strings.length)];
-
-  return `${randomPrompt} sign up for ${this.title}?`;
-});
-
-campaignSchema.virtual('declinedContinueMessage').get(function () {
-  return `Ok, we'll check in with you about ${this.title} later.`;
-});
-
-campaignSchema.virtual('askContinueMessage').get(function () {
-  return `Ready to get back to ${this.title}?`;
-});
 
 campaignSchema.virtual('isClosed').get(function () {
   const result = this.status === 'closed';
@@ -182,19 +166,6 @@ campaignSchema.virtual('isClosed').get(function () {
   return result;
 });
 
-campaignSchema.virtual('invalidSignupResponseMessage').get(function () {
-  let text = `Sorry, I didn't get that. Did you want to join ${this.title}?\n\nYes or No`;
-  text = `${text}\n\nIf you have a question, text Q.`;
-
-  return text;
-});
-
-campaignSchema.virtual('invalidContinueResponseMessage').get(function () {
-  let text = `Sorry, I didn't get that. Continue with ${this.title}?\n\nYes or No`;
-  text = `${text}\n\nIf you have a question, text Q.`;
-
-  return text;
-});
 /* eslint-enable prefer-arrow-callback */
 
 module.exports = mongoose.model('campaigns', campaignSchema);

--- a/app/routes/receive-message.js
+++ b/app/routes/receive-message.js
@@ -55,7 +55,7 @@ router.use(parseAskContinueMiddleware());
 router.use(continueCampaignMiddleware());
 
 // If we're still here, our inbound message is a Signup message for the Conversation Campaign.
-// We post it to the Gambit Campaigns service and send back the Gambit Campaigns response as our outbound reply.
+// We post to Gambit Campaigns service and send back the response as outbound reply.
 router.post('/', (req, res) => helpers.sendReplyForCampaignSignupMessage(req, res));
 
 module.exports = router;

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -37,6 +37,7 @@ module.exports.sendResponse = function (req, res) {
 
 /**
  * Sends given error message as Express response to an incoming Chatbot POST Express request.
+ * TODO: Merge this with sendGenericResponse
  *
  * @param {object} req
  * @param {object} res
@@ -57,7 +58,11 @@ module.exports.sendGenericErrorResponse = function (res, err) {
   if (!status) {
     status = 500;
   }
-  return this.sendResponseWithStatusCode(res, status, err.message);
+  let message = err.message;
+  if (!message) {
+    message = err;
+  }
+  return this.sendResponseWithStatusCode(res, status, message);
 };
 
 /**
@@ -115,11 +120,14 @@ module.exports.sendReply = function (req, res, messageText, messageTemplate) {
  */
 module.exports.sendReplyWithCampaignTemplate = function (req, res, messageTemplate) {
   const campaign = req.campaign;
+  if (!campaign._id) {
+    return exports.sendGenericErrorResponse(res, 'req.campaign undefined');
+  }
 
-  // This virtualProperty check will be deprecated once we add new Contentful fields.
-  // @see https://github.com/DoSomething/gambit-conversations/issues/67
-  const virtualProperty = campaign[messageTemplate];
-  const messageText = virtualProperty ? virtualProperty : campaign.templates[messageTemplate];
+  const messageText = campaign.templates[messageTemplate];
+  if (!messageText) {
+    return exports.sendGenericErrorResponse(res, `req.campaign.templates.${messageTemplate} undefined`);
+  }
 
   return exports.sendReply(req, res, messageText, messageTemplate);
 };


### PR DESCRIPTION
Fixes #67: Deprecates the virtual Campaign properties for Signup and Continue menu templates, now that they exist per https://github.com/DoSomething/gambit/pull/954.