### PR TITLE
Fix invalidAsk template names

### DIFF
--- a/app/models/Campaign.js
+++ b/app/models/Campaign.js
@@ -23,8 +23,8 @@ const campaignSchema = new mongoose.Schema({
     declinedContinue: String,
     declinedSignup: String,
     externalSignupMenu: String,
-    invalidContinueResponse: String,
-    invalidSignupResponse: String,
+    invalidAskContinueResponse: String,
+    invalidAskSignupResponse: String,
   },
 }, { timestamps: true });
 

--- a/config/lib/helpers.js
+++ b/config/lib/helpers.js
@@ -3,11 +3,11 @@
 module.exports = {
   askContinueTemplates: [
     'askContinue',
-    'invalidContinueResponse',
+    'invalidAskContinueResponse',
   ],
   askSignupTemplates: [
     'askSignup',
-    'invalidSignupResponse',
+    'invalidAskSignupResponse',
   ],
   gambitCampaignsTemplates: [
     'askCaption',

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -176,12 +176,12 @@ module.exports.declinedSignup = function (req, res) {
   return sendReplyWithCampaignTemplate(req, res, 'declinedSignup');
 };
 
-module.exports.invalidContinueResponse = function (req, res) {
-  return sendReplyWithCampaignTemplate(req, res, 'invalidContinueResponse');
+module.exports.invalidAskContinueResponse = function (req, res) {
+  return sendReplyWithCampaignTemplate(req, res, 'invalidAskContinueResponse');
 };
 
-module.exports.invalidSignupResponse = function (req, res) {
-  return sendReplyWithCampaignTemplate(req, res, 'invalidSignupResponse');
+module.exports.invalidAskSignupResponse = function (req, res) {
+  return sendReplyWithCampaignTemplate(req, res, 'invalidAskSignupResponse');
 };
 
 module.exports.noCampaign = function (req, res) {

--- a/lib/middleware/receive-message/parse-ask-continue-answer.js
+++ b/lib/middleware/receive-message/parse-ask-continue-answer.js
@@ -18,6 +18,6 @@ module.exports = function parseAskContinueResponse() {
       return helpers.declinedContinue(req, res);
     }
 
-    return helpers.invalidContinueResponse(req, res);
+    return helpers.invalidAskContinueResponse(req, res);
   };
 };

--- a/lib/middleware/receive-message/parse-ask-signup-answer.js
+++ b/lib/middleware/receive-message/parse-ask-signup-answer.js
@@ -15,7 +15,7 @@ module.exports = function parseAskSignupResponse() {
     }
 
     if (!helpers.isDeclinedCampaignMacro(text)) {
-      return helpers.invalidSignupResponse(req, res);
+      return helpers.invalidAskSignupResponse(req, res);
     }
 
     return req.conversation.declineSignup()


### PR DESCRIPTION
Fixes bug in #99 - `req.campaign.templates.invalidAskContinueResponse undefined` error sent when responding with neither Yes/No to Ask Continue template (same for Ask Signup)

Example Gambit Campaigns `GET /campaigns/:id` response:
```
{
  "data": {
    "id": "7",
    "title": "Mirror Messages",
    "status": "closed",
    "current_run": "7818",
    "templates": {
       invalidAskSignupResponse: { ... },
       invalidAskContinueResponse: { ... }
    }
}
```