### PR TITLE
Standardize POST responses

### DIFF
--- a/app/models/Conversation.js
+++ b/app/models/Conversation.js
@@ -232,7 +232,10 @@ conversationSchema.methods.postMessageToPlatform = function (outboundMessage) {
  * @return {boolean}
  */
 conversationSchema.methods.shouldPostToGambitCampaigns = function () {
-  const templates = ['gambit', 'externalSignupMenuMessage'];
+  // TODO: gambitCampaigns will be deprecated once we start returning the message template
+  // in the response of Gambit Campaigns /POST receive-message
+  // TODO: Define these in config.
+  const templates = ['gambitCampaigns', 'externalSignupMenuMessage'];
 
   return templates.includes(this.lastOutboundTemplate);
 };

--- a/app/routes/import-message.js
+++ b/app/routes/import-message.js
@@ -25,6 +25,6 @@ router.use(updateConvoMiddleware());
 // Create outbound message
 router.use(outboundMessageMiddleware());
 
-router.post('/', (req, res) => helpers.sendResponseWithStatusCode(res));
+router.post('/', (req, res) => helpers.sendResponseWithMessage(res, req.outboundMessage));
 
 module.exports = router;

--- a/app/routes/send-message.js
+++ b/app/routes/send-message.js
@@ -23,6 +23,6 @@ router.use(campaignMiddleware());
 router.use(supportMiddleware());
 router.use(outboundMessageMiddleware());
 
-router.post('/', (req, res) => helpers.sendResponse(req, res));
+router.post('/', (req, res) => helpers.sendResponseWithMessage(res, req.outboundMessage));
 
 module.exports = router;

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -10,15 +10,15 @@ See [Authentication](authentication.md) for details on authorizing your requests
 
 Endpoint | Functionality                                           
 -------- | -------------
-`POST /api/v1/receive-message` | [Receive inbound Message](endpoints/receive-message.md)
-`POST /api/v1/send-message` | [Send outbound Message](endpoints/send-message.md)
-`POST /api/v1/import-message` | [Import outbound Message](endpoints/import-message.md)
-`GET /api/v1/conversations` | Retrieve all Conversations
-`GET /api/v1/conversations/:id` | Retrieve a Conversation
-`GET /api/v1/messages` | Retrieve all Messages
-`GET /api/v1/messages/:id` | Retrieve a Message
-`GET /api/v1/campaigns` | Retrieve all cached Campaigns
-`GET /api/v1/campaigns/:id` | Retrieve a cached Campaign
+`POST /api/v1/receive-message` | [Receive an inbound Message, and send a reply Message.](endpoints/receive-message.md)
+`POST /api/v1/send-message` | [Send an outbound Message](endpoints/send-message.md).
+`POST /api/v1/import-message` | [Import an outbound Message](endpoints/import-message.md) that was sent on behalf of another service.
+`GET /api/v1/conversations` | Retrieve all Conversations.
+`GET /api/v1/conversations/:id` | Retrieve a Conversation.
+`GET /api/v1/messages` | Retrieve all Messages.
+`GET /api/v1/messages/:id` | Retrieve a Message.
+`GET /api/v1/campaigns` | Retrieve all cached Campaigns.
+`GET /api/v1/campaigns/:id` | Retrieve a cached Campaign.
 
 ### Query paramters
 

--- a/documentation/endpoints/import-message.md
+++ b/documentation/endpoints/import-message.md
@@ -19,7 +19,10 @@ Name | Type | Description
 
 ## Examples
 
-### Request
+
+<details>
+<summary><strong>Example Request</strong></summary>
+
 Example of an inbound POST request from a Customer.io webhook.
 
 ```
@@ -28,10 +31,10 @@ curl -X "POST" "http://localhost:5100/api/v1/import-message?platform=customerio"
      -H "Content-Type: application/json" \
      -d '{ "broadcast_id" : "7zU0Mb1k9GkWWI40o06Mic", "phone": "+5555555555", "fields": [{"customer.first_name": "taco"}]}'
 ```
+</details>
 
-```
-
-### Response
+<details>
+<summary><strong>Example Response</strong></summary>
 
 ```
 
@@ -54,3 +57,5 @@ curl -X "POST" "http://localhost:5100/api/v1/import-message?platform=customerio"
   }
 }
 ```
+</details>
+

--- a/documentation/endpoints/import-message.md
+++ b/documentation/endpoints/import-message.md
@@ -29,28 +29,28 @@ curl -X "POST" "http://localhost:5100/api/v1/import-message?platform=customerio"
      -d '{ "broadcast_id" : "7zU0Mb1k9GkWWI40o06Mic", "phone": "+5555555555", "fields": [{"customer.first_name": "taco"}]}'
 ```
 
