### PR TITLE
Handling Blink retries to prevent inbound message dupes

### DIFF
--- a/app/models/Conversation.js
+++ b/app/models/Conversation.js
@@ -150,26 +150,6 @@ conversationSchema.methods.declineSignup = function () {
 };
 
 /**
- * Loads the inbound message that matches this conversationId and
- * the metadata.requestId and updates its metadata with the new one.
- * @param {string} requestId
- * @param {object} metadata
- * @return {object}
- */
-conversationSchema.methods.loadInboundMessageAndUpdateMetadataByRequestId = function (requestId,
-  metadata = {}) {
-  const query = {
-    conversationId: this._id,
-    'metadata.requestId': requestId,
-    direction: 'inbound',
-  };
-  const update = { metadata };
-  const options = { new: true };
-
-  return Messages.findOneAndUpdate(query, update, options);
-};
-
-/**
  * Gets data for a Conversation Message.
  * @param {string} text
  * @param {string} template

--- a/app/models/Conversation.js
+++ b/app/models/Conversation.js
@@ -152,7 +152,7 @@ conversationSchema.methods.declineSignup = function () {
 /**
  * Loads the inbound message that matches this conversationId and
  * the metadata.requestId and updates its metadata with the new one.
- * @param {number} requestId
+ * @param {string} requestId
  * @param {object} metadata
  * @return {object}
  */
@@ -166,9 +166,7 @@ conversationSchema.methods.loadInboundMessageAndUpdateMetadataByRequestId = func
   const update = { metadata };
   const options = { new: true };
 
-  return this.populate('lastOutboundMessage').execPopulate()
-    .then(() => Messages.findOneAndUpdate(query, update, options)
-      .then(message => message.populate('conversationId').execPopulate()));
+  return Messages.findOneAndUpdate(query, update, options);
 };
 
 /**

--- a/app/models/Conversation.js
+++ b/app/models/Conversation.js
@@ -165,11 +165,10 @@ conversationSchema.methods.loadInboundMessageAndUpdateMetadataByRequestId = func
   };
   const update = { metadata };
   const options = { new: true };
-  return Messages.findOneAndUpdate(query, update, options)
-    .then(message => message.populate('conversationId').execPopulate())
-    .then(() => {
-      this.populate('lastOutboundMessage').execPopulate();
-    });
+
+  return this.populate('lastOutboundMessage').execPopulate()
+    .then(() => Messages.findOneAndUpdate(query, update, options)
+      .then(message => message.populate('conversationId').execPopulate()));
 };
 
 /**

--- a/app/models/Message.js
+++ b/app/models/Message.js
@@ -20,6 +20,10 @@ const messageSchema = new mongoose.Schema({
   text: String,
   topic: String,
   attachments: Array,
+  metadata: {
+    requestId: String,
+    retryCount: Number,
+  },
 }, { timestamps: true });
 
 module.exports = mongoose.model('Message', messageSchema);

--- a/app/models/Message.js
+++ b/app/models/Message.js
@@ -26,4 +26,34 @@ const messageSchema = new mongoose.Schema({
   },
 }, { timestamps: true });
 
+/**
+ * gets the inbound message that matches this metadata.requestId
+ * and updates it with the new properties passed in the update object.
+ * @param {string} requestId
+ * @param {object} update
+ * @return {object}
+ */
+messageSchema.statics.getAndUpdateInboundMessageByRequestId = function (requestId, update = {}) {
+  const query = {
+    'metadata.requestId': requestId,
+    direction: 'inbound',
+  };
+  const options = { new: true };
+
+  return this.findOneAndUpdate(query, update, options);
+};
+
+/**
+ * gets the inbound message that matches this metadata.requestId
+ * and updates its metadata with the new one.
+ * @param {string} requestId
+ * @param {object} metadata
+ * @return {object}
+ */
+messageSchema.statics.updateInboundMessageMetadataByRequestId = function (requestId,
+  metadata = {}) {
+  return this.getAndUpdateInboundMessageByRequestId(requestId, { metadata });
+};
+
+
 module.exports = mongoose.model('Message', messageSchema);

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -8,6 +8,7 @@ const importMessageRoute = require('./import-message');
 
 // middleware
 const authenticateMiddleware = require('../../lib/middleware/authenticate');
+const parseMetadataMiddleware = require('../../lib/middleware/metadata-parse');
 
 const router = express.Router();
 
