### PR TITLE
Edit Seatbelt triggers + change Signup Keyword priority

### DIFF
--- a/app/models/Conversation.js
+++ b/app/models/Conversation.js
@@ -99,12 +99,11 @@ conversationSchema.methods.supportResolved = function () {
  * @return {Promise}
  */
 conversationSchema.methods.setCampaignWithSignupStatus = function (campaign, signupStatus) {
-  this.topic = campaign.topic;
   this.campaignId = campaign._id;
   this.signupStatus = signupStatus;
   logger.debug('setCampaignWithSignupStatus', { campaign: this.campaignId, signupStatus });
 
-  return this.save();
+  return this.setTopic(campaign.topic);
 };
 
 /**

--- a/app/routes/receive-message.js
+++ b/app/routes/receive-message.js
@@ -11,10 +11,10 @@ const paramsMiddleware = require('../../lib/middleware/receive-message/params');
 const getConversationMiddleware = require('../../lib/middleware/conversation-get');
 const createConversationMiddleware = require('../../lib/middleware/conversation-create');
 const inboundMessageMiddleware = require('../../lib/middleware/receive-message/message-inbound');
+const campaignKeywordMiddleware = require('../../lib/middleware/receive-message/campaign-keyword');
 const rivescriptMiddleware = require('../../lib/middleware/receive-message/rivescript');
 const pausedMiddleware = require('../../lib/middleware/receive-message/conversation-paused');
 const campaignMenuMiddleware = require('../../lib/middleware/receive-message/campaign-menu');
-const campaignKeywordMiddleware = require('../../lib/middleware/receive-message/campaign-keyword');
 const currentCampaignMiddleware = require('../../lib/middleware/receive-message/campaign-current');
 const closedCampaignMiddleware = require('../../lib/middleware/receive-message/campaign-closed');
 const parseAskSignupMiddleware = require('../../lib/middleware/receive-message/parse-ask-signup-answer');
@@ -28,6 +28,9 @@ router.use(getConversationMiddleware());
 router.use(createConversationMiddleware());
 router.use(inboundMessageMiddleware());
 
+// If Campaign keyword, set keyword Campaign.
+router.use(campaignKeywordMiddleware());
+
 // Send our inbound message to Rivescript bot for a reply.
 router.use(rivescriptMiddleware());
 
@@ -36,9 +39,6 @@ router.use(pausedMiddleware());
 
 // If MENU command, set random Campaign and ask for Signup.
 router.use(campaignMenuMiddleware());
-
-// If Campaign keyword, set keyword Campaign.
-router.use(campaignKeywordMiddleware());
 
 // Otherwise, load the Campaign stored on the Conversation.
 router.use(currentCampaignMiddleware());

--- a/brain/games/seatbelt.rive
+++ b/brain/games/seatbelt.rive
@@ -16,20 +16,17 @@
 ^ \n\nSeatbelts aren’t just the trend of the season -- they're *literally* saving lives, and you can too. Want super, easy effective ways to keep friends safe? Text Y.{topic=seatbelt_level1}
 
 /**
- * Level 1: Send Y
+ * Level 1
  */
 > topic seatbelt_level1 includes random
 
-+ y
-- Picture this: You're about to drive a friend home from school. They get in but they don’t put their seat belt on even after you ask them to. What do you do? A) blast *awful* music until they put it or B) hit them with cold hard facts on why wearing a seat belt is important? Text A or B.{topic=seatbelt_level2}
-
 + [*]
-- Sorry, I didn't get that. Text Y to find out more.
+- Picture this: You're about to drive a friend home from school. They get in but they don’t put their seat belt on even after you ask them to. What do you do? A) blast *awful* music until they put it or B) hit them with cold hard facts on why wearing a seat belt is important? Text A or B.{topic=seatbelt_level2}
 
 < topic
 
 /**
- * Level 2: Send A or B
+ * Level 2
  */
 > topic seatbelt_level2 includes random
 
@@ -42,40 +39,34 @@
 ^ \n\nText NEXT for another tip.{topic=seatbelt_level3}
 
 + [*]
-- Sorry, I didn't get that. Text A or B.
+@ a
 
 < topic
 
 /**
- * Level 3: Send NEXT
+ * Level 3
  */
 > topic seatbelt_level3 includes random
 
-+ next
++ [*]
 - Leave a "Buckle up!" sticky note in the car where people will see it. Bonus points for making your sticky note more clever than that. Extra bonus points for using a terrible pun: “I TOAD you to buckle up!” - Frogs
 ^ \n\nText Y for more.{topic=seatbelt_level4}
 
-+ [*]
-- Sorry, I didn't get that. Text NEXT for another tip.
-
 < topic
 
 /**
- * Level 4: Send Y
+ * Level 4
  */
 > topic seatbelt_level4 includes random
 
-+ y
++ [*]
 - You and your friends are headed out for the night. You and two others jump in the backseat, and you realize they didn't buckle up. 91% of people wear seat belts in the front seat, but only 72% do in the back... even though it could save someone's life.
 ^ \n\nDo you:\na) use Kanye to keep them safe or\nb) spout movie trivia with a purpose?{topic=seatbelt_level5}
