### PR TITLE
WIP: Handling Blink retries to prevent message dupes

### DIFF
--- a/app/models/Conversation.js
+++ b/app/models/Conversation.js
@@ -159,9 +159,25 @@ conversationSchema.methods.getMessagePayload = function (req = {}) {
   };
 };
 
-conversationSchema.methods.loadMessageAndUpdateMetadataByRequestId = function (requestId,
+conversationSchema.methods.loadInboundMessageAndUpdateMetadataByRequestId = function (requestId,
   metadata = {}) {
-  const query = { conversationId: this._id, 'metadata.requestId': requestId };
+  const query = {
+    conversationId: this._id,
+    'metadata.requestId': requestId,
+    direction: 'inbound',
+  };
+  const update = { metadata };
+  const options = { new: true };
+  return Messages.findOneAndUpdate(query, update, options);
+};
+
+conversationSchema.methods.loadOutboundMessageAndUpdateMetadataByRequestId = function (requestId,
+  metadata = {}) {
+  const query = {
+    conversationId: this._id,
+    'metadata.requestId': requestId,
+    direction: { $regex: /^outbound.*/i },
+  };
   const update = { metadata };
   const options = { new: true };
   return Messages.findOneAndUpdate(query, update, options);

--- a/app/models/Conversation.js
+++ b/app/models/Conversation.js
@@ -162,6 +162,8 @@ conversationSchema.methods.createInboundMessage = function (req) {
   const message = this.getMessagePayload();
   message.text = req.inboundMessageText;
   message.direction = 'inbound';
+  // TODO: attachments should be default in the getMessagePayload method, because we will eventually
+  // have attachments for outbound messages too
   message.attachments = req.attachments;
 
   // TODO: Handle platform dependent message properties here
@@ -228,4 +230,3 @@ conversationSchema.methods.postMessageToPlatform = function (outboundMessage) {
 };
 
 module.exports = mongoose.model('conversations', conversationSchema);
-

--- a/app/models/Message.js
+++ b/app/models/Message.js
@@ -20,6 +20,10 @@ const messageSchema = new mongoose.Schema({
   text: String,
   topic: String,
   attachments: Array,
+  metadata: {
+    requestId: String,
+    retryCount: Number,
+  },
 }, { timestamps: true });
 
 module.exports = mongoose.model('messages', messageSchema);

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -6,18 +6,23 @@ const importMessageRoute = require('./import-message');
 
 // middleware
 const authenticateMiddleware = require('../../lib/middleware/authenticate');
+const parseMetadataMiddleware = require('../../lib/middleware/metadata-parse');
 
 module.exports = function init(app) {
   app.get('/', (req, res) => {
     res.send('hi');
   });
+
+  // authenticate all requests after this line
+  app.use(authenticateMiddleware());
+
+  // parse metadata like requestId and retryCount for all requests after this line
+  app.use(parseMetadataMiddleware());
+
   app.use('/api/v1/receive-message',
-    authenticateMiddleware(),
     receiveMessageRoute);
   app.use('/api/v1/send-message',
-    authenticateMiddleware(),
     sendMessageRoute);
   app.use('/api/v1/import-message',
-    authenticateMiddleware(),
     importMessageRoute);
 };

--- a/app/routes/receive-message.js
+++ b/app/routes/receive-message.js
@@ -24,9 +24,11 @@ const continueCampaignMiddleware = require('../../lib/middleware/receive-message
 
 router.use(paramsMiddleware());
 
-// Load/create conversation and load/create inbound message.
+// Load/create conversation
 router.use(getConversationMiddleware());
 router.use(createConversationMiddleware());
+
+// Load/create inbound message.
 router.use(loadInboundMessageMiddleware());
 router.use(createInboundMessageMiddleware());
 

--- a/app/routes/receive-message.js
+++ b/app/routes/receive-message.js
@@ -10,7 +10,8 @@ bot.getBot();
 const paramsMiddleware = require('../../lib/middleware/receive-message/params');
 const getConversationMiddleware = require('../../lib/middleware/conversation-get');
 const createConversationMiddleware = require('../../lib/middleware/conversation-create');
-const inboundMessageMiddleware = require('../../lib/middleware/receive-message/message-inbound');
+const loadInboundMessageMiddleware = require('../../lib/middleware/receive-message/message-inbound-load');
+const createInboundMessageMiddleware = require('../../lib/middleware/receive-message/message-inbound-create');
 const rivescriptMiddleware = require('../../lib/middleware/receive-message/rivescript');
 const pausedMiddleware = require('../../lib/middleware/receive-message/conversation-paused');
 const campaignMenuMiddleware = require('../../lib/middleware/receive-message/campaign-menu');
@@ -23,10 +24,11 @@ const continueCampaignMiddleware = require('../../lib/middleware/receive-message
 
 router.use(paramsMiddleware());
 
-// Load conversation and create inbound message.
+// Load/create conversation and load/create inbound message.
 router.use(getConversationMiddleware());
 router.use(createConversationMiddleware());
-router.use(inboundMessageMiddleware());
+router.use(loadInboundMessageMiddleware());
+router.use(createInboundMessageMiddleware());
 
 // Send our inbound message to Rivescript bot for a reply.
 router.use(rivescriptMiddleware());

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -95,7 +95,7 @@ module.exports.sendResponseWithMessage = function (res, message) {
 function sendReply(req, res, messageText, messageTemplate) {
   logger.debug('sendReply', { messageText, messageTemplate });
 
-  return req.conversation.createOutboundReplyMessage(messageText, messageTemplate)
+  return req.conversation.createOutboundReplyMessage(messageText, messageTemplate, req)
     .then((outboundMessage) => {
       req.outboundMessage = outboundMessage;
       logger.debug('createOutboundReplyMessage', { messageId: outboundMessage._id.toString() });

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const logger = require('heroku-logger');
+const Promise = require('bluebird');
+
 const contentful = require('./contentful');
 const gambitCampaigns = require('./gambit-campaigns');
 
@@ -94,8 +96,17 @@ module.exports.sendResponseWithMessage = function (res, message) {
  */
 function sendReply(req, res, messageText, messageTemplate) {
   logger.debug('sendReply', { messageText, messageTemplate });
+  let messagePromise = Promise.reject();
 
-  return req.conversation.createOutboundReplyMessage(messageText, messageTemplate, req)
+  // TODO: could be taken out to its own function
+  if (req.isARetryRequest()) {
+    messagePromise = req.conversation
+      .loadOutboundMessageAndUpdateMetadataByRequestId(req.metadata.requestId, req.metadata);
+  } else {
+    messagePromise = req.conversation.createOutboundReplyMessage(messageText, messageTemplate, req);
+  }
+
+  return messagePromise
     .then((outboundMessage) => {
       req.outboundMessage = outboundMessage;
       logger.debug('createOutboundReplyMessage', { messageId: outboundMessage._id.toString() });
@@ -197,7 +208,7 @@ module.exports.invalidSignupResponse = function (req, res) {
 };
 
 module.exports.noCampaign = function (req, res) {
-  // Move to config.
+  // TODO: Move to config.
   const text = 'Sorry, I\'m not sure how to respond to that.\n\nSay MENU to find a Campaign to join.';
   const template = 'noCampaignMessage';
 

--- a/lib/middleware/import-message/message-outbound.js
+++ b/lib/middleware/import-message/message-outbound.js
@@ -2,7 +2,7 @@
 
 module.exports = function outboundMessage() {
   return (req, res, next) => {
-    req.conversation.createOutboundImportMessage(req.importMessageText, req.outboundTemplate)
+    req.conversation.createOutboundImportMessage(req.importMessageText, req.outboundTemplate, req)
       .then((message) => {
         req.outboundMessage = message;
         return next();

--- a/lib/middleware/metadata-parse.js
+++ b/lib/middleware/metadata-parse.js
@@ -1,0 +1,34 @@
+'use strict';
+
+const logger = require('heroku-logger');
+
+function parseRetryCount(req) {
+  const retryCountFromHeader = Number(req.get('x-blink-retry-count')) || 0;
+  const retryCountFromQuery = Number(req.query['x-blink-retry-count']) || 0;
+  const retryCount = retryCountFromHeader || retryCountFromQuery || 0;
+
+  if (retryCount) {
+    req.metadata.retryCount = retryCount;
+    logger.info('Blink retry count', { retryCount });
+  }
+}
+
+function parseRequestId(req) {
+  const requestIdFromHeader = req.get('x-request-id');
+  const requestIdFromQuery = req.query['x-request-id'];
+  const requestId = requestIdFromHeader || requestIdFromQuery;
+
+  if (requestId) {
+    req.metadata.requestId = requestId;
+    logger.info('Request ID', { requestId });
+  }
+}
+
+module.exports = function parseMetadata() {
+  return (req, res, next) => {
+    req.metadata = {};
+    parseRetryCount(req);
+    parseRequestId(req);
+    return next();
+  };
+};

--- a/lib/middleware/metadata-parse.js
+++ b/lib/middleware/metadata-parse.js
@@ -24,11 +24,16 @@ function parseRequestId(req) {
   }
 }
 
+function registerIsARetryRequestFunction(req) {
+  req.isARetryRequest = () => !!req.metadata.retryCount;
+}
+
 module.exports = function parseMetadata() {
   return (req, res, next) => {
     req.metadata = {};
     parseRetryCount(req);
     parseRequestId(req);
+    registerIsARetryRequestFunction(req);
     return next();
   };
 };

--- a/lib/middleware/receive-message/message-inbound-create.js
+++ b/lib/middleware/receive-message/message-inbound-create.js
@@ -4,10 +4,17 @@ const helpers = require('../../helpers');
 
 module.exports = function createInboundMessage() {
   return (req, res, next) => {
+    // If this is a retry request, we already loaded the message
+    if (req.isARetryRequest()) {
+      return next();
+    }
+
+    // TODO: This should be moved to receive-message/params middleware
     if (req.inboundMessageText) {
       req.userCommand = req.inboundMessageText.trim();
     }
-    req.conversation.createInboundMessage(req)
+
+    return req.conversation.createInboundMessage(req)
       .then((message) => {
         req.inboundMessage = message;
 

--- a/lib/middleware/receive-message/message-inbound-create.js
+++ b/lib/middleware/receive-message/message-inbound-create.js
@@ -5,7 +5,7 @@ const helpers = require('../../helpers');
 module.exports = function createInboundMessage() {
   return (req, res, next) => {
     // If this is a retry request, we already loaded the message
-    if (req.isARetryRequest()) {
+    if (req.isARetryRequest() && req.inboundMessage) {
       return next();
     }
 

--- a/lib/middleware/receive-message/message-inbound-load.js
+++ b/lib/middleware/receive-message/message-inbound-load.js
@@ -14,7 +14,7 @@ module.exports = function loadInboundMessage() {
       req.userCommand = req.inboundMessageText.trim();
     }
 
-    return req.conversation.loadMessageAndUpdateMetadataByRequestId(req.metadata.requestId,
+    return req.conversation.loadInboundMessageAndUpdateMetadataByRequestId(req.metadata.requestId,
       req.metadata)
       .then((message) => {
         req.inboundMessage = message;

--- a/lib/middleware/receive-message/message-inbound-load.js
+++ b/lib/middleware/receive-message/message-inbound-load.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const helpers = require('../../helpers');
+
+module.exports = function loadInboundMessage() {
+  return (req, res, next) => {
+    // If this is not a retry request, we have to create a new inbound message
+    if (!req.isARetryRequest()) {
+      return next();
+    }
+
+    // TODO: This should be moved to receive-message/params middleware
+    if (req.inboundMessageText) {
+      req.userCommand = req.inboundMessageText.trim();
+    }
+
+    return req.conversation.loadMessageAndUpdateMetadataByRequestId(req.metadata.requestId,
+      req.metadata)
+      .then((message) => {
+        req.inboundMessage = message;
+
+        return next();
+      })
+      .catch(err => helpers.sendErrorResponse(res, err));
+  };
+};

--- a/lib/middleware/send-message/message-outbound.js
+++ b/lib/middleware/send-message/message-outbound.js
@@ -2,7 +2,7 @@
 
 module.exports = function outboundMessage() {
   return (req, res, next) => {
-    req.conversation.createOutboundSendMessage(req.sendMessageText, req.outboundTemplate)
+    req.conversation.createOutboundSendMessage(req.sendMessageText, req.outboundTemplate, req)
       .then((message) => {
         req.outboundMessage = message;
         return next();


### PR DESCRIPTION
## Summary
Starts implementation of this feature according to this diagram.
![](https://user-images.githubusercontent.com/863301/30079926-7aaef5f0-9247-11e7-9944-61ea1f66f41a.png)

## Tasks
- [x] Adding middleware to parse `retryCount` and `requestId` into a `req.metadata` object
- [x] Save metadata object to message created
- [x] Check if the request is a "retry" request to load an **inbound** message instead of creating a new one
- [x] Check if the request is a "retry" request to load an **outbound** message instead of creating a new one

## Relevant tickets
Fixes #51 