### PR TITLE
Adds and saves Message.broadcastId

### DIFF
--- a/app/models/Message.js
+++ b/app/models/Message.js
@@ -20,6 +20,7 @@ const messageSchema = new mongoose.Schema({
   text: String,
   topic: String,
   attachments: Array,
+  broadcastId: String,
   metadata: {
     requestId: String,
     retryCount: Number,

--- a/lib/middleware/conversation-get.js
+++ b/lib/middleware/conversation-get.js
@@ -14,8 +14,7 @@ module.exports = function getConversation() {
         const lastOutboundMessage = req.conversation.lastOutboundMessage;
         if (lastOutboundMessage) {
           req.lastOutboundTemplate = lastOutboundMessage.template;
-        } else {
-          req.lastOutboundTemplate = null;
+          req.lastOutboundBroadcastId = lastOutboundMessage.broadcastId;
         }
 
         logger.debug('getConversation', {

--- a/lib/middleware/import-message/conversation-update.js
+++ b/lib/middleware/import-message/conversation-update.js
@@ -12,7 +12,7 @@ module.exports = function updateConversation() {
     }
 
     return Campaigns.findById(req.campaignId)
-      .then(campaign => req.conversation.promptSignupForBroadcast(campaign, req.broadcastId))
+      .then(campaign => req.conversation.promptSignupForCampaign(campaign))
       .then(() => {
         req.outboundTemplate = 'askSignup';
         return next();


### PR DESCRIPTION
* Fixes #56: Sets `broadcastId` for an imported Broadcast message, and also when an inbound message is received and it's for a Conversation where the Last Outbound Message was a Broadcast message.

* Removes unused `Conversation.lastBroadcastId`. This has got me thinking about whether we need `campaignId` and `topic` stored on the Conversation at all, but instead should just always inspect the properties on the `lastOutboundMessage`. They should always be the same, and probably makes sense to have less things to keep in sync.
   * I suppose a disadvantage could potentially be needing to run the join query if we ever want to find how many Conversations are currently set to Campaign X -- but this may be something we should be running in our own data warehouse instead of the production DB... 
