### PR TITLE
WIP: Handling Blink retries to prevent outbound message dupes in `receive-message` route

### DIFF
--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -12,13 +12,13 @@ const parseMetadataMiddleware = require('../../lib/middleware/metadata-parse');
 
 const router = express.Router();
 
-const ConversationModel = require('../models/Conversation');
-const MessageModel = require('../models/Message');
-const CampaignModel = require('../models/Campaign');
+const Conversation = require('../models/Conversation');
+const Message = require('../models/Message');
+const Campaign = require('../models/Campaign');
 
-restify.serve(router, ConversationModel, { name: 'conversations' });
-restify.serve(router, MessageModel, { name: 'messages' });
-restify.serve(router, CampaignModel, { name: 'campaigns' });
+restify.serve(router, Conversation, { name: 'conversations' });
+restify.serve(router, Message, { name: 'messages' });
+restify.serve(router, Campaign, { name: 'campaigns' });
 
 module.exports = function init(app) {
   app.get('/', (req, res) => {

--- a/lib/middleware/conversation-get.js
+++ b/lib/middleware/conversation-get.js
@@ -1,12 +1,12 @@
 'use strict';
 
 const logger = require('heroku-logger');
-const Conversations = require('../../app/models/Conversation');
+const Conversation = require('../../app/models/Conversation');
 const helpers = require('../helpers');
 
 module.exports = function getConversation() {
   return (req, res, next) => {
-    Conversations.getFromReq(req)
+    Conversation.getFromReq(req)
       .then((conversation) => {
         if (!conversation) return next();
 

--- a/lib/middleware/import-message/conversation-update.js
+++ b/lib/middleware/import-message/conversation-update.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const helpers = require('../../helpers');
-const Campaigns = require('../../../app/models/Campaign');
+const Campaign = require('../../../app/models/Campaign');
 
 module.exports = function updateConversation() {
   return (req, res, next) => {
@@ -11,7 +11,7 @@ module.exports = function updateConversation() {
       return req.conversation.setTopic(topic).then(() => next());
     }
 
-    return Campaigns.findById(req.campaignId)
+    return Campaign.findById(req.campaignId)
       .then(campaign => req.conversation.promptSignupForCampaign(campaign))
       .then(() => {
         req.outboundTemplate = 'askSignup';

--- a/lib/middleware/receive-message/campaign-current.js
+++ b/lib/middleware/receive-message/campaign-current.js
@@ -2,7 +2,7 @@
 
 const logger = require('heroku-logger');
 const helpers = require('../../helpers');
-const Campaigns = require('../../../app/models/Campaign');
+const Campaign = require('../../../app/models/Campaign');
 
 module.exports = function getCurrentCampaign() {
   return (req, res, next) => {
@@ -19,7 +19,7 @@ module.exports = function getCurrentCampaign() {
       return helpers.noCampaign(req, res);
     }
 
-    return Campaigns.findById(campaignId)
+    return Campaign.findById(campaignId)
       .then((campaign) => {
         if (!campaign) {
           return helpers.noCampaign(req, res);

--- a/lib/middleware/receive-message/campaign-keyword.js
+++ b/lib/middleware/receive-message/campaign-keyword.js
@@ -2,7 +2,7 @@
 
 const logger = require('heroku-logger');
 const helpers = require('../../helpers');
-const Campaigns = require('../../../app/models/Campaign');
+const Campaign = require('../../../app/models/Campaign');
 
 module.exports = function getCampaignForKeyword() {
   return (req, res, next) => {
@@ -10,7 +10,7 @@ module.exports = function getCampaignForKeyword() {
     const keyword = req.userCommand;
 
     // Did User send a Campaign keyword?
-    Campaigns.findByKeyword(keyword)
+    Campaign.findByKeyword(keyword)
       .then((campaign) => {
         if (!campaign) {
           logger.debug(`${loggerMessage} not found`, { keyword });

--- a/lib/middleware/receive-message/campaign-menu.js
+++ b/lib/middleware/receive-message/campaign-menu.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const Campaigns = require('../../../app/models/Campaign');
+const Campaign = require('../../../app/models/Campaign');
 const helpers = require('../../helpers.js');
 
 module.exports = function campaignMenu() {
@@ -11,7 +11,7 @@ module.exports = function campaignMenu() {
 
     // Find a random Campaign to prompt for Signup.
     // Eventually query Signups to find Campaigns that are new to User, within their interests, etc.
-    return Campaigns.findRandomCampaignNotEqualTo(req.conversation.campaignId)
+    return Campaign.findRandomCampaignNotEqualTo(req.conversation.campaignId)
       .then((randomCampaign) => {
         req.campaign = randomCampaign;
 

--- a/lib/middleware/send-message/campaign.js
+++ b/lib/middleware/send-message/campaign.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const Campaigns = require('../../../app/models/Campaign');
+const Campaign = require('../../../app/models/Campaign');
 const UnprocessibleEntityError = require('../../../app/exceptions/UnprocessibleEntityError');
 const helpers = require('../../helpers');
 
@@ -15,7 +15,7 @@ module.exports = function sendCampaignTemplate() {
       return helpers.sendErrorResponse(res, err);
     }
 
-    return Campaigns.findById(req.campaignId)
+    return Campaign.findById(req.campaignId)
       .then((campaign) => {
         if (!campaign) {
           return helpers.sendResponseWithStatusCode(res, 404, 'Campaign not found.');

--- a/server.js
+++ b/server.js
@@ -18,10 +18,10 @@ mongoose.connect(config.dbUri, {
 });
 
 // Sync Campaign cache with Gambit Campaigns API.
-const CampaignModel = require('./app/models/Campaign');
+const Campaign = require('./app/models/Campaign');
 
 if (process.env.DS_GAMBIT_CAMPAIGNS_SYNC) {
-  CampaignModel.sync();
+  Campaign.sync();
 }
 
 const db = mongoose.connection;


### PR DESCRIPTION
## Summary
Checks if the request contains retry count headers . If it does, it loads the outbound message based on its `metadata.requestId` and direction, instead of creating a new one, preventing duplicates.

## Related issues
Issue #73 
Part B of #105 