### PR TITLE
Minimalist approach to regularly updating Campaign cache

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,5 @@
 DS_GAMBIT_CAMPAIGNS_API_KEY=totallysecret
 DS_GAMBIT_CAMPAIGNS_API_BASEURI=http://ds-mdata-responder-staging.herokuapp.com/v1
-DS_GAMBIT_CAMPAIGNS_SYNC=anything
 
 SLACK_API_TOKEN=totallysecret
 
@@ -28,3 +27,7 @@ NEW_RELIC_APP_NAME=Example App
 NEW_RELIC_ENABLED=false
 NEW_RELIC_LICENSE_KEY=totallysecret
 NEW_RELIC_LOGGING_LEVEL=info
+
+## Optional vars
+
+DS_GAMBIT_CAMPAIGNS_SYNC_INTERVAL=3600000

--- a/config/index.js
+++ b/config/index.js
@@ -1,9 +1,10 @@
 'use strict';
 
 const configVars = {
+  campaignSyncInterval: process.env.DS_GAMBIT_CAMPAIGNS_SYNC_INTERVAL || 3600000,
   corsEnabled: process.env.CORS_DISABLED || true,
-  port: process.env.PORT || 5100,
   dbUri: process.env.MONGODB_URI || 'mongodb://localhost/gambit-conversations',
+  port: process.env.PORT || 5100,
 };
 
 module.exports = configVars;

--- a/server.js
+++ b/server.js
@@ -20,8 +20,9 @@ mongoose.connect(config.dbUri, {
 // Sync Campaign cache with Gambit Campaigns API.
 const CampaignModel = require('./app/models/Campaign');
 
+CampaignModel.sync();
 if (process.env.DS_GAMBIT_CAMPAIGNS_SYNC) {
-  CampaignModel.sync();
+  setInterval(() => { CampaignModel.sync() }, 50000);
 }
 
 const db = mongoose.connection;

--- a/server.js
+++ b/server.js
@@ -17,13 +17,12 @@ mongoose.connect(config.dbUri, {
   useMongoClient: true,
 });
 
-// Sync Campaign cache with Gambit Campaigns API.
+
 const CampaignModel = require('./app/models/Campaign');
 
+// Sync Campaign cache with Gambit Campaigns API.
 CampaignModel.sync();
-if (process.env.DS_GAMBIT_CAMPAIGNS_SYNC) {
-  setInterval(() => { CampaignModel.sync() }, 50000);
-}
+setInterval(() => { CampaignModel.sync() }, config.campaignSyncInterval);
 
 const db = mongoose.connection;
 db.on('error', () => {


### PR DESCRIPTION
Refs #37 -- currently our Campaign cache gets updated on app start, and that's it.

This PR calls the `Campaign.sync` every `DS_GAMBIT_CAMPAIGNS_SYNC_INTERVAL` milliseconds. The sync will execute every hour if the config variable is not set.

The ideal would be that Gambit Campaigns begins to cache Campaign data, and posts updates to our Gambit Conversations cache to avoid polling -- but this shouldn't be a launch blocker. I'm thinking that regular polling every hour (we could increase this to every few hours if it's too much of a load on G-Campaigns) is a better go-live approach that restarting the Gambit Conversations app.