### PR TITLE
Import of broadcast message through Twilio statusCallback POST requests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,7 @@ DS_GAMBIT_CAMPAIGNS_API_BASEURI=http://ds-mdata-responder-staging.herokuapp.com/
 
 DS_GAMBIT_CONVERSATIONS_API_BASIC_AUTH_NAME=puppet
 DS_GAMBIT_CONVERSATIONS_API_BASIC_AUTH_PASS=totallysecret
+DS_GAMBIT_CONVERSATIONS_API_KEY=totallysecret2
 
 DS_NORTHSTAR_API_KEY=totallysecret
 DS_NORTHSTAR_API_BASEURI=https://northstar-slothbot4eva.dosomething.org/v1

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -21,9 +21,9 @@ restify.serve(router, Message, { name: 'messages' });
 restify.serve(router, Campaign, { name: 'campaigns' });
 
 module.exports = function init(app) {
-  app.get('/', (req, res) => {
-    res.send('hi');
-  });
+  app.get('/', (req, res) => res.send('hi'));
+  app.get('/favicon.ico', (req, res) => res.sendStatus(204));
+
   // TODO: Eventually remove this.
   // @see https://github.com/DoSomething/gambit-conversations/issues/55
   app.use((req, res, next) => {

--- a/lib/helpers/broadcast.js
+++ b/lib/helpers/broadcast.js
@@ -1,7 +1,11 @@
 'use strict';
 
+function getBroadcastId(req) {
+  return req.body.broadcastId || req.query.broadcastId;
+}
+
 /**
- * Customer.io helper
+ * Broadcast helper
  */
 module.exports = {
   /**
@@ -11,8 +15,6 @@ module.exports = {
    * @return {promise}
    */
   parseBody: function parseBody(req) {
-    req.platform = 'sms';
-    req.platformUserId = req.body.phone;
-    req.messageFields = req.body.fields;
+    req.broadcastId = getBroadcastId(req);
   },
 };

--- a/lib/helpers/broadcast.js
+++ b/lib/helpers/broadcast.js
@@ -9,7 +9,7 @@ function getBroadcastId(req) {
  */
 module.exports = {
   /**
-   * parseBody - parses properties out of the body of a Facebook request
+   * parseBody
    *
    * @param  {object} req
    * @return {promise}

--- a/lib/helpers/index.js
+++ b/lib/helpers/index.js
@@ -6,6 +6,7 @@ const customerIo = require('./customerio');
 const facebook = require('./facebook');
 const slack = require('./slack');
 const request = require('./request');
+const broadcast = require('./broadcast');
 
 module.exports = {
   attachments,
@@ -14,4 +15,5 @@ module.exports = {
   facebook,
   slack,
   request,
+  broadcast,
 };

--- a/lib/helpers/request.js
+++ b/lib/helpers/request.js
@@ -22,7 +22,7 @@ module.exports = {
     // TODO: Should be in a config constant
     return platform === 'customerio';
   },
-  isStatusCallback: function isStatusCallback(req) {
+  isTwilioStatusCallback: function isTwilioStatusCallback(req) {
     const messageStatus = req.body.MessageStatus;
 
     /**

--- a/lib/helpers/request.js
+++ b/lib/helpers/request.js
@@ -22,4 +22,14 @@ module.exports = {
     // TODO: Should be in a config constant
     return platform === 'customerio';
   },
+  isStatusCallback: function isStatusCallback(req) {
+    const messageStatus = req.body.MessageStatus;
+
+    /**
+     * Twilio has received confirmation of message delivery from the upstream carrier,
+     * and, where available, the destination handset.
+     * @see https://www.twilio.com/docs/api/messaging/message#message-status-values
+     */
+    return messageStatus === 'delivered';
+  },
 };

--- a/lib/helpers/twilio.js
+++ b/lib/helpers/twilio.js
@@ -19,9 +19,17 @@ module.exports = {
    */
   parseBody: function parseBody(req) {
     req.platform = 'sms';
-    req.platformUserId = req.body.From;
     req.inboundMessageText = req.body.Body;
     req.platformMessageId = req.body.MessageSid;
+    req.platformUserId = req.body.From;
+
+    /**
+     * Inspect baseUrl to check if it's an import request
+     * @see http://expressjs.com/en/api.html#req.baseUrl
+     */
+    if (req.baseUrl.indexOf('import-message') >= 0) {
+      req.platformUserId = req.body.To;
+    }
 
     const attachmentObject = this.parseAttachmentFromReq(req);
 

--- a/lib/middleware/authenticate.js
+++ b/lib/middleware/authenticate.js
@@ -5,24 +5,40 @@ const logger = require('heroku-logger');
 
 const helpers = require('../helpers');
 
+const unauthorizedErrorMessage = 'Invalid or missing auth parameters. Unauthorized.';
+
 // TODO move to config file
-function validateAuth(user) {
+function validateBasicAuth(user) {
   return (user.name === process.env.DS_GAMBIT_CONVERSATIONS_API_BASIC_AUTH_NAME &&
     user.pass === process.env.DS_GAMBIT_CONVERSATIONS_API_BASIC_AUTH_PASS);
 }
 
+// TODO: We don't need this when Blink becomes the proxy between Twilio statuCallbacks and
+// Conversations. For now it's here for testing purposes, as the Twilio Messaging API doesn't
+// support setting Basic Auth in the statusCallback query param when POSTing a new message.
+function validateAPIKey(apiKey) {
+  return (apiKey === process.env.DS_GAMBIT_CONVERSATIONS_API_KEY);
+}
+
+function getAPIKey(req) {
+  return req.query.apiKey || req.body.apiKey;
+}
+
 function sendUnauthorizedResponse(req, res) {
-  logger.error('Unauthorized request headers', req.headers);
-  logger.error('Unauthorized request body', req.body);
+  logger.debug('Unauthorized request headers', req.headers);
+  logger.debug('Unauthorized request query', req.query);
+  logger.debug('Unauthorized request body', req.body);
   res.setHeader('WWW-Authenticate', 'Basic');
-  return helpers.sendResponseWithStatusCode(res, 401, 'Unauthorized');
+  return helpers.sendResponseWithStatusCode(res, 401, unauthorizedErrorMessage);
 }
 
 module.exports = function authenticate() {
   return (req, res, next) => {
     const user = auth(req) || {};
+    const apiKey = getAPIKey(req);
 
-    if (!validateAuth(user)) {
+    if (!validateBasicAuth(user) && !validateAPIKey(apiKey)) {
+      logger.error(unauthorizedErrorMessage);
       return sendUnauthorizedResponse(req, res);
     }
 

--- a/lib/middleware/authenticate.js
+++ b/lib/middleware/authenticate.js
@@ -13,10 +13,10 @@ function validateBasicAuth(user) {
     user.pass === process.env.DS_GAMBIT_CONVERSATIONS_API_BASIC_AUTH_PASS);
 }
 
-// TODO: We don't need this when Blink becomes the proxy between Twilio statuCallbacks and
+// TODO: We don't need this when Blink becomes the proxy between Twilio statusCallbacks and
 // Conversations. For now it's here for testing purposes, as the Twilio Messaging API doesn't
 // support setting Basic Auth in the statusCallback query param when POSTing a new message.
-function validateAPIKey(apiKey) {
+function validateApiKey(apiKey) {
   return (apiKey === process.env.DS_GAMBIT_CONVERSATIONS_API_KEY);
 }
 
@@ -37,7 +37,7 @@ module.exports = function authenticate() {
     const user = auth(req) || {};
     const apiKey = getAPIKey(req);
 
-    if (!validateBasicAuth(user) && !validateAPIKey(apiKey)) {
+    if (!validateBasicAuth(user) && !validateApiKey(apiKey)) {
       logger.error(unauthorizedErrorMessage);
       return sendUnauthorizedResponse(req, res);
     }

--- a/lib/middleware/authenticate.js
+++ b/lib/middleware/authenticate.js
@@ -20,7 +20,7 @@ function validateApiKey(apiKey) {
   return (apiKey === process.env.DS_GAMBIT_CONVERSATIONS_API_KEY);
 }
 
-function getAPIKey(req) {
+function getApiKey(req) {
   return req.query.apiKey || req.body.apiKey;
 }
 
@@ -35,7 +35,7 @@ function sendUnauthorizedResponse(req, res) {
 module.exports = function authenticate() {
   return (req, res, next) => {
     const user = auth(req) || {};
-    const apiKey = getAPIKey(req);
+    const apiKey = getApiKey(req);
 
     if (!validateBasicAuth(user) && !validateApiKey(apiKey)) {
       logger.error(unauthorizedErrorMessage);

--- a/lib/middleware/import-message/broadcast.js
+++ b/lib/middleware/import-message/broadcast.js
@@ -20,6 +20,8 @@ function getTopic(broadcastObject) {
 }
 
 // TODO: Move inside lib/contentful
+// TODO: This might not be needed if we decide to never use liquid tags in the broadcast body that
+// are meant to be parsed with Customer.io's user attributes.
 function replaceFieldsInMessage(fields = [], message) {
   let msg = message;
   fields.forEach((field) => {

--- a/lib/middleware/import-message/params.js
+++ b/lib/middleware/import-message/params.js
@@ -8,11 +8,21 @@ module.exports = function params() {
   return (req, res, next) => {
     logger.debug('POST /import-message', { body: req.body });
 
-    if (!helpers.request.isCustomerIo(req)) {
-      const error = new UnprocessibleEntityError('Invalid platform.');
+    // Customer.io's webhook import
+    if (helpers.request.isCustomerIo(req)) {
+      helpers.customerIo.parseBody(req);
+
+    // Twilio's statusCallback import
+    } else if (helpers.request.isStatusCallback(req)) {
+      logger.debug('Importing \'Delivered\' Twilio message');
+      helpers.twilio.parseBody(req);
+    } else {
+      const error = new UnprocessibleEntityError('Not a valid import request.');
       return helpers.sendErrorResponse(res, error);
     }
-    helpers.customerIo.parseBody(req);
+
+    // get broadcastId property
+    helpers.broadcast.parseBody(req);
 
     return next();
   };

--- a/lib/middleware/import-message/params.js
+++ b/lib/middleware/import-message/params.js
@@ -13,7 +13,7 @@ module.exports = function params() {
       helpers.customerIo.parseBody(req);
 
     // Twilio's statusCallback import
-    } else if (helpers.request.isStatusCallback(req)) {
+    } else if (helpers.request.isTwilioStatusCallback(req)) {
       logger.debug('Importing \'Delivered\' Twilio message');
       helpers.twilio.parseBody(req);
     } else {

--- a/test/helpers/stubs.js
+++ b/test/helpers/stubs.js
@@ -1,0 +1,10 @@
+'use strict';
+
+module.exports = {
+  stubLogger: function stubLogger(sandbox, logger) {
+    sandbox.stub(logger, 'warn').returns(() => {});
+    sandbox.stub(logger, 'error').returns(() => {});
+    sandbox.stub(logger, 'debug').returns(() => {});
+    sandbox.stub(logger, 'info').returns(() => {});
+  },
+};

--- a/test/lib/lib-helpers/broadcast.test.js
+++ b/test/lib/lib-helpers/broadcast.test.js
@@ -1,0 +1,54 @@
+'use strict';
+
+// libs
+require('dotenv').config();
+const test = require('ava');
+const chai = require('chai');
+const sinon = require('sinon');
+const sinonChai = require('sinon-chai');
+const httpMocks = require('node-mocks-http');
+const logger = require('heroku-logger');
+const stubs = require('../../helpers/stubs');
+
+// setup "x.should.y" assertion style
+chai.should();
+chai.use(sinonChai);
+
+// module to be tested
+const broadcastHelper = require('../../../lib/helpers/broadcast');
+
+// sinon sandbox object
+const sandbox = sinon.sandbox.create();
+
+// Setup!
+test.beforeEach(() => {
+  stubs.stubLogger(sandbox, logger);
+});
+
+// Cleanup!
+test.afterEach(() => {
+  // reset stubs, spies, and mocks
+  sandbox.restore();
+});
+
+test('the broadcastId should be parsed out of the query params and injected in the req object', () => {
+  const broadcastId = 'test';
+  const req = httpMocks.createRequest({
+    method: 'POST',
+    url: '/test',
+    query: { broadcastId },
+  });
+  broadcastHelper.parseBody(req);
+  req.broadcastId.should.be.equal(broadcastId);
+});
+
+test('the broadcastId should be parsed out of the body params and injected in the req object', () => {
+  const broadcastId = 'test';
+  const req = httpMocks.createRequest({
+    method: 'POST',
+    url: '/test',
+    body: { broadcastId },
+  });
+  broadcastHelper.parseBody(req);
+  req.broadcastId.should.be.equal(broadcastId);
+});


### PR DESCRIPTION
# Summary
This is the code that supports the Proof-Of-Concept approach to broadcasts depicted in #139.

# Things to consider
- **Twilio**
    - Twilio will POST (n) requests to the URL we set up as `statusCallback` URI. The amount of requests depend on many factors, including the carrier. A list of possible statuses sent to the `statusCallback` URI can be [found here](https://www.twilio.com/docs/api/messaging/message#message-status-values).
        - Example: My carrier is T-mobile. The statuses Twilio POSTed to my local Convo API while developing were: `queued`, `sent`, and `delivered`.
    - We are only importing messages that have been `delivered` to the user. This filtering should happen at the Blink worker level so we don't run the risk of overloading the Convo API. However, is important to respond with success for all message statuses, even if we are filtering them out, otherwise we will get [#11200 errors](https://www.twilio.com/docs/api/errors/11200) in our Twilio dashboard.
- **Security**
    - We are using a Twilio revokable API Key as an added layer of security when creating messages from the Customer.io's Webhook workflow step.
    - Twilio requests should be validated against their `X-Twilio-Signature` header. This check should happen at the Blink worker level, since it gets the request directly from Twilio. For testing, I have enabled API key authentication, so that the `statusCallback` URI can contain an API Key as a query parameter and be authenticated.
        - [Docs about how to do this in Node and Express using the webhook() middleware](https://www.twilio.com/docs/guides/how-to-secure-your-express-app-by-validating-incoming-twilio-requests#use-twilio-express-request-validation-middleware)
        - [API Reference docs on the methods we can use to do this manually](https://twilio.github.io/twilio-node/3.5.0/global.html#validateExpressRequest)
    - ~~Basic Auth in the `statusCallback` doesn't seem to be supported.~~ [It is.](https://github.com/DoSomething/gambit-conversations/pull/141#issuecomment-332318577)
- **Customer.io**
    - The Webhook workflow step must be setup with `application/x-www-form-urlencoded` content type headers. `application/json` [is NOT supported](https://www.twilio.com/docs/api/rest/request#post).
    - The `statusCallback` URI sent in the body of the webhook **must** be [URI encoded](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent) in order to preserve its query parameters like `broadcastId`, and `apiKey` (for now).
        - Example of the Webhook body:
        ```To={{customer.phone}}&MessagingServiceSid=secretSauce&Body=tacos are great&StatusCallback=http%3A%2F%2F57528dc6.ngrok.io%2Fapi%2Fv1%2Fimport-message%3FbroadcastId%3Dtacosfest%26apiKey%3Dthe-api-key-yo```

# Next tasks to work on
- Add route to generate the Webhook body, given a `broadcastId` and `apiKey`.
- Add documentation for this broadcast process #123.
- Remove code that supports the `Backup solution` in #139.

# Relevant Issues
Ref #139 
Ref #123