### PR TITLE
fix twilio helper bug exports.getAttachmentUrl is not a function

### DIFF
--- a/lib/helpers/twilio.js
+++ b/lib/helpers/twilio.js
@@ -27,7 +27,7 @@ module.exports = {
 
     return new Promise((resolve, reject) => {
       if (attachmentObject.redirectUrl) {
-        exports.getAttachmentUrl(attachmentObject.redirectUrl)
+        module.exports.getAttachmentUrl(attachmentObject.redirectUrl)
           .then((url) => {
             req.mediaUrl = url;
             attachmentObject.url = url;


### PR DESCRIPTION
Noticed an error in staging when it started processing Twilio requests. It was due to how I was trying to refer to the `getAttachmentUrl` function, using the `exports` alias. The problem is that it doesn't work when the module is defined using the object literal pattern. I had to use the full path `module.exports.getAttachmentUrl`. 