### PR TITLE
Send Message fix + Conversation.lastOutboundMessage

### DIFF
--- a/app/models/Campaign.js
+++ b/app/models/Campaign.js
@@ -168,4 +168,4 @@ campaignSchema.virtual('isClosed').get(function () {
 
 /* eslint-enable prefer-arrow-callback */
 
-module.exports = mongoose.model('campaigns', campaignSchema);
+module.exports = mongoose.model('Campaign', campaignSchema);

--- a/app/models/Conversation.js
+++ b/app/models/Conversation.js
@@ -231,7 +231,7 @@ conversationSchema.methods.outboundSend = function (text, template) {
  * @param {string} template
  * @return {Promise}
  */
-conversationSchema.methods.createOutboundImportMessage = function (text, template) {
+conversationSchema.methods.outboundImport = function (text, template) {
   return this.createOutboundMessage(text, template, 'outbound-api-import');
 };
 
@@ -265,4 +265,3 @@ conversationSchema.methods.postMessageToPlatform = function () {
 };
 
 module.exports = mongoose.model('Conversation', conversationSchema);
-

--- a/app/models/Conversation.js
+++ b/app/models/Conversation.js
@@ -105,6 +105,7 @@ conversationSchema.methods.setCampaignWithSignupStatus = function (campaign, sig
   this.topic = campaign.topic;
   this.campaignId = campaign._id;
   this.signupStatus = signupStatus;
+  logger.debug('setCampaignWithSignupStatus', { campaign: this.campaignId, signupStatus });
 
   return this.save();
 };
@@ -116,7 +117,7 @@ conversationSchema.methods.setCampaignWithSignupStatus = function (campaign, sig
  * @param {string} keyword
  */
 conversationSchema.methods.setCampaign = function (campaign) {
-  this.setCampaignWithSignupStatus(campaign, 'doing');
+  return this.setCampaignWithSignupStatus(campaign, 'doing');
 };
 
 /**
@@ -191,6 +192,8 @@ conversationSchema.methods.createInboundMessage = function (req) {
  * @return {Promise}
  */
 conversationSchema.methods.createOutboundMessage = function (text, template, direction) {
+  logger.debug('createOutboundMessage', { direction });
+
   const data = this.getMessagePayload(text, template);
   data.direction = direction;
 
@@ -240,7 +243,11 @@ conversationSchema.methods.createOutboundImportMessage = function (text, templat
 conversationSchema.methods.postMessageToPlatform = function () {
   const loggerMessage = 'conversation.postMessageToPlatform';
   const messageText = this.lastOutboundMessage.text;
-  logger.debug(loggerMessage, { messageText });
+  // This could be blank for noReply templates.
+  if (!messageText) {
+    return;
+  }
+  logger.debug(loggerMessage);
 
   if (this.platform === 'slack') {
     slack.postMessage(this.slackChannel, messageText);

--- a/app/models/Message.js
+++ b/app/models/Message.js
@@ -22,4 +22,4 @@ const messageSchema = new mongoose.Schema({
   attachments: Array,
 }, { timestamps: true });
 
-module.exports = mongoose.model('messages', messageSchema);
+module.exports = mongoose.model('Message', messageSchema);

--- a/app/routes/send-message.js
+++ b/app/routes/send-message.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const express = require('express');
-const helpers = require('../../lib/helpers');
 
 const router = express.Router();
 
@@ -11,7 +10,7 @@ const getConversationMiddleware = require('../../lib/middleware/conversation-get
 const createConversationMiddleware = require('../../lib/middleware/conversation-create');
 const campaignMiddleware = require('../../lib/middleware/send-message/campaign');
 const supportMiddleware = require('../../lib/middleware/send-message/support');
-const outboundMessageMiddleware = require('../../lib/middleware/send-message/message-outbound');
+const outboundSendMiddleware = require('../../lib/middleware/send-message/message-outbound');
 
 router.use(supportParamsMiddleware());
 router.use(campaignParamsMiddleware());
@@ -21,8 +20,6 @@ router.use(createConversationMiddleware());
 
 router.use(campaignMiddleware());
 router.use(supportMiddleware());
-router.use(outboundMessageMiddleware());
-
-router.post('/', (req, res) => helpers.sendResponseWithMessage(res, req.outboundMessage));
+router.use(outboundSendMiddleware());
 
 module.exports = router;

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -78,7 +78,7 @@ module.exports.sendResponseWithStatusCode = function (res, code = 200, message =
  * @param {Message} message
  */
 module.exports.sendResponseWithMessage = function (res, message) {
-  logger.debug('sendResponseWithMessage', { messageId: message._id.toString() });
+  logger.debug('sendResponseWithMessage', { messageId: message.id });
 
   const data = { messages: [message] };
 

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -95,22 +95,11 @@ module.exports.sendResponseWithMessage = function (res, message) {
 function sendReply(req, res, messageText, messageTemplate) {
   logger.debug('sendReply', { messageText, messageTemplate });
 
-  return req.conversation.createOutboundReplyMessage(messageText, messageTemplate)
-    .then((outboundMessage) => {
-      req.outboundMessage = outboundMessage;
-      logger.debug('createOutboundReplyMessage', { messageId: outboundMessage._id.toString() });
-
-      if (!outboundMessage.text) {
-        return true;
-      }
-      // Post our outbound message to the API of our Conversation platform.
-      return req.conversation.postMessageToPlatform(outboundMessage);
-    })
+  return req.conversation.outboundReply(messageText, messageTemplate)
     .then(() => {
-      // If successful, return the inbound and outbound messages created for our request.
       const data = {
         inbound: [req.inboundMessage],
-        outbound: [req.outboundMessage],
+        outbound: [req.conversation.lastOutboundMessage],
       };
 
       return res.send({ data });

--- a/lib/middleware/conversation-get.js
+++ b/lib/middleware/conversation-get.js
@@ -11,7 +11,12 @@ module.exports = function getConversation() {
         if (!conversation) return next();
 
         req.conversation = conversation;
-        req.lastOutboundTemplate = req.conversation.lastOutboundTemplate;
+        const lastOutboundMessage = req.conversation.lastOutboundMessage;
+        if (lastOutboundMessage) {
+          req.lastOutboundTemplate = lastOutboundMessage.template;
+        } else {
+          req.lastOutboundTemplate = null;
+        }
 
         logger.debug('getConversation', {
           conversationId: conversation.id,

--- a/lib/middleware/import-message/message-outbound.js
+++ b/lib/middleware/import-message/message-outbound.js
@@ -1,12 +1,11 @@
 'use strict';
 
+const helpers = require('../../helpers');
+
 module.exports = function outboundMessage() {
-  return (req, res, next) => {
-    req.conversation.createOutboundImportMessage(req.importMessageText, req.outboundTemplate)
-      .then((message) => {
-        req.outboundMessage = message;
-        return next();
-      })
-      .catch(err => err);
+  return (req, res) => {
+    req.conversation.outboundImport(req.importMessageText, req.outboundTemplate)
+      .then(() => helpers.sendResponseWithMessage(res, req.conversation.lastOutboundMessage))
+      .catch(err => helpers.sendErrorResponse(res, err));
   };
 };

--- a/lib/middleware/send-message/campaign.js
+++ b/lib/middleware/send-message/campaign.js
@@ -3,26 +3,25 @@
 const Campaigns = require('../../../app/models/Campaign');
 const helpers = require('../../helpers');
 
-module.exports = function sendCampaignMessage() {
+module.exports = function sendCampaignTemplate() {
   return (req, res, next) => {
-    if (req.outboundTemplate === 'support') {
-      return next();
-    }
-
-    return Campaigns.findById(req.campaignId)
+    Campaigns.findById(req.campaignId)
       .then((campaign) => {
         if (!campaign) {
           return helpers.sendResponseWithStatusCode(res, 404, 'Campaign not found.');
         }
-
         if (campaign.isClosed) {
           return helpers.sendResponseWithStatusCode(res, 422, 'Campaign is closed.');
         }
 
-        req.conversation.setCampaign(campaign);
         req.sendMessageText = campaign.templates[req.outboundTemplate];
+        if (!req.sendMessageText) {
+          return helpers.sendResponseWithStatusCode(res, 422, 'Campaign template undefined.');
+        }
 
-        return next();
+        return req.conversation.setCampaign(campaign)
+          .then(() => next())
+          .catch(err => helpers.sendErrorResponse(res, err));
       });
   };
 };

--- a/lib/middleware/send-message/message-outbound.js
+++ b/lib/middleware/send-message/message-outbound.js
@@ -1,12 +1,11 @@
 'use strict';
 
+const helpers = require('../../helpers');
+
 module.exports = function outboundMessage() {
-  return (req, res, next) => {
-    req.conversation.createOutboundSendMessage(req.sendMessageText, req.outboundTemplate)
-      .then((message) => {
-        req.outboundMessage = message;
-        return next();
-      })
-      .catch(err => err);
+  return (req, res) => {
+    req.conversation.outboundSend(req.sendMessageText, req.outboundTemplate)
+      .then(() => helpers.sendResponseWithMessage(res, req.conversation.lastOutboundMessage))
+      .catch(err => helpers.sendErrorResponse(res, err));
   };
 };


### PR DESCRIPTION
* Fixes bug introduced in #97, where `conversation.postMessageToPlatform` was mistakenly removed from `POST /send-message`

* Refactors `Conversation.lastOutboundTemplate` string as `Conversation.lastOutboundMessage` reference to the outbound `Message` document created. This will be used to inspect whether the last outbound contained a `broadcastId` (#56)  

* Refactors `Conversation.createOutbound` functions to create outbound message but also post the message to platform when necessary (for the `outbound-reply`, `outbound-api-send` directions)