### PR TITLE
Bug/109 inbound attachments in outbound messages

### DIFF
--- a/app/models/Conversation.js
+++ b/app/models/Conversation.js
@@ -165,6 +165,12 @@ conversationSchema.methods.getDefaultMessagePayload = function (text, template) 
  */
 conversationSchema.methods.getMessagePayloadFromReq = function (req = {}, direction = '') {
   let broadcastId = null;
+
+  // Attachments are stored in sub objects named according to the direction of the message
+  // 'inbound' or 'outbound'
+  const isOutbound = direction.includes('outbound');
+  const attachmentDirection = isOutbound ? 'outbound' : 'inbound';
+
   if (req.broadcastId) {
     broadcastId = req.broadcastId;
   // Set broadcastId when this is an inbound message responding to an outbound broadcast:
@@ -176,7 +182,7 @@ conversationSchema.methods.getMessagePayloadFromReq = function (req = {}, direct
   const data = {
     broadcastId,
     metadata: req.metadata || {},
-    attachments: req.attachments || [],
+    attachments: req.attachments[attachmentDirection] || [],
   };
 
   return data;

--- a/lib/middleware/receive-message/params.js
+++ b/lib/middleware/receive-message/params.js
@@ -18,9 +18,9 @@ function getAttachmentObject(req) {
   };
 }
 
-function addAttachment(req, attachmentObject) {
+function addAttachment(req, attachmentObject, direction = 'inbound') {
   if (attachmentObject.url) {
-    req.attachments.push({
+    req.attachments[direction].push({
       url: attachmentObject.url,
       contentType: attachmentObject.contentType,
     });
@@ -54,8 +54,12 @@ module.exports = function params() {
 
     const body = req.body;
     req.inboundMessageText = body.text;
-    req.attachments = [];
+    req.attachments = {
+      inbound: [],
+      outbound: [],
+    };
 
+    // Slack
     if (body.slackId) {
       req.platform = 'slack';
       req.platformUserId = body.slackId;
@@ -65,6 +69,7 @@ module.exports = function params() {
       return next();
     }
 
+    // Twilio
     if (body.MessageSid) {
       req.platform = 'sms';
       req.platformUserId = body.From;
@@ -77,7 +82,7 @@ module.exports = function params() {
           .then((url) => {
             req.mediaUrl = url;
             attachmentObject.url = url;
-            addAttachment(req, attachmentObject);
+            addAttachment(req, attachmentObject, 'inbound');
             return next();
           })
           .catch(error => helpers.sendErrorResponse(res, error));
@@ -85,6 +90,7 @@ module.exports = function params() {
       return next();
     }
 
+    // Messenger
     if (body.facebookId) {
       req.platform = 'facebook';
       req.platformUserId = body.facebookId;
@@ -92,13 +98,14 @@ module.exports = function params() {
       return next();
     }
 
+    // Api
     req.platformUserId = body.platformUserId;
     req.platform = 'api';
 
     const attachmentObject = getAttachmentObject(req);
     if (attachmentObject.url) {
       req.mediaUrl = attachmentObject.url;
-      addAttachment(req, attachmentObject);
+      addAttachment(req, attachmentObject, 'inbound');
     }
 
     return next();


### PR DESCRIPTION
## Summary
Adds support for having both `inbound` and `outbound` attachments.

## Relevant tickets
Fixes #109 

## Test
- Using Consolebot, go through a complete reportback.

## Success
- The outbound message should not contain the inbound attachments.

Example:
```
{
  "_id": ObjectId("59b30cf1da9bde5ec37ab89f"),
  "updatedAt": ISODate("2017-09-08T21:34:41.218Z"),
  "createdAt": ISODate("2017-09-08T21:34:41.218Z"),
  "text": "Got it! Now text back a caption for your photo (think Instagram)! Keep it short & sweet, under 60 characters please.",
  "direction": "outbound-reply",
  "template": "askCaption",
  "conversationId": ObjectId("59b17f33c34d9c4ed85a6339"),
  "campaignId": 2900,
  "topic": "campaign",
  "broadcastId": null,
  "attachments": [ ],
  "__v": 0
}
{
  "_id": ObjectId("59b30cf0da9bde5ec37ab89e"),
  "updatedAt": ISODate("2017-09-08T21:34:40.248Z"),
  "createdAt": ISODate("2017-09-08T21:34:40.248Z"),
  "text": "",
  "direction": "inbound",
  "template": null,
  "conversationId": ObjectId("59b17f33c34d9c4ed85a6339"),
  "campaignId": 2900,
  "topic": "campaign",
  "broadcastId": null,
  "attachments": [
    {
      "url": "https://www.wired.com/wp-content/uploads/2015/03/The-X-Files1-1024x768.jpg"
    }
  ],
  "__v": 0
}
```