### PR TITLE
Save Gambit Campaigns message templates

### DIFF
--- a/app/models/Conversation.js
+++ b/app/models/Conversation.js
@@ -147,7 +147,7 @@ conversationSchema.methods.promptSignupForBroadcast = function (campaign, broadc
  */
 conversationSchema.methods.declineSignup = function () {
   this.signupStatus = 'declined';
-  this.save();
+  return this.save();
 };
 
 conversationSchema.methods.getMessagePayload = function () {

--- a/app/models/Conversation.js
+++ b/app/models/Conversation.js
@@ -227,17 +227,5 @@ conversationSchema.methods.postMessageToPlatform = function (outboundMessage) {
   }
 };
 
-/**
- * Should we POST to Gambit Campaigns to determine how to reply to an inbound message? 
- * @return {boolean}
- */
-conversationSchema.methods.shouldPostToGambitCampaigns = function () {
-  // TODO: gambitCampaigns will be deprecated once we start returning the message template
-  // in the response of Gambit Campaigns /POST receive-message
-  // TODO: Define these in config.
-  const templates = ['gambitCampaigns', 'externalSignupMenuMessage'];
-
-  return templates.includes(this.lastOutboundTemplate);
-};
-
 module.exports = mongoose.model('conversations', conversationSchema);
+

--- a/app/routes/receive-message.js
+++ b/app/routes/receive-message.js
@@ -2,7 +2,6 @@
 
 const express = require('express');
 const bot = require('../../lib/rivescript');
-const helpers = require('../../lib/helpers');
 
 const router = express.Router();
 // Load Rivescript triggers and replies.
@@ -51,11 +50,7 @@ router.use(closedCampaignMiddleware());
 router.use(parseAskSignupMiddleware());
 router.use(parseAskContinueMiddleware());
 
-// If our last outbound template was not for the Campaign, prompt to continue Campaign Completion.
+// Continue Campaign conversation, or prompt to return back to it.
 router.use(continueCampaignMiddleware());
-
-// If we're still here, our inbound message is a Signup message for the Conversation Campaign.
-// We post to Gambit Campaigns service and send back the response as outbound reply.
-router.post('/', (req, res) => helpers.sendReplyForCampaignSignupMessage(req, res));
 
 module.exports = router;

--- a/config/lib/helpers.js
+++ b/config/lib/helpers.js
@@ -1,0 +1,26 @@
+'use strict';
+
+module.exports = {
+  gambitCampaignsTemplates: [
+    'askCaptionMessage',
+    'askPhotoMessage',
+    'askQuantityMessage',
+    'askWhyParticipatedMessage',
+    'completedMenuMessage',
+    'askWhyParticipatedMessage',
+    'externalSignupMenuMessage',
+    'gambitSignupMenuMessage',
+    'invalidCaptionMessage',
+    'invalidCompletedMenuCommandMessage',
+    'invalidPhotoMessage',
+    'invalidQuantityMessage',
+    'invalidSignupMenuCommandMessage',
+    'invalidWhyParticipatedMessage',
+  ],
+  menuCommand: 'menu',
+  rivescriptMacros: [
+    'confirmedCampaign',
+    'declinedCampaign',
+    'gambit',
+  ],
+};

--- a/config/lib/helpers.js
+++ b/config/lib/helpers.js
@@ -18,9 +18,9 @@ module.exports = {
     'invalidWhyParticipatedMessage',
   ],
   menuCommand: 'menu',
-  rivescriptMacros: [
-    'confirmedCampaign',
-    'declinedCampaign',
-    'gambit',
-  ],
+  macros: {
+    confirmedCampaign: 'confirmedCampaign',
+    declinedCampaign: 'declinedCampaign',
+    gambit: 'gambit',
+  },
 };