@@ -30,14 +31,19 @@ module.exports = function init(app) {
     res.header('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept');
     return next();
   });
+  // restified routes
   app.use(router);
+  // authenticate all requests after this line
+  app.use(authenticateMiddleware());
+  // parse metadata like requestId and retryCount for all requests after this line
+  app.use(parseMetadataMiddleware());
+  // receive-message route
   app.use('/api/v1/receive-message',
-    authenticateMiddleware(),
     receiveMessageRoute);
+  // send-message route
   app.use('/api/v1/send-message',
-    authenticateMiddleware(),
     sendMessageRoute);
+  // import-message route
   app.use('/api/v1/import-message',
-    authenticateMiddleware(),
     importMessageRoute);
 };

--- a/app/routes/receive-message.js
+++ b/app/routes/receive-message.js
@@ -10,7 +10,8 @@ bot.getBot();
 const paramsMiddleware = require('../../lib/middleware/receive-message/params');
 const getConversationMiddleware = require('../../lib/middleware/conversation-get');
 const createConversationMiddleware = require('../../lib/middleware/conversation-create');
-const inboundMessageMiddleware = require('../../lib/middleware/receive-message/message-inbound');
+const loadInboundMessageMiddleware = require('../../lib/middleware/receive-message/message-inbound-load');
+const createInboundMessageMiddleware = require('../../lib/middleware/receive-message/message-inbound-create');
 const rivescriptMiddleware = require('../../lib/middleware/receive-message/rivescript');
 const pausedMiddleware = require('../../lib/middleware/receive-message/conversation-paused');
 const campaignMenuMiddleware = require('../../lib/middleware/receive-message/campaign-menu');