-### Created message
-
-```
-{
-  "_id": ObjectId("599afa3cf446e81659550cbc"),
-  "updatedAt": ISODate("2017-08-21T15:20:28.949Z"),
-  "createdAt": ISODate("2017-08-21T15:20:28.949Z"),
-  "campaignId": 819,
-  "topic": "campaign",
-  "conversationId": ObjectId("5994caf4a92890fa8a52de72"),
-  "text": "Do you like tacos taco? Want to sign up for mirror messages?  taco is your name right?",
-  "template": "askSignupMessage",
-  "direction": "outbound-api-import",
-  "attachments": [ ],
-  "__v": 0
-}
 ```
 
 ### Response
 
 ```
-{
-    "message": "OK"
+
+  "data": {
+    "messages": [
+      {
+        "__v": 0,
+        "updatedAt": "2017-08-31T19:29:38.689Z",
+        "createdAt": "2017-08-31T19:29:38.689Z",
+        "conversationId": "59a863a25e5v860956ffcc45",
+        "campaignId": 7,
+        "topic": "campaign",
+        "text": "Heya, taco! Down to complete today's action?",
+        "template": "askSignupMessage",
+        "direction": "outbound-api-import",
+        "_id": "59a863a25e5d960956ffcc46",
+        "attachments": []
+      }
+    ]
+  }
 }
 ```

--- a/documentation/endpoints/receive-message.md
+++ b/documentation/endpoints/receive-message.md
@@ -46,35 +46,41 @@ curl -X "POST" "http://localhost:5100/api/v1/receive-message" \
 
 ```
 {
-  "messages": {
-    "inbound": {
-      "__v": 0,
-      "updatedAt": "2017-08-29T05:11:02.980Z",
-      "createdAt": "2017-08-29T05:11:02.980Z",
-      "conversationId": "59a4f7669ea1a81cf1ac566f",
-      "topic": "random",
-      "text": "uhh",
-      "direction": "inbound",
-      "_id": "59a4f7669ea1a81cf1ac5670",
-      "attachments": [
-        {
-          "contentType": "image/png",
-          "url": "http://placekitten.com/g/800/800"
-        }
-      ]
-    },
-    "reply": {
-      "__v": 0,
-      "updatedAt": "2017-08-29T05:11:02.993Z",
-      "createdAt": "2017-08-29T05:11:02.993Z",
-      "conversationId": "59a4f7669ea1a81cf1ac566f",
-      "topic": "random",
-      "text": "Sorry, I'm not sure how to respond to that.\n\nSay MENU to find a Campaign to join.",
-      "template": "noCampaignMessage",
-      "direction": "outbound-reply",
-      "_id": "59a4f7669ea1a81cf1ac5671",
-      "attachments": []
-    }
+  "data": {
+    "inbound": [
+      {
+        "__v": 0,
+        "updatedAt": "2017-08-31T19:21:47.556Z",
+        "createdAt": "2017-08-31T19:21:47.556Z",
+        "conversationId": "59a7203fc731160d31cfdad2",
+        "campaignId": 2710,
+        "topic": "campaign",
+        "text": "menu",
+        "direction": "inbound",
+        "_id": "59a861cbf64c3e0902d956e7",
+        "attachments": [
+          {
+            "contentType": "image/png",
+            "url": "http://placekitten.com/g/800/600"
+          }
+        ]
+      }
+    ],
+    "outbound": [
+      {
+        "__v": 0,
+        "updatedAt": "2017-08-31T19:21:47.597Z",
+        "createdAt": "2017-08-31T19:21:47.597Z",
+        "conversationId": "59a7203fc731160d31cfdad2",
+        "campaignId": 7656,
+        "topic": "campaign_7656",
+        "text": "Help us send letters of support to every mosque in the United States. \n\nWant to join Sincerely, Us?\n\nYes or No",
+        "template": "askSignupMessage",
+        "direction": "outbound-reply",
+        "_id": "59a861cbf64c3e0902d956e8",
+        "attachments": []
+      }
+    ]
   }
 }
 ```

