### PR TITLE
Return UnprocessibleEntityError when sending Campaign template to paused Conversations

### DIFF
--- a/lib/middleware/send-message/campaign.js
+++ b/lib/middleware/send-message/campaign.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const Campaigns = require('../../../app/models/Campaign');
+const UnprocessibleEntityError = require('../../../app/exceptions/UnprocessibleEntityError');
 const helpers = require('../../helpers');
 
 module.exports = function sendCampaignTemplate() {
@@ -9,18 +10,25 @@ module.exports = function sendCampaignTemplate() {
       return next();
     }
 
+    if (req.conversation.paused) {
+      const err = new UnprocessibleEntityError('Conversation is paused.');
+      return helpers.sendErrorResponse(res, err);
+    }
+
     return Campaigns.findById(req.campaignId)
       .then((campaign) => {
         if (!campaign) {
           return helpers.sendResponseWithStatusCode(res, 404, 'Campaign not found.');
         }
         if (campaign.isClosed) {
-          return helpers.sendResponseWithStatusCode(res, 422, 'Campaign is closed.');
+          const err = new UnprocessibleEntityError('Campaign is closed.');
+          return helpers.sendErrorResponse(res, err);
         }
 
         req.sendMessageText = campaign.templates[req.outboundTemplate];
         if (!req.sendMessageText) {
-          return helpers.sendResponseWithStatusCode(res, 422, 'Campaign template undefined.');
+          const err = new UnprocessibleEntityError('Campaign template undefined.');
+          return helpers.sendErrorResponse(res, err);
         }
 
         return req.conversation.setCampaign(campaign)


### PR DESCRIPTION
* Closes #81 -- If a Conversation is paused, don't allow sending an external Outbound (e.g. External Signup Confirmation)

* DRY by adding `UnprocessibleEntityError`