### PR TITLE
Update User in POST /receive-message

### DIFF
--- a/app/routes/receive-message.js
+++ b/app/routes/receive-message.js
@@ -15,8 +15,8 @@ const loadInboundMessageMiddleware = require('../../lib/middleware/receive-messa
 const createInboundMessageMiddleware = require('../../lib/middleware/receive-message/message-inbound-create');
 const campaignKeywordMiddleware = require('../../lib/middleware/receive-message/campaign-keyword');
 const rivescriptMiddleware = require('../../lib/middleware/receive-message/rivescript');
-const pausedMiddleware = require('../../lib/middleware/receive-message/conversation-paused');
-const subscriptionStatusMiddleware = require('../../lib/middleware/receive-message/subscription-status');
+const updateUserMiddleware = require('../../lib/middleware/receive-message/user-update');
+const supportMiddleware = require('../../lib/middleware/receive-message/support');
 const campaignMenuMiddleware = require('../../lib/middleware/receive-message/campaign-menu');
 const currentCampaignMiddleware = require('../../lib/middleware/receive-message/campaign-current');
 const closedCampaignMiddleware = require('../../lib/middleware/receive-message/campaign-closed');
@@ -32,6 +32,7 @@ router.use(createConversationMiddleware());
 
 // Fetch Conversation Northstar User.
 router.use(getUserMiddleware());
+// TODO: Create User if not found.
 
 // Load/create inbound message.
 router.use(loadInboundMessageMiddleware());
@@ -43,11 +44,10 @@ router.use(campaignKeywordMiddleware());
 // Send our inbound message to Rivescript bot for a reply. If reply is not a macro, send it. 
 router.use(rivescriptMiddleware());
 
-// If Conversation is paused, forward inbound messages elsewhere and send a noReply.
-router.use(pausedMiddleware());
+router.use(updateUserMiddleware());
 
-// Check for subscription status macros.
-router.use(subscriptionStatusMiddleware());
+// If Conversation is paused, forward inbound messages elsewhere and send a noReply.
+router.use(supportMiddleware());
 
 // If MENU command, set random Campaign and ask for Signup.
 router.use(campaignMenuMiddleware());

--- a/config/lib/helpers.js
+++ b/config/lib/helpers.js
@@ -29,6 +29,7 @@ module.exports = {
   ],
   gambitConversationsTemplateText: {
     noCampaign: `Sorry, I'm not sure how to respond to that.\n\nSay ${menuCommand.toUpperCase()} to find a Campaign to join.`,
+    noReply: '',
     subscriptionStatusLess: 'Sure, we\'ll only message you once a month.',
     subscriptionStatusStop: 'You\'ve been unsubscribed.',
   },

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -212,32 +212,33 @@ module.exports.invalidAskSignupResponse = function (req, res) {
   return sendReplyWithCampaignTemplate(req, res, 'invalidAskSignupResponse');
 };
 
-module.exports.noCampaign = function (req, res) {
-  const template = 'noCampaign';
-  const text = config.gambitConversationsTemplateText[template];
-
-  return sendReply(req, res, text, template);
-};
-
-module.exports.noReply = function (req, res) {
-  return sendReply(req, res, '', 'noReply');
-};
-
 module.exports.rivescriptReply = function (req, res, messageText) {
   return sendReply(req, res, messageText, 'rivescript');
 };
 
-function updateSubscriptionStatus(req, res, template) {
+/**
+ * Send templates defined in Gambit Conversations.
+ */
+
+function sendGambitConversationsTemplate(req, res, template) {
   const text = config.gambitConversationsTemplateText[template];
   return sendReply(req, res, text, template);
 }
 
+module.exports.noCampaign = function (req, res) {
+  return sendGambitConversationsTemplate(req, res, 'noCampaign');
+};
+
+module.exports.noReply = function (req, res) {
+  return sendGambitConversationsTemplate(req, res, 'noReply');
+};
+
 module.exports.subscriptionStatusLess = function (req, res) {
-  return updateSubscriptionStatus(req, res, 'subscriptionStatusLess');
+  return sendGambitConversationsTemplate(req, res, 'subscriptionStatusLess');
 };
 
 module.exports.subscriptionStatusStop = function (req, res) {
-  return updateSubscriptionStatus(req, res, 'subscriptionStatusStop');
+  return sendGambitConversationsTemplate(req, res, 'subscriptionStatusStop');
 };
 
 /**

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -229,8 +229,6 @@ module.exports.rivescriptReply = function (req, res, messageText) {
 
 function updateSubscriptionStatus(req, res, template) {
   const text = config.gambitConversationsTemplateText[template];
-  // TODO: Find Northstar User for our Conversation.platformUserId, POST update subscriptionStatus.
-  // @see https://github.com/DoSomething/gambit-conversations/issues/65
   return sendReply(req, res, text, template);
 }
 

--- a/lib/middleware/receive-message/support.js
+++ b/lib/middleware/receive-message/support.js
@@ -4,7 +4,7 @@ const logger = require('heroku-logger');
 const front = require('../../front');
 const helpers = require('../../helpers');
 
-module.exports = function isPaused() {
+module.exports = function postSupportMessageToFront() {
   return (req, res, next) => {
     if (!req.conversation.paused) {
       return next();

--- a/lib/middleware/receive-message/user-get.js
+++ b/lib/middleware/receive-message/user-get.js
@@ -12,7 +12,8 @@ module.exports = function getNorthstarUser() {
     return req.conversation.getNorthstarUser()
       .then((user) => {
         req.user = user;
-        logger.debug('getNorthstarUser', { userId: user.id });
+        req.userId = user.id;
+        logger.debug('getNorthstarUser', { userId: req.userId });
 
         return next();
       })

--- a/lib/middleware/receive-message/user-update.js
+++ b/lib/middleware/receive-message/user-update.js
@@ -2,7 +2,7 @@
 
 const helpers = require('../../helpers');
 
-module.exports = function subscriptionStatus() {
+module.exports = function updateNorthstarUser() {
   return (req, res, next) => {
     const text = req.rivescriptReplyText;
 

--- a/lib/middleware/receive-message/user-update.js
+++ b/lib/middleware/receive-message/user-update.js
@@ -1,19 +1,49 @@
 'use strict';
 
+const logger = require('heroku-logger');
 const helpers = require('../../helpers');
+const northstar = require('../../northstar');
 
 module.exports = function updateNorthstarUser() {
   return (req, res, next) => {
-    const text = req.rivescriptReplyText;
-
-    if (helpers.isSubscriptionStatusStopMacro(text)) {
-      return helpers.subscriptionStatusStop(req, res);
+    // If we dont have a userId set, skip Northstar updates.
+    if (!req.userId) {
+      return next();
     }
 
-    if (helpers.isSubscriptionStatusLessMacro(text)) {
-      return helpers.subscriptionStatusLess(req, res);
+    const replyText = req.rivescriptReplyText;
+    const currentStatus = req.user.sms_status;
+    let statusUpdate = null;
+
+    if (helpers.isSubscriptionStatusStopMacro(replyText)) {
+      statusUpdate = 'undeliverable';
+    } else if (helpers.isSubscriptionStatusLessMacro(replyText)) {
+      statusUpdate = 'less';
+    // If User is set to undeliverable but we've now received a message from them:
+    } else if (currentStatus === 'undeliverable') {
+      statusUpdate = 'active';
     }
 
-    return next();
+    const data = {
+      last_messaged_at: req.inboundMessage.createdAt,
+      sms_paused: req.conversation.paused,
+    };
+    if (statusUpdate) {
+      data.sms_status = statusUpdate;
+    }
+
+    return northstar.updateUser(req.userId, data)
+      .then(() => {
+        logger.debug('northstar.updateUser success', { userId: req.userId, data });
+
+        if (statusUpdate === 'less') {
+          return helpers.subscriptionStatusLess(req, res);
+        } else if (statusUpdate === 'undeliverable') {
+          return helpers.subscriptionStatusStop(req, res);
+        }
+
+        return next();
+      })
+      .catch(err => helpers.sendErrorResponse(res, err));
   };
 };

--- a/lib/northstar.js
+++ b/lib/northstar.js
@@ -48,3 +48,12 @@ module.exports.fetchUserByMobile = function (mobile) {
 
   return exports.getClient().Users.get('mobile', mobile);
 };
+
+/**
+ * @param {string} userId
+ * @param {object} data
+ * @return {Promise}
+ */
+module.exports.updateUser = function (userId, data) {
+  return exports.getClient().Users.update(userId, data);
+};

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "node": "6.11.1"
   },
   "dependencies": {
-    "@dosomething/northstar-js": "^1.0.0",
+    "@dosomething/northstar-js": "git://github.com/DoSomething/northstar-js.git",
     "@slack/client": "^3.10.0",
     "basic-auth": "^1.1.0",
     "bluebird": "^3.5.0",


### PR DESCRIPTION
Adds `/lib/middleware/receive-message/user-update` and calls `northstar.updateUser` per https://github.com/DoSomething/northstar-js/pull/38

* Fixes #124: Saves our `req.inboundMessage.createdAt` on NS User `last_messaged_at`

* Fixes #63: Updates NS User `sms_status`:
    * Sets to `'less'` or `'undeliverable'` for triggers defined in `/brain/profile.rive`
    * Sets to `'active'` if the User's current `sms_status` is currently `'undeliverable'`

* Fixes #65: Updates NS `sms_paused` 

Some cleanup:
* DRY helpers that send templates defined in Gambit Conversations code with `sendGambitConversationsTemplate`
* Renames `/lib/middleware/conversation-paused` to `/lib/middleware/support/`
* Add TODO to create a User if not found for the `req.platformUserId`

Will deploy to staging for testing - texting in the Subscription keywords should update your Thor Northstar User.