--- a/config/lib/helpers.js
+++ b/config/lib/helpers.js
@@ -1,6 +1,14 @@
 'use strict';
 
 module.exports = {
+  askContinueTemplates: [
+    'askContinueMessage',
+    'invalidContinueResponseMessage',
+  ],
+  askSignupTemplates: [
+    'askSignupMessage',
+    'invalidSignupResponseMessage',
+  ],
   gambitCampaignsTemplates: [
     'askCaptionMessage',
     'askPhotoMessage',

--- a/config/lib/rivescript.js
+++ b/config/lib/rivescript.js
@@ -4,6 +4,4 @@ module.exports = {
   debug: process.env.RIVESCRIPT_DEBUG,
   directory: 'brain',
   concat: 'newline',
-  macroNames: ['confirmedCampaign', 'declinedCampaign', 'gambit'],
-  menuCommand: 'menu',
 };

--- a/lib/gambit-campaigns.js
+++ b/lib/gambit-campaigns.js
@@ -41,9 +41,10 @@ function parseReceiveMessageRequest(req) {
   }
   const data = {
     phone,
-    campaignId: req.campaign._id,
+    campaignId: req.campaign.id,
     text: req.inboundMessageText,
     mediaUrl: req.mediaUrl,
+    broadcastId: req.broadcastId,
   };
   if (req.keyword) {
     data.keyword = req.keyword.toLowerCase();

--- a/lib/gambit-campaigns.js
+++ b/lib/gambit-campaigns.js
@@ -30,9 +30,33 @@ module.exports.getActiveCampaigns = function () {
 };
 
 /**
+ * Parse our incoming Express request for expected Gambit Campaigns format.
+ * @param {object} req
+ * @return {object}
+ */
+function parseReceiveMessageRequest(req) {
+  let phone = req.conversation._id;
+  if (req.conversation.platform === 'sms') {
+    phone = req.conversation.platformUserId;
+  }
+  const data = {
+    phone,
+    campaignId: req.campaign._id,
+    text: req.inboundMessageText,
+    mediaUrl: req.mediaUrl,
+  };
+  if (req.keyword) {
+    data.keyword = req.keyword.toLowerCase();
+  }
+
+  return data;
+}
+
+/**
  * Posts data to the /receive-message endpoint.
  */
-module.exports.postReceiveMessage = function (data) {
+module.exports.postReceiveMessage = function (req) {
+  const data = parseReceiveMessageRequest(req);
   logger.debug('gambitCampaigns.postReceiveMessage', data);
 
   return new Promise((resolve, reject) => {

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -6,53 +6,39 @@ const gambitCampaigns = require('./gambit-campaigns');
 
 const config = require('../config/lib/helpers');
 
-/**
- * @param {string} text
- * @return {boolean}
- */
+module.exports.isAskContinueTemplate = function (templateName) {
+  return config.askContinueTemplates.includes(templateName);
+};
+
+module.exports.isAskSignupTemplate = function (templateName) {
+  return config.askSignupTemplates.includes(templateName);
+};
+
 module.exports.isConfirmedCampaignMacro = function (text) {
   return (text === config.macros.confirmedCampaign);
 };
 
-/**
- * @param {string} text
- * @return {boolean}
- */
 module.exports.isDeclinedCampaignMacro = function (text) {
   return (text === config.macros.declinedCampaign);
 };
 
-/**
- * @param {string} text
- * @return {boolean}
- */
 module.exports.isGambitCampaignsTemplate = function (templateName) {
-  logger.trace('isGambitCampaignsTemplate', { templateName });
-
   const result = config.gambitCampaignsTemplates.includes(templateName);
+  logger.trace('isGambitCampaignsTemplate', { templateName, result });
 
   return result;
 };
 
-/**
- * @param {string} text
- * @return {boolean}
- */
 module.exports.isMacro = function (text) {
   const result = config.macros[text];
-  logger.trace('isMacro', { result });
+  logger.trace('isMacro', { text, result });
 
   return result;
 };
 
-/**
- * @param {string} text
- * @return {boolean}
- */
 module.exports.isMenuCommand = function (text = '') {
   return (text.toLowerCase() === config.menuCommand);
 };
-
 
 /**
  * Sends response with err code and message.

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -133,29 +133,6 @@ function sendReplyWithCampaignTemplate(req, res, messageTemplate) {
 }
 
 /**
- * Parse our incoming Express request for expected Gambit Campaigns format.
- * @param {object} req
- * @return {object}
- */
-function parseRequestForGambitCampaigns(req) {
-  let phone = req.conversation._id;
-  if (req.conversation.platform === 'sms') {
-    phone = req.conversation.platformUserId;
-  }
-  const data = {
-    phone,
-    campaignId: req.campaign._id,
-    text: req.inboundMessageText,
-    mediaUrl: req.mediaUrl,
-  };
-  if (req.keyword) {
-    data.keyword = req.keyword.toLowerCase();
-  }
-
-  return data;
-}
-
-/**
  * Sends reply message by posting inboundMessage to Gambit Campaigns for Conversation Campaign.
  * @param {object} req
  * @param {object} res
@@ -166,9 +143,7 @@ module.exports.continueCampaign = function (req, res) {
     return exports.sendErrorResponse(res, 'req.campaign undefined');
   }
 
-  const data = parseRequestForGambitCampaigns(req);
-
-  return gambitCampaigns.postReceiveMessage(data)
+  return gambitCampaigns.postReceiveMessage(req)
     .then(reply => sendReply(req, res, reply.message, reply.template))
     .catch(err => exports.sendErrorResponse(res, err));
 };

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -86,7 +86,7 @@ module.exports.sendResponseWithMessage = function (res, message) {
  * @param {string} messageText
  * @param {string} messageTemplate
  */
-module.exports.sendReply = function (req, res, messageText, messageTemplate) {
+function sendReply(req, res, messageText, messageTemplate) {
   logger.debug('sendReply', { messageText, messageTemplate });
 
   return req.conversation.createOutboundReplyMessage(messageText, messageTemplate)
@@ -110,7 +110,7 @@ module.exports.sendReply = function (req, res, messageText, messageTemplate) {
       return res.send({ data });
     })
     .catch(err => exports.sendErrorResponse(res, err));
-};
+}
 
 /**
  * Sends given template for Conversation Campaign as reply.
@@ -118,7 +118,7 @@ module.exports.sendReply = function (req, res, messageText, messageTemplate) {
  * @param {object} res
  * @param {string} messageTemplate
  */
-module.exports.sendReplyWithCampaignTemplate = function (req, res, messageTemplate) {
+function sendReplyWithCampaignTemplate(req, res, messageTemplate) {
   const campaign = req.campaign;
   if (!campaign._id) {
     return exports.sendGenericErrorResponse(res, 'req.campaign undefined');
@@ -129,9 +129,14 @@ module.exports.sendReplyWithCampaignTemplate = function (req, res, messageTempla
     return exports.sendGenericErrorResponse(res, `req.campaign.templates.${messageTemplate} undefined`);
   }
 
-  return exports.sendReply(req, res, messageText, messageTemplate);
-};
+  return sendReply(req, res, messageText, messageTemplate);
+}
 
+/**
+ * Parse our incoming Express request for expected Gambit Campaigns format.
+ * @param {object} req
+ * @return {object}
+ */
 function parseRequestForGambitCampaigns(req) {
   let phone = req.conversation._id;
   if (req.conversation.platform === 'sms') {
@@ -164,8 +169,52 @@ module.exports.continueCampaign = function (req, res) {
   const data = parseRequestForGambitCampaigns(req);
 
   return gambitCampaigns.postReceiveMessage(data)
-    .then(reply => exports.sendReply(req, res, reply.message, reply.template))
+    .then(reply => sendReply(req, res, reply.message, reply.template))
     .catch(err => exports.sendErrorResponse(res, err));
+};
+
+module.exports.askContinue = function (req, res) {
+  return sendReplyWithCampaignTemplate(req, res, 'askContinueMessage');
+};
+
+module.exports.askSignup = function (req, res) {
+  return sendReplyWithCampaignTemplate(req, res, 'askSignupMessage');
+};
+
+module.exports.campaignClosed = function (req, res) {
+  return sendReplyWithCampaignTemplate(req, res, 'campaignClosedMessage');
+};
+
+module.exports.declinedContinue = function (req, res) {
+  return sendReplyWithCampaignTemplate(req, res, 'declinedContinueMessage');
+};
+
+module.exports.declinedSignup = function (req, res) {
+  return sendReplyWithCampaignTemplate(req, res, 'declinedSignupMessage');
+};
+
+module.exports.invalidContinueResponse = function (req, res) {
+  return sendReplyWithCampaignTemplate(req, res, 'invalidContinueResponseMessage');
+};
+
+module.exports.invalidSignupResponse = function (req, res) {
+  return sendReplyWithCampaignTemplate(req, res, 'invalidSignupResponseMessage');
+};
+
+module.exports.noCampaign = function (req, res) {
+  // Move to config.
+  const text = 'Sorry, I\'m not sure how to respond to that.\n\nSay MENU to find a Campaign to join.';
+  const template = 'noCampaignMessage';
+
+  return sendReply(req, res, text, template);
+};
+
+module.exports.noReply = function (req, res) {
+  return sendReply(req, res, '', 'noReply');
+};
+
+module.exports.rivescriptReply = function (req, res, messageText) {
+  return sendReply(req, res, messageText, 'rivescript');
 };
 
 /**

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -7,7 +7,23 @@ const gambitCampaigns = require('./gambit-campaigns');
 const config = require('../config/lib/helpers');
 
 /**
- * Inbound messages responding to these messages templates should be forwarded to Gambit Campaigns.
+ * @param {string} text
+ * @return {boolean}
+ */
+module.exports.isConfirmedCampaignMacro = function (text) {
+  return (text === config.macros.confirmedCampaign);
+};
+
+/**
+ * @param {string} text
+ * @return {boolean}
+ */
+module.exports.isDeclinedCampaignMacro = function (text) {
+  return (text === config.macros.declinedCampaign);
+};
+
+/**
+ * @param {string} text
  * @return {boolean}
  */
 module.exports.isGambitCampaignsTemplate = function (templateName) {
@@ -19,20 +35,24 @@ module.exports.isGambitCampaignsTemplate = function (templateName) {
 };
 
 /**
- * Returns whether given text is a Rivescript macro.
- * @param {string} reply
+ * @param {string} text
  * @return {boolean}
  */
-module.exports.isRivescriptMacro = function (text) {
-  const result = config.rivescriptMacros.some(macroName => macroName === text);
-  logger.trace('isRivescriptMacro', { result });
+module.exports.isMacro = function (text) {
+  const result = config.macros[text];
+  logger.trace('isMacro', { result });
 
   return result;
 };
 
+/**
+ * @param {string} text
+ * @return {boolean}
+ */
 module.exports.isMenuCommand = function (text = '') {
   return (text.toLowerCase() === config.menuCommand);
 };
+
 
 /**
  * Sends response with err code and message.
@@ -158,6 +178,20 @@ module.exports.askSignup = function (req, res) {
 
 module.exports.campaignClosed = function (req, res) {
   return sendReplyWithCampaignTemplate(req, res, 'campaignClosedMessage');
+};
+
+module.exports.confirmedContinue = function (req, res) {
+  // Set this to include the "Picking up where you left off" prefix in Gambit Campaigns reply.
+  req.keyword = 'continue';
+
+  return exports.continueCampaign(req, res);
+};
+
+module.exports.confirmedSignup = function (req, res) {
+  // Set this to trigger Campaign Doing Menu reply in Gambit Campaigns.
+  req.keyword = 'confirmed';
+
+  return exports.continueCampaign(req, res);
 };
 
 module.exports.declinedContinue = function (req, res) {

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,23 +1,37 @@
 'use strict';
 
 const logger = require('heroku-logger');
-const botConfig = require('../config/lib/rivescript');
 const contentful = require('./contentful');
 const gambitCampaigns = require('./gambit-campaigns');
 
+const config = require('../config/lib/helpers');
+
 /**
- * Returns whether given botReply should be handled via macro.
+ * Inbound messages responding to these messages templates should be forwarded to Gambit Campaigns.
+ * @return {boolean}
+ */
+module.exports.isGambitCampaignsTemplate = function (templateName) {
+  logger.trace('isGambitCampaignsTemplate', { templateName });
+
+  const result = config.gambitCampaignsTemplates.includes(templateName);
+
+  return result;
+};
+
+/**
+ * Returns whether given text is a Rivescript macro.
  * @param {string} reply
  * @return {boolean}
  */
-module.exports.isMacro = function (botReply) {
-  const macroExistsForReply = botConfig.macroNames.some(macroName => macroName === botReply);
+module.exports.isRivescriptMacro = function (text) {
+  const result = config.rivescriptMacros.some(macroName => macroName === text);
+  logger.trace('isRivescriptMacro', { result });
 
-  return macroExistsForReply;
+  return result;
 };
 
 module.exports.isMenuCommand = function (text = '') {
-  return (text.toLowerCase() === botConfig.menuCommand);
+  return (text.toLowerCase() === config.menuCommand);
 };
 
 /**
@@ -141,7 +155,7 @@ function parseRequestForGambitCampaigns(req) {
  * @param {object} req
  * @param {object} res
  */
-module.exports.sendReplyForCampaignSignupMessage = function (req, res) {
+module.exports.continueCampaign = function (req, res) {
   const campaignId = req.campaign._id;
   if (!campaignId) {
     return exports.sendErrorResponse(res, 'req.campaign undefined');
@@ -150,9 +164,7 @@ module.exports.sendReplyForCampaignSignupMessage = function (req, res) {
   const data = parseRequestForGambitCampaigns(req);
 
   return gambitCampaigns.postReceiveMessage(data)
-    // TODO: Pass reply.template instead of hardcoded 'gambitCampaigns'.
-    // @see Conversation.shouldPostToGambitCampaigns
-    .then(reply => exports.sendReply(req, res, reply.message, 'gambitCampaigns'))
+    .then(reply => exports.sendReply(req, res, reply.message, reply.template))
     .catch(err => exports.sendErrorResponse(res, err));
 };
 

--- a/lib/middleware/conversation-create.js
+++ b/lib/middleware/conversation-create.js
@@ -11,6 +11,7 @@ module.exports = function createConversation() {
     return Conversation.createFromReq(req)
       .then((conversation) => {
         req.conversation = conversation;
+        req.lastOutboundTemplate = req.conversation.lastOutboundTemplate;
 
         return next();
       })

--- a/lib/middleware/conversation-get.js
+++ b/lib/middleware/conversation-get.js
@@ -11,8 +11,10 @@ module.exports = function getConversation() {
         if (!conversation) return next();
 
         req.conversation = conversation;
+        req.lastOutboundTemplate = req.conversation.lastOutboundTemplate;
+
         logger.debug('getConversation', {
-          conversationId: conversation._id.toString(),
+          conversationId: conversation.id,
           topic: conversation.topic,
         });
 

--- a/lib/middleware/receive-message/campaign-closed.js
+++ b/lib/middleware/receive-message/campaign-closed.js
@@ -9,7 +9,7 @@ module.exports = function closedCampaign() {
     }
 
     if (req.campaign.isClosed) {
-      return helpers.sendReplyWithCampaignTemplate(req, res, 'campaignClosedMessage');
+      return helpers.campaignClosed(req, res);
     }
 
     return next();

--- a/lib/middleware/receive-message/campaign-continue.js
+++ b/lib/middleware/receive-message/campaign-continue.js
@@ -3,9 +3,9 @@
 const helpers = require('../../helpers');
 
 module.exports = function askContinueTemplate() {
-  return (req, res, next) => {
-    if (req.conversation.shouldPostToGambitCampaigns()) {
-      return next();
+  return (req, res) => {
+    if (helpers.isGambitCampaignsTemplate(req.lastOutboundTemplate)) {
+      return helpers.continueCampaign(req, res);
     }
 
     // Topic may be set to random from the last Rivescript reply.

--- a/lib/middleware/receive-message/campaign-continue.js
+++ b/lib/middleware/receive-message/campaign-continue.js
@@ -8,10 +8,12 @@ module.exports = function askContinueTemplate() {
       return helpers.continueCampaign(req, res);
     }
 
-    // Topic may be set to random from the last Rivescript reply.
-    // We set it to the Campaign topic to listen for confirmedCampaign, declinedCampaign macros.
+    // If we're here, we may have a non-Campaign topic set. 
+    // Set topic to current Campaign to listen for confirmedCampaign, declinedCampaign macros.
     req.conversation.setTopic(req.campaign.topic);
 
-    return helpers.sendReplyWithCampaignTemplate(req, res, 'askContinueMessage');
+    // TODO: If Conversation.signupStatus is 'declined', we shouldn't keep asking to continue
+    // the same Campaign -- ask signup for a random Campaign instead?
+    return helpers.askContinue(req, res);
   };
 };

--- a/lib/middleware/receive-message/campaign-current.js
+++ b/lib/middleware/receive-message/campaign-current.js
@@ -4,10 +4,6 @@ const logger = require('heroku-logger');
 const helpers = require('../../helpers');
 const Campaigns = require('../../../app/models/Campaign');
 
-// TODO: Set these in config somewhere.
-const template = 'noCampaignMessage';
-const text = 'Sorry, I\'m not sure how to respond to that.\n\nSay MENU to find a Campaign to join.';
-
 module.exports = function getCurrentCampaign() {
   return (req, res, next) => {
     // If we already have a Campaign, user sent a keyword.
@@ -20,13 +16,13 @@ module.exports = function getCurrentCampaign() {
 
     // If no Campaign has been set, User has never signed up for a Campaign.
     if (!campaignId) {
-      return helpers.sendReply(req, res, text, template);
+      return helpers.noCampaign(req, res);
     }
 
     return Campaigns.findById(campaignId)
       .then((campaign) => {
         if (!campaign) {
-          return helpers.sendReply(req, res, text, template);
+          return helpers.noCampaign(req, res);
         }
 
         req.campaign = campaign;

--- a/lib/middleware/receive-message/campaign-keyword.js
+++ b/lib/middleware/receive-message/campaign-keyword.js
@@ -27,7 +27,7 @@ module.exports = function getCampaignForKeyword() {
           return next();
         }
 
-        return helpers.sendReplyForCampaignSignupMessage(req, res);
+        return helpers.continueCampaign(req, res);
       })
       .catch(err => helpers.sendErrorResponse(res, err));
   };

--- a/lib/middleware/receive-message/campaign-menu.js
+++ b/lib/middleware/receive-message/campaign-menu.js
@@ -17,7 +17,7 @@ module.exports = function campaignMenu() {
 
         return req.conversation.setCampaign(randomCampaign);
       })
-      .then(() => helpers.sendReplyWithCampaignTemplate(req, res, 'askSignupMessage'))
+      .then(() => helpers.askSignup(req, res))
       .catch(err => helpers.sendErrorResponse(res, err));
   };
 };

--- a/lib/middleware/receive-message/conversation-paused.js
+++ b/lib/middleware/receive-message/conversation-paused.js
@@ -14,7 +14,7 @@ module.exports = function isPaused() {
       .then((frontRes) => {
         logger.debug('front.postMessage', frontRes);
 
-        return helpers.sendOutboundReply(req, res, '', 'noReply');
+        return helpers.noReply(req, res);
       })
       .catch(err => helpers.sendErrorResponse(res, err));
   };

--- a/lib/middleware/receive-message/parse-ask-continue-answer.js
+++ b/lib/middleware/receive-message/parse-ask-continue-answer.js
@@ -4,7 +4,7 @@ const helpers = require('../../helpers');
 
 module.exports = function parseAskContinueResponse() {
   return (req, res, next) => {
-    const lastReply = req.conversation.lastOutboundTemplate;
+    const lastReply = req.lastOutboundTemplate;
 
     const askedForContinue = (lastReply === 'askContinueMessage' || lastReply === 'invalidContinueResponseMessage');
     if (!askedForContinue) {
@@ -15,7 +15,7 @@ module.exports = function parseAskContinueResponse() {
       // Set this to include the "Picking up where you left off" prefix in Gambit Campaigns reply.
       req.keyword = 'continue';
 
-      return helpers.sendReplyForCampaignSignupMessage(req, res);
+      return helpers.continueCampaign(req, res);
     }
 
     const template = req.rivescriptReplyText === 'declinedCampaign' ? 'declinedContinueMessage' : 'invalidContinueResponseMessage';

--- a/lib/middleware/receive-message/parse-ask-continue-answer.js
+++ b/lib/middleware/receive-message/parse-ask-continue-answer.js
@@ -10,14 +10,12 @@ module.exports = function parseAskContinueResponse() {
       return next();
     }
 
-    if (req.rivescriptReplyText === 'confirmedCampaign') {
-      // Set this to include the "Picking up where you left off" prefix in Gambit Campaigns reply.
-      req.keyword = 'continue';
-
-      return helpers.continueCampaign(req, res);
+    const text = req.rivescriptReplyText;
+    if (helpers.isConfirmedCampaignMacro(text)) {
+      return helpers.confirmedContinue(req, res);
     }
 
-    if (req.rivescriptReplyText === 'declinedCampaign') {
+    if (helpers.isDeclinedCampaignMacro(text)) {
       return helpers.declinedContinue(req, res);
     }
 

--- a/lib/middleware/receive-message/parse-ask-continue-answer.js
+++ b/lib/middleware/receive-message/parse-ask-continue-answer.js
@@ -4,10 +4,9 @@ const helpers = require('../../helpers');
 
 module.exports = function parseAskContinueResponse() {
   return (req, res, next) => {
-    const lastReply = req.lastOutboundTemplate;
-
-    const askedForContinue = (lastReply === 'askContinueMessage' || lastReply === 'invalidContinueResponseMessage');
-    if (!askedForContinue) {
+    const template = req.lastOutboundTemplate;
+    const asked = (template === 'askContinueMessage' || template === 'invalidContinueResponseMessage');
+    if (!asked) {
       return next();
     }
 
@@ -18,8 +17,10 @@ module.exports = function parseAskContinueResponse() {
       return helpers.continueCampaign(req, res);
     }
 
-    const template = req.rivescriptReplyText === 'declinedCampaign' ? 'declinedContinueMessage' : 'invalidContinueResponseMessage';
+    if (req.rivescriptReplyText === 'declinedCampaign') {
+      return helpers.declinedContinue(req, res);
+    }
 
-    return helpers.sendReplyWithCampaignTemplate(req, res, template);
+    return helpers.invalidContinueResponse(req, res);
   };
 };

--- a/lib/middleware/receive-message/parse-ask-continue-answer.js
+++ b/lib/middleware/receive-message/parse-ask-continue-answer.js
@@ -4,8 +4,7 @@ const helpers = require('../../helpers');
 
 module.exports = function parseAskContinueResponse() {
   return (req, res, next) => {
-    const template = req.lastOutboundTemplate;
-    const asked = (template === 'askContinueMessage' || template === 'invalidContinueResponseMessage');
+    const asked = helpers.isAskContinueTemplate(req.lastOutboundTemplate);
     if (!asked) {
       return next();
     }

--- a/lib/middleware/receive-message/parse-ask-signup-answer.js
+++ b/lib/middleware/receive-message/parse-ask-signup-answer.js
@@ -4,8 +4,7 @@ const helpers = require('../../helpers');
 
 module.exports = function parseAskSignupResponse() {
   return (req, res, next) => {
-    const template = req.conversation.lastOutboundTemplate;
-    const asked = (template === 'askSignupMessage' || template === 'invalidSignupResponseMessage');
+    const asked = helpers.isAskSignupTemplate(req.lastOutboundTemplate);
     if (!asked) {
       return next();
     }

--- a/lib/middleware/receive-message/parse-ask-signup-answer.js
+++ b/lib/middleware/receive-message/parse-ask-signup-answer.js
@@ -10,14 +10,12 @@ module.exports = function parseAskSignupResponse() {
       return next();
     }
 
-    if (req.rivescriptReplyText === 'confirmedCampaign') {
-      // Set this to trigger Campaign Doing Menu reply in Gambit Campaigns.
-      req.keyword = 'confirmed';
-
-      return helpers.continueCampaign(req, res);
+    const text = req.rivescriptReplyText;
+    if (helpers.isConfirmedCampaignMacro(text)) {
+      return helpers.confirmedSignup(req, res);
     }
 
-    if (req.rivescriptReplyText !== 'declinedCampaign') {
+    if (!helpers.isDeclinedCampaignMacro(text)) {
       return helpers.invalidSignupResponse(req, res);
     }
 

--- a/lib/middleware/receive-message/parse-ask-signup-answer.js
+++ b/lib/middleware/receive-message/parse-ask-signup-answer.js
@@ -15,7 +15,7 @@ module.exports = function parseAskSignupResponse() {
       // Set this to trigger Campaign Doing Menu reply in Gambit Campaigns.
       req.keyword = 'confirmed';
 
-      return helpers.sendReplyForCampaignSignupMessage(req, res);
+      return helpers.continueCampaign(req, res);
     }
 
     let template;

--- a/lib/middleware/receive-message/parse-ask-signup-answer.js
+++ b/lib/middleware/receive-message/parse-ask-signup-answer.js
@@ -4,10 +4,9 @@ const helpers = require('../../helpers');
 
 module.exports = function parseAskSignupResponse() {
   return (req, res, next) => {
-    const lastReply = req.conversation.lastOutboundTemplate;
-
-    const askedForSignup = (lastReply === 'askSignupMessage' || lastReply === 'invalidSignupResponseMessage');
-    if (!askedForSignup) {
+    const template = req.conversation.lastOutboundTemplate;
+    const asked = (template === 'askSignupMessage' || template === 'invalidSignupResponseMessage');
+    if (!asked) {
       return next();
     }
 
@@ -18,14 +17,12 @@ module.exports = function parseAskSignupResponse() {
       return helpers.continueCampaign(req, res);
     }
 
-    let template;
-    if (req.rivescriptReplyText === 'declinedCampaign') {
-      req.conversation.declineSignup();
-      template = 'declinedSignupMessage';
-    } else {
-      template = 'invalidSignupResponseMessage';
+    if (req.rivescriptReplyText !== 'declinedCampaign') {
+      return helpers.invalidSignupResponse(req, res);
     }
 
-    return helpers.sendReplyWithCampaignTemplate(req, res, template);
+    return req.conversation.declineSignup()
+      .then(() => helpers.declinedSignup(req, res))
+      .catch(err => helpers.sendErrorResponse(res, err));
   };
 };

--- a/lib/middleware/receive-message/rivescript.js
+++ b/lib/middleware/receive-message/rivescript.js
@@ -12,11 +12,11 @@ module.exports = function getRivescriptReply() {
         return req.conversation.setTopic(rivescriptRes.topic);
       })
       .then(() => {
-        if (!helpers.isMacro(req.rivescriptReplyText)) {
-          return helpers.sendReply(req, res, req.rivescriptReplyText, 'brain');
+        if (helpers.isRivescriptMacro(req.rivescriptReplyText)) {
+          return next();
         }
 
-        return next();
+        return helpers.sendReply(req, res, req.rivescriptReplyText, 'rivescript');
       })
       .catch(err => helpers.sendErrorResponse(res, err));
   };

--- a/lib/middleware/receive-message/rivescript.js
+++ b/lib/middleware/receive-message/rivescript.js
@@ -16,7 +16,7 @@ module.exports = function getRivescriptReply() {
           return next();
         }
 
-        return helpers.sendReply(req, res, req.rivescriptReplyText, 'rivescript');
+        return helpers.rivescriptReply(req, res, req.rivescriptReplyText);
       })
       .catch(err => helpers.sendErrorResponse(res, err));
   };

--- a/lib/middleware/receive-message/rivescript.js
+++ b/lib/middleware/receive-message/rivescript.js
@@ -12,7 +12,7 @@ module.exports = function getRivescriptReply() {
         return req.conversation.setTopic(rivescriptRes.topic);
       })
       .then(() => {
-        if (helpers.isRivescriptMacro(req.rivescriptReplyText)) {
+        if (helpers.isMacro(req.rivescriptReplyText)) {
           return next();
         }
 


### PR DESCRIPTION
* Fixes #98: Instead of saving our Gambit Campaigns outbound reply messages with template `gambitCampaigns`, save the template now returned in Gambit Campaigns response added in https://github.com/DoSomething/gambit/pull/956
    * This gets our Messages data in good shape to start logging our outbound templates, per #49 

* Refactors `helpers.sendReply` as individual functions per template, a la https://github.com/DoSomething/gambit/pull/926