@@ -23,10 +24,13 @@ const continueCampaignMiddleware = require('../../lib/middleware/receive-message
 
 router.use(paramsMiddleware());
 
-// Load conversation and create inbound message.
+// Load/create conversation
 router.use(getConversationMiddleware());
 router.use(createConversationMiddleware());
-router.use(inboundMessageMiddleware());
+
+// Load/create inbound message.
+router.use(loadInboundMessageMiddleware());
+router.use(createInboundMessageMiddleware());
 
 // Send our inbound message to Rivescript bot for a reply.
 router.use(rivescriptMiddleware());

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -94,8 +94,7 @@ module.exports.sendResponseWithMessage = function (res, message) {
  */
 function sendReply(req, res, messageText, messageTemplate) {
   logger.debug('sendReply', { messageText, messageTemplate });
-
-  return req.conversation.createAndPostOutboundReplyMessage(messageText, messageTemplate)
+  return req.conversation.createAndPostOutboundReplyMessage(messageText, messageTemplate, req)
     .then(() => {
       const data = {
         inbound: [req.inboundMessage],

--- a/lib/middleware/import-message/message-outbound.js
+++ b/lib/middleware/import-message/message-outbound.js
@@ -4,7 +4,7 @@ const helpers = require('../../helpers');
 
 module.exports = function outboundMessage() {
   return (req, res) => {
-    req.conversation.createOutboundImportMessage(req.importMessageText, req.outboundTemplate)
+    req.conversation.createOutboundImportMessage(req.importMessageText, req.outboundTemplate, req)
       .then(() => helpers.sendResponseWithMessage(res, req.conversation.lastOutboundMessage))
       .catch(err => helpers.sendErrorResponse(res, err));
   };

--- a/lib/middleware/metadata-parse.js
+++ b/lib/middleware/metadata-parse.js
@@ -1,0 +1,34 @@
+'use strict';
+
+const logger = require('heroku-logger');
+
+function parseRetryCount(req) {
+  const retryCountFromHeader = Number(req.get('x-blink-retry-count')) || 0;
+  const retryCountFromQuery = Number(req.query['x-blink-retry-count']) || 0;
+  const retryCount = retryCountFromHeader || retryCountFromQuery || 0;
+
+  if (retryCount) {
+    req.metadata.retryCount = retryCount;
+    logger.info('Blink retry count', { retryCount });
+  }
+}
+
+function parseRequestId(req) {
+  const requestIdFromHeader = req.get('x-request-id');
+  const requestIdFromQuery = req.query['x-request-id'];
+  const requestId = requestIdFromHeader || requestIdFromQuery;
+
+  if (requestId) {
+    req.metadata.requestId = requestId;
+    logger.info('Request ID', { requestId });
+  }
+}
+
+module.exports = function parseMetadata() {
+  return (req, res, next) => {
+    req.metadata = {};
+    parseRetryCount(req);
+    parseRequestId(req);
+    return next();
+  };
+};

--- a/lib/middleware/metadata-parse.js
+++ b/lib/middleware/metadata-parse.js
@@ -24,11 +24,16 @@ function parseRequestId(req) {
   }
 }
 
+function registerIsARetryRequestFunction(req) {
+  req.isARetryRequest = () => !!req.metadata.retryCount;
+}
+
 module.exports = function parseMetadata() {
   return (req, res, next) => {
     req.metadata = {};
     parseRetryCount(req);
     parseRequestId(req);
+    registerIsARetryRequestFunction(req);
     return next();
   };
 };

--- a/lib/middleware/receive-message/message-inbound-create.js
+++ b/lib/middleware/receive-message/message-inbound-create.js
@@ -4,10 +4,17 @@ const helpers = require('../../helpers');
 
 module.exports = function createInboundMessage() {
   return (req, res, next) => {
+    // If this is a retry request, we already loaded the message
+    if (req.isARetryRequest() && req.inboundMessage) {
+      return next();
+    }
+
+    // TODO: This should be moved to receive-message/params middleware
     if (req.inboundMessageText) {
       req.userCommand = req.inboundMessageText.trim();
     }
-    req.conversation.createMessage('inbound', req.inboundMessageText, null, req.attachments)
+
+    return req.conversation.createMessage('inbound', req.inboundMessageText, null, req)
       .then((message) => {
         req.inboundMessage = message;
 

--- a/lib/middleware/receive-message/message-inbound-load.js
+++ b/lib/middleware/receive-message/message-inbound-load.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const helpers = require('../../helpers');
+const Message = require('../../../app/models/Message');
 
 module.exports = function loadInboundMessage() {
   return (req, res, next) => {
@@ -14,7 +15,7 @@ module.exports = function loadInboundMessage() {
       req.userCommand = req.inboundMessageText.trim();
     }
 
-    return req.conversation.loadInboundMessageAndUpdateMetadataByRequestId(req.metadata.requestId,
+    return Message.updateInboundMessageMetadataByRequestId(req.metadata.requestId,
       req.metadata)
       .then((message) => {
         req.inboundMessage = message;

--- a/lib/middleware/receive-message/message-inbound-load.js
+++ b/lib/middleware/receive-message/message-inbound-load.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const helpers = require('../../helpers');
+
+module.exports = function loadInboundMessage() {
+  return (req, res, next) => {
+    // If this is not a retry request, we have to create a new inbound message
+    if (!req.isARetryRequest()) {
+      return next();
+    }
+
+    // TODO: This should be moved to receive-message/params middleware
+    if (req.inboundMessageText) {
+      req.userCommand = req.inboundMessageText.trim();
+    }
+
+    return req.conversation.loadInboundMessageAndUpdateMetadataByRequestId(req.metadata.requestId,
+      req.metadata)
+      .then((message) => {
+        req.inboundMessage = message;
+
+        return next();
+      })
+      .catch(err => helpers.sendErrorResponse(res, err));
+  };
+};

--- a/lib/middleware/send-message/message-outbound.js
+++ b/lib/middleware/send-message/message-outbound.js
@@ -4,7 +4,8 @@ const helpers = require('../../helpers');
 
 module.exports = function outboundMessage() {
   return (req, res) => {
-    req.conversation.createAndPostOutboundSendMessage(req.sendMessageText, req.outboundTemplate)
+    req.conversation.createAndPostOutboundSendMessage(req.sendMessageText,
+      req.outboundTemplate, req)
       .then(() => helpers.sendResponseWithMessage(res, req.conversation.lastOutboundMessage))
       .catch(err => helpers.sendErrorResponse(res, err));
   };


### PR DESCRIPTION
## Summary
Starts implementation of this feature according to this diagram.
![](https://user-images.githubusercontent.com/863301/30079926-7aaef5f0-9247-11e7-9944-61ea1f66f41a.png)

## Tasks
- [x] Adding middleware to parse `retryCount` and `requestId` into a `req.metadata` object
- [x] Save metadata object to message created
- [x] Check if the request is a "retry" request to load an **inbound** message instead of creating a new one

## Relevant tickets
Fixes #51 