--- a/documentation/endpoints/send-message.md
+++ b/documentation/endpoints/send-message.md
@@ -48,18 +48,22 @@ curl -X "POST" "http://localhost:5100/api/v1/send-message" \
 
 ```
 {
-  "reply": {
-    "__v": 0,
-    "updatedAt": "2017-08-18T19:36:31.664Z",
-    "createdAt": "2017-08-18T19:36:31.664Z",
-    "campaignId": 48,
-    "topic": "campaign",
-    "conversationId": "59972fac96c01d1d6b86c73c",
-    "text": "Hey - this is Freddie from DoSomething. Thanks for joining Pride Over Prejudice!\n\nA new White House executive order denies all new refugees entry to the US for 120 days and places a 90-day travel ban on six Muslim-majority nations.\n\nThe solution is simple: Post a selfie to stand in solidarity with refugees and immigrants.\n\nMake sure to take a photo of what you did! When you have Shared some Pictures, text START to share your photo.",
-    "template": "externalSignupMenuMessage",
-    "direction": "outbound-api-send",
-    "_id": "599741bf9f03df1f2c0cb5fb",
-    "attachments": []
+  "data": {
+    "messages": [
+      {
+        "__v": 0,
+        "updatedAt": "2017-08-31T19:07:02.312Z",
+        "createdAt": "2017-08-31T19:07:02.312Z",
+        "conversationId": "59a5c175717a2f25fc628811",
+        "campaignId": 7,
+        "topic": "campaign",
+        "text": "Hey - this is Freddie from DoSomething. Thanks for joining a movement to spread positivity in school. You can do something simple to make a big impact for a stranger.\n\nLet's do this: post encouraging notes in places that can trigger low self-esteem, like school bathrooms.\n\nThen, text START to share a photo of the messages you posted (and you'll be entered to win a $1000 scholarship)!",
+        "template": "externalSignupMenuMessage",
+        "direction": "outbound-api-send",
+        "_id": "59a85e56d975b4080974ab2d",
+        "attachments": []
+      }
+    ]
   }
 }
 ```

