### PR TITLE
Topic broadcasts

### DIFF
--- a/app/models/Message.js
+++ b/app/models/Message.js
@@ -20,6 +20,7 @@ const messageSchema = new mongoose.Schema({
   text: String,
   topic: String,
   attachments: Array,
+  broadcastId: String,
 }, { timestamps: true });
 
 module.exports = mongoose.model('Message', messageSchema);

--- a/app/models/Message.js
+++ b/app/models/Message.js
@@ -20,7 +20,6 @@ const messageSchema = new mongoose.Schema({
   text: String,
   topic: String,
   attachments: Array,
-  broadcastId: String,
 }, { timestamps: true });
 
 module.exports = mongoose.model('Message', messageSchema);

--- a/documentation/endpoints/import-message.md
+++ b/documentation/endpoints/import-message.md
@@ -14,8 +14,8 @@ It's the only supported importer at this time. See [Broadcast Process Wiki](http
 Name | Type | Description
 --- | --- | ---
 `phone` | `string` | User's phone number
-`broadcast_id` | `string` | Broadcast Id associated to this imported message (Contentful broadcast id)
-`fields` | `Array` | Array of field objects. Each field object's value is used to interpolate placeholders in the copy of the message stored in contentful.
+`broadcastId` | `string` | Contentful Broadcast Id of this imported message
+`fields` | `Array` | Array of field objects. Each field object's value is used to interpolate placeholders in the copy of the message stored in Contentful.
 
 ## Examples
 
@@ -29,7 +29,7 @@ Example of an inbound POST request from a Customer.io webhook.
 curl -X "POST" "http://localhost:5100/api/v1/import-message?platform=customerio" \
      -H "Authorization: Basic cHVwcGV0OnRvdGFsbHlzZWNyZXQ=" \
      -H "Content-Type: application/json" \
-     -d '{ "broadcast_id" : "7zU0Mb1k9GkWWI40o06Mic", "phone": "+5555555555", "fields": [{"customer.first_name": "taco"}]}'
+     -d '{ "broadcastId" : "7zU0Mb1k9GkWWI40o06Mic", "phone": "+5555555555", "fields": [{"customer.first_name": "taco"}]}'
 ```
 </details>
 

--- a/lib/middleware/import-message/broadcast.js
+++ b/lib/middleware/import-message/broadcast.js
@@ -6,7 +6,14 @@ const helpers = require('../../helpers');
 
 function getCampaignId(broadcastObject) {
   const campaign = broadcastObject.fields.campaign;
+  if (!campaign.fields) {
+    return null;
+  }
   return campaign.fields.campaignId;
+}
+
+function getTopic(broadcastObject) {
+  return broadcastObject.fields.topic;
 }
 
 function replaceFieldsInMessage(fields = [], message) {
@@ -25,6 +32,7 @@ function getMessage(broadcastObject) {
 function parsePropertiesFromBroadcast(req, res) {
   return helpers.getBroadcast(req, res)
     .then((broadcast) => {
+      req.topic = getTopic(broadcast);
       req.campaignId = getCampaignId(broadcast);
       req.importMessageText = replaceFieldsInMessage(req.messageFields, getMessage(broadcast));
       return broadcast;

--- a/lib/middleware/import-message/conversation-update.js
+++ b/lib/middleware/import-message/conversation-update.js
@@ -5,13 +5,18 @@ const Campaigns = require('../../../app/models/Campaign');
 
 module.exports = function updateConversation() {
   return (req, res, next) => {
-    if (req.query.platform === 'customerio') {
-      Campaigns.findById(req.campaignId)
-        .then(campaign => req.conversation.promptSignupForBroadcast(campaign, req.broadcastId))
-        .then(() => next())
-        .catch(err => helpers.sendErrorResponse(err));
-    } else {
-      next();
+    const topic = req.topic;
+    if (topic) {
+      req.outboundTemplate = 'rivescript';
+      return req.conversation.setTopic(topic).then(() => next());
     }
+
+    return Campaigns.findById(req.campaignId)
+      .then(campaign => req.conversation.promptSignupForBroadcast(campaign, req.broadcastId))
+      .then(() => {
+        req.outboundTemplate = 'askSignup';
+        return next();
+      })
+      .catch(err => helpers.sendErrorResponse(err));
   };
 };

--- a/lib/middleware/import-message/params.js
+++ b/lib/middleware/import-message/params.js
@@ -19,9 +19,9 @@ module.exports = function params() {
     if (platform === 'customerio') {
       req.platform = 'sms';
       req.platformUserId = body.phone;
-      req.broadcastId = body.broadcast_id;
+      req.broadcastId = body.broadcastId;
       req.messageFields = body.fields;
-      req.outboundTemplate = 'askSignupMessage';
+      req.outboundTemplate = 'askSignup';
     } else {
       const error = new UnprocessibleEntityError('Invalid platform.');
       return helpers.sendErrorResponse(res, error);

--- a/lib/middleware/import-message/params.js
+++ b/lib/middleware/import-message/params.js
@@ -11,21 +11,20 @@ function getPlatform(req) {
 
 module.exports = function params() {
   return (req, res, next) => {
-    logger.info('POST /import-message req.body', req.body);
-
     const body = req.body;
-    const platform = getPlatform(req);
+    logger.debug('POST /import-message', { body });
 
-    if (platform === 'customerio') {
-      req.platform = 'sms';
-      req.platformUserId = body.phone;
-      req.broadcastId = body.broadcastId;
-      req.messageFields = body.fields;
-      req.outboundTemplate = 'askSignup';
-    } else {
+    const platform = getPlatform(req);
+    if (platform !== 'customerio') {
       const error = new UnprocessibleEntityError('Invalid platform.');
       return helpers.sendErrorResponse(res, error);
     }
+
+    req.platform = 'sms';
+    req.platformUserId = body.phone;
+    req.broadcastId = body.broadcastId;
+    req.messageFields = body.fields;
+
     return next();
   };
 };


### PR DESCRIPTION
Closes #101:
* Adds a `topic` field to our Broadcast content type in Contentful
* Adds check for the Broadcast topic to `POST /import-message`. If it exists, execute `Conversation.setTopic` instead of finding and setting Campaign
* Renames `broadcast_id` param to `broadcastId` for API consistency

I've created a broadcast for the Michael topic: 
```
## POST import message Rivescript
curl -X "POST" "http://localhost:5100/api/v1/import-message?platform=customerio" \
     -H "Content-Type: application/json; charset=utf-8" \
     -u puppet:totallysecret \
     -d $'{
  "phone": "[removed]",
  "broadcastId": "Michael Test",
  "fields": []
}'
```
Upon running locally and then POSTing to `/receive-message`, you should receive a response from the Michael topic.

Thinking eventually (or could add here) we should refactor the `getBroadcast` function to query by the Broadcast entry's ID in Contentful (not the `broadcastId` field) - refs https://github.com/DoSomething/gambit-conversations/pull/48#discussion_r137641464