-
-+ [*]
-- Sorry, I didn't get that. Text Y for more.
 
 < topic
 
 /**
- * Level 5: Send A or B
+ * Level 5
  */
 > topic seatbelt_level5 includes random
 
@@ -88,49 +79,40 @@
 ^\n\nText Y for more.{topic=seatbelt_level6}
 
 + [*]
-- Sorry, I didn't get that. Text A or B.
+@ a
 
 < topic
 
 /**
- * Level 6: Send Y
+ * Level 6
  */
 > topic seatbelt_level6 includes random
 
-+ y
++ [*]
 - Reminding your friends to wear a seat belt is a great way to keep them safe. Want another way? Learn how to cut out distractions, like your radio.
 ^ \n\nHere's how: Make your DJ set *before* you leave the house. Cue up your playlist before you leave so you won't be tempted to switch the song while driving.
 ^ \n\nText Y for the last tip.{topic=seatbelt_level7}
 
-+ [*]
-- Sorry, I didn't get that. Text Y for more.
-
 < topic
 
 /**
- * Level 7: Send NEXT
+ * Level 7
  */
 > topic seatbelt_level7 includes random
 
-+ y
++ [*]
 - Another distraction: cell phones. Everyone knows texting and driving is dangerous and dumb, but 666,000 drivers are doing it...literally at this moment!
 ^ \n\nCreate a "no phone zone." When you get in the car, put your phone in the glove compartment and don't take it out until you reach your destination. Or if a friend is in the car, make them your personal assistant: Get a text? Tell them what to say. Need a photo? They’ll be happy to take one of you...after all, you *are* giving them a ride.
 ^ \n\nText NEXT for something you can do IRL.{topic=seatbelt_completed}
 
-+ [*]
-- Sorry, I didn't get that. Text Y for the last tip.
-
 < topic
 
 /**
- * Final boss: Send NEXT
+ * Completed
  */
 > topic seatbelt_completed includes random
 
-+ next
-- Want to help others keep their friends and family safe? Lead them through a game of Ride & Seek by texting SEEK to 38383. There, you can create flyers with fill-in-the-blank questions. When friends text in for the answer, they’ll get tips to help them *literally* save people's lives. You’ll also have the chance to be famed on our Facebook page and the chance to win a $5,000 scholarship!{topic=random}
-
 + [*]
-- Sorry, I didn't get that. Text NEXT for something you can do IRL.
+- Want to help others keep their friends and family safe? Lead them through a game of Ride & Seek by texting SEEK to 38383. There, you can create flyers with fill-in-the-blank questions. When friends text in for the answer, they’ll get tips to help them *literally* save people's lives. You’ll also have the chance to be famed on our Facebook page and the chance to win a $5,000 scholarship!{topic=random}
 
 < topic


### PR DESCRIPTION
Closes #90

* Instead of "Sorry I didn't get that",  just assume they texted what we asked them to. 💯 🥇  Because these topics inherit our `random` trigger, other "global" triggers defined in `random` like Crisis keywords will still catch (vs advancing to the next game level)


* Changes sequence of `receive-message` middleware so a Campaign Signup keyword will exit a Rivescript topic.
    * Calls `setTopic` in `Campaign.setCampaign` to unpause a Conversation if a User sends a Campaign Signup keyword.