### PR TITLE
added eslint. Fixed lint error by adding uuid package to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,17 +44,18 @@
     "rivescript": "^1.17.2",
     "superagent": "^3.5.2",
     "twilio": "^3.5.0",
-    "underscore": "^1.8.3"
+    "underscore": "^1.8.3",
+    "uuid": "^3.1.0"
   },
   "devDependencies": {
     "@dosomething/eslint-config": "^3.1.0",
     "ava": "^0.21.0",
     "chai": "^4.1.0",
+    "eslint": "^4.7.0",
     "eslint-plugin-ava": "^4.2.1",
     "nock": "^9.0.14",
     "readline": "^1.3.0",
     "sinon": "^2.3.8",
-    "sinon-chai": "^2.12.0",
-    "uuid": "^3.1.0"
+    "sinon-chai": "^2.12.0"
   }
 }


### PR DESCRIPTION
## What does this PR do?
- It adds `eslint` package to `DevDependencies`.
- It moves `uuid` from `devDependencies` to `dependencies` to pass the linter.