### PR TITLE
Subscription status keywords

### DIFF
--- a/app/routes/receive-message.js
+++ b/app/routes/receive-message.js
@@ -15,6 +15,7 @@ const createInboundMessageMiddleware = require('../../lib/middleware/receive-mes
 const campaignKeywordMiddleware = require('../../lib/middleware/receive-message/campaign-keyword');
 const rivescriptMiddleware = require('../../lib/middleware/receive-message/rivescript');
 const pausedMiddleware = require('../../lib/middleware/receive-message/conversation-paused');
+const subscriptionStatusMiddleware = require('../../lib/middleware/receive-message/subscription-status');
 const campaignMenuMiddleware = require('../../lib/middleware/receive-message/campaign-menu');
 const currentCampaignMiddleware = require('../../lib/middleware/receive-message/campaign-current');
 const closedCampaignMiddleware = require('../../lib/middleware/receive-message/campaign-closed');
@@ -32,14 +33,17 @@ router.use(createConversationMiddleware());
 router.use(loadInboundMessageMiddleware());
 router.use(createInboundMessageMiddleware());
 
-// If Campaign keyword, set keyword Campaign.
+// If Campaign keyword was sent, set and continue conversation for the keyword Campaign.
 router.use(campaignKeywordMiddleware());
 
-// Send our inbound message to Rivescript bot for a reply.
+// Send our inbound message to Rivescript bot for a reply. If reply is not a macro, send it. 
 router.use(rivescriptMiddleware());
 
-// If Conversation is paused, forward inbound messages elsewhere.
+// If Conversation is paused, forward inbound messages elsewhere and send a noReply.
 router.use(pausedMiddleware());
+
+// Check for subscription status macros.
+router.use(subscriptionStatusMiddleware());
 
 // If MENU command, set random Campaign and ask for Signup.
 router.use(campaignMenuMiddleware());

--- a/app/routes/receive-message.js
+++ b/app/routes/receive-message.js
@@ -33,7 +33,7 @@ router.use(createConversationMiddleware());
 router.use(loadInboundMessageMiddleware());
 router.use(createInboundMessageMiddleware());
 
-// If Campaign keyword was sent, set and continue conversation for the keyword Campaign.
+// If Campaign keyword was sent, update Conversation campaign and send continueCampaign reply.
 router.use(campaignKeywordMiddleware());
 
 // Send our inbound message to Rivescript bot for a reply. If reply is not a macro, send it. 

--- a/brain/begin/index.rive
+++ b/brain/begin/index.rive
@@ -59,6 +59,7 @@
   ^ rape|raped|rapes|raping
   ^ is violent|gets violent
   ^ suicidal|suicidial|suicide
+! array messaging = texting|talking to|messaging
 ! array no        = n no nah nope nay
 ! array photo     = photo photos mms pic pics pix image image img
 ! array question  = is there|who|what|when|why|how

--- a/brain/profile.rive
+++ b/brain/profile.rive
@@ -6,3 +6,9 @@
 
 + stop
 - subscriptionStatusStop
+
++ stop @messaging [me]
+@ stop
+
++ shut up
+@ stop

--- a/brain/profile.rive
+++ b/brain/profile.rive
@@ -1,0 +1,8 @@
+// profile.rive
+// Account management and macros.
+
++ less
+- subscriptionStatusLess
+
++ stop
+- subscriptionStatusStop

--- a/config/lib/helpers.js
+++ b/config/lib/helpers.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const menuCommand = 'menu';
+
 module.exports = {
   askContinueTemplates: [
     'askContinue',
@@ -26,10 +28,11 @@ module.exports = {
     'invalidWhyParticipated',
   ],
   gambitConversationsTemplateText: {
+    noCampaign: `Sorry, I'm not sure how to respond to that.\n\nSay ${menuCommand.toUpperCase()} to find a Campaign to join.`,
     subscriptionStatusLess: 'Sure, we\'ll only message you once a month.',
     subscriptionStatusStop: 'You\'ve been unsubscribed.',
   },
-  menuCommand: 'menu',
+  menuCommand,
   macros: {
     confirmedCampaign: 'confirmedCampaign',
     declinedCampaign: 'declinedCampaign',

--- a/config/lib/helpers.js
+++ b/config/lib/helpers.js
@@ -25,10 +25,16 @@ module.exports = {
     'invalidSignupMenuCommand',
     'invalidWhyParticipated',
   ],
+  gambitConversationsTemplateText: {
+    subscriptionStatusLess: 'Sure, we\'ll only message you once a month.',
+    subscriptionStatusStop: 'You\'ve been unsubscribed.',
+  },
   menuCommand: 'menu',
   macros: {
     confirmedCampaign: 'confirmedCampaign',
     declinedCampaign: 'declinedCampaign',
     gambit: 'gambit',
+    subscriptionStatusLess: 'subscriptionStatusLess',
+    subscriptionStatusStop: 'subscriptionStatusStop',
   },
 };

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -193,9 +193,8 @@ module.exports.invalidAskSignupResponse = function (req, res) {
 };
 
 module.exports.noCampaign = function (req, res) {
-  // Move to config.
-  const text = 'Sorry, I\'m not sure how to respond to that.\n\nSay MENU to find a Campaign to join.';
-  const template = 'noCampaignMessage';
+  const template = 'noCampaign';
+  const text = config.gambitConversationsTemplateText[template];
 
   return sendReply(req, res, text, template);
 };

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -40,6 +40,14 @@ module.exports.isMenuCommand = function (text = '') {
   return (text.toLowerCase() === config.menuCommand);
 };
 
+module.exports.isSubscriptionStatusLessMacro = function (text) {
+  return (text === config.macros.subscriptionStatusLess);
+};
+
+module.exports.isSubscriptionStatusStopMacro = function (text) {
+  return (text === config.macros.subscriptionStatusStop);
+};
+
 /**
  * Sends response with err code and message.
  *
@@ -198,6 +206,21 @@ module.exports.noReply = function (req, res) {
 
 module.exports.rivescriptReply = function (req, res, messageText) {
   return sendReply(req, res, messageText, 'rivescript');
+};
+
+function updateSubscriptionStatus(req, res, template) {
+  const text = config.gambitConversationsTemplateText[template];
+  // TODO: Find Northstar User for our Conversation.platformUserId, POST update subscriptionStatus.
+  // @see https://github.com/DoSomething/gambit-conversations/issues/65
+  return sendReply(req, res, text, template);
+}
+
+module.exports.subscriptionStatusLess = function (req, res) {
+  return updateSubscriptionStatus(req, res, 'subscriptionStatusLess');
+};
+
+module.exports.subscriptionStatusStop = function (req, res) {
+  return updateSubscriptionStatus(req, res, 'subscriptionStatusStop');
 };
 
 /**

--- a/lib/middleware/receive-message/subscription-status.js
+++ b/lib/middleware/receive-message/subscription-status.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const helpers = require('../../helpers');
+
+module.exports = function subscriptionStatus() {
+  return (req, res, next) => {
+    const text = req.rivescriptReplyText;
+
+    if (helpers.isSubscriptionStatusStopMacro(text)) {
+      return helpers.subscriptionStatusStop(req, res, 'less');
+    }
+
+    if (helpers.isSubscriptionStatusLessMacro(text)) {
+      return helpers.subscriptionStatusLess(req, res, 'stop');
+    }
+
+    return next();
+  };
+};

--- a/lib/middleware/receive-message/subscription-status.js
+++ b/lib/middleware/receive-message/subscription-status.js
@@ -7,11 +7,11 @@ module.exports = function subscriptionStatus() {
     const text = req.rivescriptReplyText;
 
     if (helpers.isSubscriptionStatusStopMacro(text)) {
-      return helpers.subscriptionStatusStop(req, res, 'less');
+      return helpers.subscriptionStatusStop(req, res);
     }
 
     if (helpers.isSubscriptionStatusLessMacro(text)) {
-      return helpers.subscriptionStatusLess(req, res, 'stop');
+      return helpers.subscriptionStatusLess(req, res);
     }
 
     return next();


### PR DESCRIPTION
Refs #63:
- Adds `less` and `stop` keywords and replies
- Adds TODO for updating the Conversation User in Northstar accordingly

Note: This isn't adding a property to the Conversation model. So far with our functionality, the only spot we'd ever potentially use would it be in a`POST send-message` request as a sanity check prevent requests to unsubscribed conversations (refs #81) . If this is a requirement, it'd likely make more sense for each POST request to query Northstar to check the User's Subscription Status for the Conversation medium (or build sync support)

This also suggests that each time we receive a message from a User, we should store the last received message from the User. If we receive a message and the User's subscription status is `'unsubscribed'`, we should reset their subscription status to something like `'active'`, as the User has now opted into DS conversations again.

cc @DFurnes 