### PR TITLE
Handling Blink retries to prevent outbound message dupes in `send-message` route

### DIFF
--- a/app/routes/send-message.js
+++ b/app/routes/send-message.js
@@ -10,7 +10,8 @@ const getConversationMiddleware = require('../../lib/middleware/conversation-get
 const createConversationMiddleware = require('../../lib/middleware/conversation-create');
 const campaignMiddleware = require('../../lib/middleware/send-message/campaign');
 const supportMiddleware = require('../../lib/middleware/send-message/support');
-const outboundSendMiddleware = require('../../lib/middleware/send-message/message-outbound');
+const loadOutboundSendMessageMiddleware = require('../../lib/middleware/send-message/message-outbound-load');
+const createOutboundSendMessageMiddleware = require('../../lib/middleware/send-message/message-outbound-create');
 
 router.use(supportParamsMiddleware());
 router.use(campaignParamsMiddleware());
@@ -20,6 +21,8 @@ router.use(createConversationMiddleware());
 
 router.use(campaignMiddleware());
 router.use(supportMiddleware());
-router.use(outboundSendMiddleware());
+
+router.use(loadOutboundSendMessageMiddleware());
+router.use(createOutboundSendMessageMiddleware());
 
 module.exports = router;

--- a/lib/middleware/send-message/message-outbound-create.js
+++ b/lib/middleware/send-message/message-outbound-create.js
@@ -2,7 +2,7 @@
 
 const helpers = require('../../helpers');
 
-module.exports = function outboundMessage() {
+module.exports = function createOutboundSendMessage() {
   return (req, res) => {
     req.conversation.createAndPostOutboundSendMessage(req.sendMessageText,
       req.outboundTemplate, req)

--- a/lib/middleware/send-message/message-outbound-load.js
+++ b/lib/middleware/send-message/message-outbound-load.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const logger = require('heroku-logger');
+
+const helpers = require('../../helpers');
+const Message = require('../../../app/models/Message');
+
+module.exports = function loadOutboundSendMessage() {
+  return (req, res, next) => {
+    // If this is not a retry request, we have to create a new inbound message
+    if (!req.isARetryRequest()) {
+      return next();
+    }
+    logger.debug('loadOutboundSendMessage: Is a retry request. Proceeding with loading message.');
+
+    return Message.updateOutboundApiSendMessageMetadataByRequestId(req.metadata.requestId,
+      req.metadata)
+      .then((message) => {
+        // If there is no loaded message, it means it was not created successfully
+        // so we should attempt to create it
+        if (!message) {
+          logger.debug('loadOutboundSendMessage: Message not found. Calling next to attempt to create it.');
+          return next();
+        }
+        return req.conversation.setLastOutboundMessage(message);
+      })
+      .then(() => req.conversation.postLastOutboundMessageToPlatform())
+      .then(() => helpers.sendResponseWithMessage(res, req.conversation.lastOutboundMessage))
+      .catch(err => helpers.sendErrorResponse(res, err));
+  };
+};

--- a/lib/middleware/send-message/message-outbound-load.js
+++ b/lib/middleware/send-message/message-outbound-load.js
@@ -7,7 +7,7 @@ const Message = require('../../../app/models/Message');
 
 module.exports = function loadOutboundSendMessage() {
   return (req, res, next) => {
-    // If this is not a retry request, we have to create a new inbound message
+    // If this is not a retry request, we have to create a new outbound message
     if (!req.isARetryRequest()) {
       return next();
     }
@@ -22,10 +22,10 @@ module.exports = function loadOutboundSendMessage() {
           logger.debug('loadOutboundSendMessage: Message not found. Calling next to attempt to create it.');
           return next();
         }
-        return req.conversation.setLastOutboundMessage(message);
+        return req.conversation.setLastOutboundMessage(message)
+          .then(() => req.conversation.postLastOutboundMessageToPlatform())
+          .then(() => helpers.sendResponseWithMessage(res, req.conversation.lastOutboundMessage));
       })
-      .then(() => req.conversation.postLastOutboundMessageToPlatform())
-      .then(() => helpers.sendResponseWithMessage(res, req.conversation.lastOutboundMessage))
       .catch(err => helpers.sendErrorResponse(res, err));
   };
 };


### PR DESCRIPTION
## Summary
Checks if the request contains retry count headers . If it does, it loads the outbound message based on its `metadata.requestId` and direction, instead of creating a new one, preventing duplicates.

## Related issues
Issue #73 
Part B of #105 