### PR TITLE
Return cached templates for Campaign Receive Message requests

### DIFF
--- a/documentation/endpoints/receive-message.md
+++ b/documentation/endpoints/receive-message.md
@@ -47,40 +47,42 @@ curl -X "POST" "http://localhost:5100/api/v1/receive-message" \
 ```
 {
   "data": {
-    "inbound": [
-      {
-        "__v": 0,
-        "updatedAt": "2017-08-31T19:21:47.556Z",
-        "createdAt": "2017-08-31T19:21:47.556Z",
-        "conversationId": "59a7203fc731160d31cfdad2",
-        "campaignId": 2710,
-        "topic": "campaign",
-        "text": "menu",
-        "direction": "inbound",
-        "_id": "59a861cbf64c3e0902d956e7",
-        "attachments": [
-          {
-            "contentType": "image/png",
-            "url": "http://placekitten.com/g/800/600"
-          }
-        ]
-      }
-    ],
-    "outbound": [
-      {
-        "__v": 0,
-        "updatedAt": "2017-08-31T19:21:47.597Z",
-        "createdAt": "2017-08-31T19:21:47.597Z",
-        "conversationId": "59a7203fc731160d31cfdad2",
-        "campaignId": 7656,
-        "topic": "campaign_7656",
-        "text": "Help us send letters of support to every mosque in the United States. \n\nWant to join Sincerely, Us?\n\nYes or No",
-        "template": "askSignupMessage",
-        "direction": "outbound-reply",
-        "_id": "59a861cbf64c3e0902d956e8",
-        "attachments": []
-      }
-    ]
+    "messages": {
+      "inbound": [
+        {
+          "__v": 0,
+          "updatedAt": "2017-08-31T19:21:47.556Z",
+          "createdAt": "2017-08-31T19:21:47.556Z",
+          "conversationId": "59a7203fc731160d31cfdad2",
+          "campaignId": 2710,
+          "topic": "campaign",
+          "text": "menu",
+          "direction": "inbound",
+          "_id": "59a861cbf64c3e0902d956e7",
+          "attachments": [
+            {
+              "contentType": "image/png",
+              "url": "http://placekitten.com/g/800/600"
+            }
+          ]
+        }
+      ],
+      "outbound": [
+        {
+          "__v": 0,
+          "updatedAt": "2017-08-31T19:21:47.597Z",
+          "createdAt": "2017-08-31T19:21:47.597Z",
+          "conversationId": "59a7203fc731160d31cfdad2",
+          "campaignId": 7656,
+          "topic": "campaign_7656",
+          "text": "Help us send letters of support to every mosque in the United States. \n\nWant to join Sincerely, Us?\n\nYes or No",
+          "template": "askSignupMessage",
+          "direction": "outbound-reply",
+          "_id": "59a861cbf64c3e0902d956e8",
+          "attachments": []
+        }
+      ]
+    }
   }
 }
 ```

--- a/lib/consolebot.js
+++ b/lib/consolebot.js
@@ -84,9 +84,9 @@ class Consolebot {
     this.prompt();
   }
   handleSuccess(res) {
-    const data = res.body.data;
-    if (data.outbound) {
-      return this.reply(data.outbound[0].text);
+    const messages = res.body.data.messages;
+    if (messages.outbound) {
+      return this.reply(messages.outbound[0].text);
     }
 
     return this.reply('');

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -145,7 +145,7 @@ function sendReply(req, res, messageText, messageTemplate) {
         signup: req.signup,
         messages: {
           inbound: [req.inboundMessage],
-          outbound: [req.conversation.lastOutboundMessage],         
+          outbound: [req.conversation.lastOutboundMessage],
         },
       };
 

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -141,13 +141,35 @@ function sendReply(req, res, messageText, messageTemplate) {
   return promise
     .then(() => {
       const data = {
-        inbound: [req.inboundMessage],
-        outbound: [req.conversation.lastOutboundMessage],
+        user: req.user,
+        signup: req.signup,
+        messages: {
+          inbound: [req.inboundMessage],
+          outbound: [req.conversation.lastOutboundMessage],         
+        },
       };
 
       return res.send({ data });
     })
     .catch(err => exports.sendErrorResponse(res, err));
+}
+
+/**
+ * @param {string} string
+ * @param {object} signup
+ * @return {string}
+ */
+function replaceQuantity(string, signup) {
+  let quantity = signup.totalQuantitySubmitted;
+  const draft = signup.draftReportbackSubmission;
+  if (draft) {
+    quantity = draft.quantity;
+  }
+
+  if (quantity) {
+    return string.replace(/{{quantity}}/gi, quantity);
+  }
+  return string;
 }
 
 /**
@@ -162,9 +184,13 @@ function sendReplyWithCampaignTemplate(req, res, messageTemplate) {
     return exports.sendErrorResponse(res, 'req.campaign undefined');
   }
 
-  const messageText = campaign.templates[messageTemplate];
+  let messageText = campaign.templates[messageTemplate];
   if (!messageText) {
     return exports.sendErrorResponse(res, `req.campaign.templates.${messageTemplate} undefined`);
+  }
+
+  if (req.signup) {
+    messageText = replaceQuantity(messageText, req.signup);
   }
 
   return sendReply(req, res, messageText, messageTemplate);
@@ -183,10 +209,9 @@ module.exports.continueCampaign = function (req, res) {
 
   return gambitCampaigns.postReceiveMessage(req)
     .then((gambitCampaignsRes) => {
-      const signup = gambitCampaignsRes.signup;
-      logger.debug('continueCampaign', { signupId: signup.id });
-      const reply = gambitCampaignsRes.reply;
-      return sendReply(req, res, reply.text, reply.template);
+      req.signup = gambitCampaignsRes.signup;
+      logger.debug('continueCampaign', { signupId: req.signup.id });
+      return sendReplyWithCampaignTemplate(req, res, gambitCampaignsRes.replyTemplate);
     })
     .catch(err => exports.sendErrorResponse(res, err));
 };

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -141,8 +141,7 @@ function sendReply(req, res, messageText, messageTemplate) {
   return promise
     .then(() => {
       const data = {
-        user: req.user,
-        signup: req.signup,
+        // TODO: Include User, Signup, Conversation properties.
         messages: {
           inbound: [req.inboundMessage],
           outbound: [req.conversation.lastOutboundMessage],


### PR DESCRIPTION
* Resolves #37: completes last task by using our Campaign model's template value instead of the  `body.data.reply.text` returned in a Gambit Campaigns `POST /receive-message` response


    * Replaces any `{{quantity}}` tags with the relevant quantity from the Gambit Campaigns `POST /receive-message` response `body.data.signup`


* Speaking of that `res.body.data.reply.text`, it's gone per API changes in https://github.com/DoSomething/gambit/pull/968. We now need to use the `res.body.data.replyTemplate`.


* For the Conversations `POST /receive-message` response:

    * Moves `inbound` and `outbound` properties to a `res.body.data.messages` property (instead of `res.body.data`)

    * Adds a TODO to include `res.body.data.user`, `res.body.data.signup`, `res.body.data.conversation`


TODO:
* [ ] Include User, Signup, and Conversation properties in our API responses
* [ ] Remove `v` properties, rename `_id` as `_id` per https://github.com/DoSomething/gambit/pull/967