--- a/lib/consolebot.js
+++ b/lib/consolebot.js
@@ -60,9 +60,9 @@ class Consolebot {
     this.prompt();
   }
   handleSuccess(res) {
-    const messages = res.body.messages;
-    if (messages) {
-      return this.reply(messages.reply.text);
+    const data = res.body.data;
+    if (data.outbound) {
+      return this.reply(data.outbound[0].text);
     }
 
     return this.reply('');

--- a/lib/gambit-campaigns.js
+++ b/lib/gambit-campaigns.js
@@ -37,7 +37,7 @@ module.exports.postReceiveMessage = function (data) {
 
   return new Promise((resolve, reject) => {
     this.post('receive-message', data)
-      .then(res => resolve(res.success.message))
+      .then(res => resolve(res.success))
       .catch(err => reject(err));
   });
 };

--- a/lib/gambit-campaigns.js
+++ b/lib/gambit-campaigns.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const superagent = require('superagent');
+const Promise = require('bluebird');
 const logger = require('heroku-logger');
 
 const uri = process.env.DS_GAMBIT_CAMPAIGNS_API_BASEURI;
@@ -20,18 +21,23 @@ module.exports.post = function (endpoint, data) {
     .post(`${uri}/${endpoint}`)
     .set('x-gambit-api-key', apiKey)
     .send(data)
-    .then(response => response.body)
-    .catch(err => logger.error(err));
+    .then(res => res.body)
+    .catch(err => err);
 };
 
 module.exports.getActiveCampaigns = function () {
   return this.get('campaigns');
 };
 
-module.exports.postSignupMessage = function (data) {
-  logger.debug('gambit.postSignupMessage', data);
+/**
+ * Posts data to the /receive-message endpoint.
+ */
+module.exports.postReceiveMessage = function (data) {
+  logger.debug('gambitCampaigns.postReceiveMessage', data);
 
-  return this.post('receive-message', data)
-    .then(res => res.success.message)
-    .catch(err => err.message);
+  return new Promise((resolve, reject) => {
+    this.post('receive-message', data)
+      .then(res => resolve(res.success.message))
+      .catch(err => reject(err));
+  });
 };

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -21,39 +21,12 @@ module.exports.isMenuCommand = function (text = '') {
 };
 
 /**
- * Sends Express response for incoming POST Chatbot Express request.
+ * Sends response with err code and message.
  *
- * @param {object} req
- * @param {object} res
+ * @param  {Object} res
+ * @param  {Error} err
  */
-module.exports.sendResponse = function (req, res) {
-  // Our outboundMessage.text may be empty if this is a noReply.
-  if (req.conversation.platform && req.outboundMessage && req.outboundMessage.text) {
-    req.conversation.postMessageToPlatform(req.outboundMessage);
-  }
-
-  res.send({ reply: req.outboundMessage });
-};
-
-/**
- * Sends given error message as Express response to an incoming Chatbot POST Express request.
- * TODO: Merge this with sendGenericResponse
- *
- * @param {object} req
- * @param {object} res
- */
-module.exports.sendResponseForError = function (req, res, error) {
-  logger.error('sendResponseForError', { error });
-
-  req.reply = {
-    text: error.message,
-    template: 'error',
-  };
-
-  return exports.sendResponse(req, res);
-};
-
-module.exports.sendGenericErrorResponse = function (res, err) {
+module.exports.sendErrorResponse = function (res, err) {
   let status = err.status;
   if (!status) {
     status = 500;
@@ -122,7 +95,7 @@ module.exports.sendReply = function (req, res, messageText, messageTemplate) {
 
       return res.send({ data });
     })
-    .catch(err => exports.sendResponseForError(res, err));
+    .catch(err => exports.sendErrorResponse(res, err));
 };
 
 /**
@@ -145,6 +118,24 @@ module.exports.sendReplyWithCampaignTemplate = function (req, res, messageTempla
   return exports.sendReply(req, res, messageText, messageTemplate);
 };
 
+function parseRequestForGambitCampaigns(req) {
+  let phone = req.conversation._id;
+  if (req.conversation.platform === 'sms') {
+    phone = req.conversation.platformUserId;
+  }
+  const data = {
+    phone,
+    campaignId: req.campaign._id,
+    text: req.inboundMessageText,
+    mediaUrl: req.mediaUrl,
+  };
+  if (req.keyword) {
+    data.keyword = req.keyword.toLowerCase();
+  }
+
+  return data;
+}
+
 /**
  * Sends reply message by posting inboundMessage to Gambit Campaigns for Conversation Campaign.
  * @param {object} req
@@ -153,26 +144,16 @@ module.exports.sendReplyWithCampaignTemplate = function (req, res, messageTempla
 module.exports.sendReplyForCampaignSignupMessage = function (req, res) {
   const campaignId = req.campaign._id;
   if (!campaignId) {
-    return exports.sendResponseForError(res, 'req.campaign undefined');
+    return exports.sendErrorResponse(res, 'req.campaign undefined');
   }
 
-  let phone = req.conversation._id;
-  if (req.conversation.platform === 'sms') {
-    phone = req.conversation.platformUserId;
-  }
-  const data = {
-    phone,
-    campaignId,
-    text: req.inboundMessageText,
-    mediaUrl: req.mediaUrl,
-  };
-  if (req.keyword) {
-    data.keyword = req.keyword.toLowerCase();
-  }
+  const data = parseRequestForGambitCampaigns(req);
 
-  return gambitCampaigns.postSignupMessage(data)
-    .then(replyText => exports.sendReply(req, res, replyText, 'gambit'))
-    .catch(err => exports.sendResponseForError(res, err));
+  return gambitCampaigns.postReceiveMessage(data)
+    // TODO: Once Gambit Campaigns includes the message template in the response, store it
+    // instead of hardcoded 'gambitCampaigns'.
+    .then(messageText => exports.sendReply(req, res, messageText, 'gambitCampaigns'))
+    .catch(err => exports.sendErrorResponse(res, err));
 };
 
 /**

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -80,6 +80,19 @@ module.exports.sendResponseWithStatusCode = function (res, code = 200, message =
 };
 
 /**
+ * Sends response with Message.
+ * @param {object} req
+ * @param {Message} message
+ */
+module.exports.sendResponseWithMessage = function (res, message) {
+  logger.debug('sendResponseWithMessage', { messageId: message._id.toString() });
+
+  const data = { messages: [message] };
+
+  return res.send({ data });
+};
+
+/**
  * Creates and sends outbound-reply Message with given messageText and messageTemplate.
  * @param {object} req
  * @param {object} res

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -150,9 +150,9 @@ module.exports.sendReplyForCampaignSignupMessage = function (req, res) {
   const data = parseRequestForGambitCampaigns(req);
 
   return gambitCampaigns.postReceiveMessage(data)
-    // TODO: Once Gambit Campaigns includes the message template in the response, store it
-    // instead of hardcoded 'gambitCampaigns'.
-    .then(messageText => exports.sendReply(req, res, messageText, 'gambitCampaigns'))
+    // TODO: Pass reply.template instead of hardcoded 'gambitCampaigns'.
+    // @see Conversation.shouldPostToGambitCampaigns
+    .then(reply => exports.sendReply(req, res, reply.message, 'gambitCampaigns'))
     .catch(err => exports.sendErrorResponse(res, err));
 };
 

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -115,12 +115,12 @@ module.exports.sendReply = function (req, res, messageText, messageTemplate) {
     })
     .then(() => {
       // If successful, return the inbound and outbound messages created for our request.
-      const messages = {
-        inbound: req.inboundMessage,
-        reply: req.outboundMessage,
+      const data = {
+        inbound: [req.inboundMessage],
+        outbound: [req.outboundMessage],
       };
 
-      return res.send({ messages });
+      return res.send({ data });
     })
     .catch(err => exports.sendResponseForError(res, err));
 };

--- a/lib/middleware/conversation-create.js
+++ b/lib/middleware/conversation-create.js
@@ -14,6 +14,6 @@ module.exports = function createConversation() {
 
         return next();
       })
-      .catch(err => helpers.sendResponseForError(req, res, err));
+      .catch(err => helpers.sendErrorResponse(res, err));
   };
 };

--- a/lib/middleware/conversation-get.js
+++ b/lib/middleware/conversation-get.js
@@ -18,6 +18,6 @@ module.exports = function getConversation() {
 
         return next();
       })
-      .catch(err => helpers.sendResponseForError(req, res, err));
+      .catch(err => helpers.sendErrorResponse(res, err));
   };
 };

--- a/lib/middleware/receive-message/campaign-current.js
+++ b/lib/middleware/receive-message/campaign-current.js
@@ -33,6 +33,6 @@ module.exports = function getCurrentCampaign() {
 
         return next();
       })
-      .catch(err => helpers.sendResponseForError(res, err));
+      .catch(err => helpers.sendErrorResponse(res, err));
   };
 };

--- a/lib/middleware/receive-message/campaign-keyword.js
+++ b/lib/middleware/receive-message/campaign-keyword.js
@@ -29,6 +29,6 @@ module.exports = function getCampaignForKeyword() {
 
         return helpers.sendReplyForCampaignSignupMessage(req, res);
       })
-      .catch(err => helpers.sendResponseForError(res, err));
+      .catch(err => helpers.sendErrorResponse(res, err));
   };
 };

--- a/lib/middleware/receive-message/campaign-menu.js
+++ b/lib/middleware/receive-message/campaign-menu.js
@@ -18,6 +18,6 @@ module.exports = function campaignMenu() {
         return req.conversation.setCampaign(randomCampaign);
       })
       .then(() => helpers.sendReplyWithCampaignTemplate(req, res, 'askSignupMessage'))
-      .catch(err => helpers.sendResponseForError(req, res, err));
+      .catch(err => helpers.sendErrorResponse(res, err));
   };
 };

--- a/lib/middleware/receive-message/conversation-paused.js
+++ b/lib/middleware/receive-message/conversation-paused.js
@@ -16,6 +16,6 @@ module.exports = function isPaused() {
 
         return helpers.sendOutboundReply(req, res, '', 'noReply');
       })
-      .catch(err => helpers.sendResponseForError(req, res, err));
+      .catch(err => helpers.sendErrorResponse(res, err));
   };
 };

--- a/lib/middleware/receive-message/message-inbound.js
+++ b/lib/middleware/receive-message/message-inbound.js
@@ -13,6 +13,6 @@ module.exports = function createInboundMessage() {
 
         return next();
       })
-      .catch(err => helpers.sendResponseForError(req, res, err));
+      .catch(err => helpers.sendErrorResponse(res, err));
   };
 };

--- a/lib/middleware/receive-message/rivescript.js
+++ b/lib/middleware/receive-message/rivescript.js
@@ -18,6 +18,6 @@ module.exports = function getRivescriptReply() {
 
         return next();
       })
-      .catch(err => helpers.sendResponseForError(res, err));
+      .catch(err => helpers.sendErrorResponse(res, err));
   };
 };


### PR DESCRIPTION
* Closes #39  -- updates the responses of our POST Receive, Send, and Import Message endpoints to return all Message documents created.

* Fixes catching ECONNREFUSED Gambit Campaigns errors (#86) - renames `gambitCampaigns.postSignupMessage `  to `gambitCampaigns.postReceiveMessage` for clarity

* Refactors `sendResponseForError` and `sendGenericErrorResponse` functions as single `sendErrorResposne`
