### PR TITLE
Adds `broadcast-settings` route.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,8 @@ DS_GAMBIT_CAMPAIGNS_API_BASEURI=http://ds-mdata-responder-staging.herokuapp.com/
 DS_GAMBIT_CONVERSATIONS_API_BASIC_AUTH_NAME=puppet
 DS_GAMBIT_CONVERSATIONS_API_BASIC_AUTH_PASS=totallysecret
 
+DS_BLINK_SMS_BROADCAST_WEBHOOK_URL=http://localhost:5050/api/v1
+
 DS_NORTHSTAR_API_KEY=totallysecret
 DS_NORTHSTAR_API_BASEURI=https://northstar-slothbot4eva.dosomething.org/v1
 
@@ -16,6 +18,9 @@ SLACK_OAUTH_ACCESS_TOKEN=totallysecret
 TWILIO_ACCOUNT_SID=totallysecret
 TWILIO_AUTH_TOKEN=totallysecret
 TWILIO_MESSAGING_SERVICE_SID=totallysecret
+TWILIO_API_BASEURI=https://fakeapi.com
+TWILIO_BROADCASTS_REVOKABLE_API_SID=puppet
+TWILIO_BROADCASTS_REVOKABLE_API_SECRET=totallysecret
 
 FB_MESSENGER_VERIFY_TOKEN=totallysecret
 FB_PAGE_ACCESS_TOKEN=totallysecret

--- a/app/exceptions/NotFoundError.js
+++ b/app/exceptions/NotFoundError.js
@@ -1,0 +1,10 @@
+'use strict';
+
+class NotFoundError extends Error {
+  constructor(message) {
+    super(message);
+    this.status = 404;
+  }
+}
+
+module.exports = NotFoundError;

--- a/app/routes/broadcast-settings.js
+++ b/app/routes/broadcast-settings.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const express = require('express');
+
+const router = express.Router();
+
+// Middleware
+const broadcastMiddleware = require('../../lib/middleware/broadcast-settings/broadcast');
+const generateSettingsMiddleware = require('../../lib/middleware/broadcast-settings/settings');
+
+router.get('/:broadcastId',
+  broadcastMiddleware(),
+  generateSettingsMiddleware());
+
+module.exports = router;

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -5,6 +5,7 @@ const restify = require('express-restify-mongoose');
 const receiveMessageRoute = require('./receive-message');
 const sendMessageRoute = require('./send-message');
 const importMessageRoute = require('./import-message');
+const broadcastSettingsRoute = require('./broadcast-settings');
 
 // middleware
 const authenticateMiddleware = require('../../lib/middleware/authenticate');
@@ -37,6 +38,7 @@ module.exports = function init(app) {
   app.use(authenticateMiddleware());
   // parse metadata like requestId and retryCount for all requests after this line
   app.use(parseMetadataMiddleware());
+
   // receive-message route
   app.use('/api/v1/receive-message',
     receiveMessageRoute);
@@ -46,4 +48,7 @@ module.exports = function init(app) {
   // import-message route
   app.use('/api/v1/import-message',
     importMessageRoute);
+  // broadcast-settings route
+  app.use('/api/v1/broadcast-settings',
+    broadcastSettingsRoute);
 };

--- a/config/lib/helpers/broadcast.js
+++ b/config/lib/helpers/broadcast.js
@@ -1,0 +1,7 @@
+'use strict';
+
+module.exports = {
+  customerIo: {
+    userPhoneField: '{{customer.phone}}',
+  },
+};

--- a/config/lib/helpers/twilio.js
+++ b/config/lib/helpers/twilio.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const configVars = {};
+configVars.accountSid = process.env.TWILIO_ACCOUNT_SID || 'totallysecret';
+configVars.messageServiceSid = process.env.TWILIO_MESSAGING_SERVICE_SID || 'totallysecret';
+
+// Blink related
+configVars.blink = {};
+/**
+ * Our current smsBroadcastWebhook is setup in Blink
+ *
+ * Blink requires Basic Auth but it may not need it in the future.
+ * This can be easily managed without additional code by adding/removing
+ * the name:pass@ to the URL set in the .env file directly.
+ */
+configVars.blink.smsBroadcastWebhookUrl = process.env.DS_BLINK_SMS_BROADCAST_WEBHOOK_URL || 'http://localhost:5050/api/v1';
+
+// Twilio REST API related
+configVars.api = {};
+configVars.api.sid = process.env.TWILIO_BROADCASTS_REVOKABLE_API_SID || 'totallysecret';
+configVars.api.secret = process.env.TWILIO_BROADCASTS_REVOKABLE_API_SECRET || 'totallysecret';
+configVars.api.baseUri = process.env.TWILIO_API_BASEURI || 'https://fakeapi.com';
+configVars.api.authBaseUri = `${configVars.api.baseUri.replace('//', `//${configVars.api.sid}:${configVars.api.secret}@`)}`;
+configVars.api.messagesListResourceUri = `/2010-04-01/Accounts/${configVars.accountSid}/Messages.json`;
+module.exports = configVars;

--- a/config/lib/middleware/broadcast-settings/settings.js
+++ b/config/lib/middleware/broadcast-settings/settings.js
@@ -1,0 +1,7 @@
+'use strict';
+
+module.exports = {
+  customerIo: {
+    userPhoneField: '{{customer.phone}}',
+  },
+};

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -13,6 +13,7 @@ Endpoint | Functionality
 `POST /api/v1/receive-message` | [Receive an inbound Message, and send a reply Message.](endpoints/receive-message.md)
 `POST /api/v1/send-message` | [Send an outbound Message](endpoints/send-message.md).
 `POST /api/v1/import-message` | [Import an outbound Message](endpoints/import-message.md) that was sent on behalf of another service.
+`GET /api/v1/broadcast-settings` | [Get broadcast setup settings](endpoints/broadcast-settings.md)
 `GET /api/v1/conversations` | Retrieve all Conversations.
 `GET /api/v1/conversations/:id` | Retrieve a Conversation.
 `GET /api/v1/messages` | Retrieve all Messages.

--- a/documentation/authentication.md
+++ b/documentation/authentication.md
@@ -1,6 +1,6 @@
 # Authentication
 
-The `receive-message`, `import-message`, and `send-message` routes are protected by Basic Auth, using config vars:
+The `receive-message`, `import-message`, `send-message`, and `broadcast-settings` routes are protected by Basic Auth, using config vars:
 * `DS_GAMBIT_CONVERSATIONS_API_BASIC_AUTH_NAME`
 * `DS_GAMBIT_CONVERSATIONS_API_BASIC_AUTH_PASS`
 

--- a/documentation/endpoints/broadcast-settings.md
+++ b/documentation/endpoints/broadcast-settings.md
@@ -1,0 +1,56 @@
+# Broadcast Settings
+
+```
+GET /api/v1/broadcast-settings/<broadcastId>
+```
+Returns the settings necessary to setup a Customer.io Triggered Campaign **after** the broadcast is created in Contentful.
+
+## Authentication
+
+The endpoint expects you to use [Basic Auth](../authentication.md). Example url using the browser: `http://protectedName:protectedPass@localhost:5100/api/v1/broadcast-settings/100`
+
+## Examples
+
+
+<details>
+<summary><strong>Example Request</strong></summary>
+
+GET settings for the broadcastId: `tacosfest`.
+
+```
+curl -X "GET" "http://localhost:5100/api/v1/broadcast-settings/tacosfest" \
+     -H "Authorization: Basic cHVwcGV0OnRvdGFsbHlzZWNyZXQ="
+```
+</details>
+
+<details>
+<summary><strong>Example Response</strong></summary>
+
+```
+{
+  "broadcast": {
+    "broadcastId": "tacosfest",
+    "message": "hola, you are invited to the best tacos festival in the whole world.",
+    "declinedMessage": "nope"
+  },
+  "campaign": {
+    "campaignId": "48"
+  },
+  "webhook": {
+    "url": "https://SKXX:wtXX@api.twilio.com/2010-04-01/Accounts/ACXX/Messages.json",
+    "headers": {
+      "Content-Type": "application/x-www-form-urlencoded"
+    },
+    "body": "To={{customer.phone}}&Body=hola, you are invited to the best tacos festival in the whole world.&MessagingServiceSid=MGXX&StatusCallback=https%3A%2F%2Fpuppet%3Atotallysecret%4057528dc6.ngrok.io%2Fapi%2Fv1%2Fimport-message%3FbroadcastId%3Dtacosfest"
+  }
+}
+```
+</details>
+
+## Troubleshooting
+
+Error | Meaning
+--- | ---
+Cannot GET `/api/v1/broadcast-settings` | Missing broadcastId in the URL
+Broadcast **X** not found. | broadcastId was not found in Contentful. Is it published?
+Broadcast misconfigured. Message is required! | Broadcast `message` field is empty in Contentful. Is this an old broadcast? Customer.io broadcasts expect the copy to exist in Contentful.

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -8,6 +8,7 @@ const gambitCampaigns = require('./gambit-campaigns');
 const config = require('../config/lib/helpers');
 const helpers = require('./helpers/index');
 const Message = require('../app/models/Message');
+const NotFoundError = require('../app/exceptions/NotFoundError');
 
 // TODO: Move contents of this helper.js file into lib/helpers/index.js or to modular helpers
 
@@ -294,13 +295,15 @@ module.exports.subscriptionStatusStop = function (req, res) {
  * @return {Promise}
  */
 module.exports.getBroadcast = function getBroadcast(req, res) {
-  return contentful.fetchBroadcast(req.broadcastId)
-    .then((broadcast) => {
-      if (!broadcast) {
-        return exports.sendResponseWithStatusCode(res, 404, `Broadcast ${req.broadcast_id} not found.`);
-      }
-
-      return broadcast;
-    })
-    .catch(err => exports.sendErrorResponse(res, err));
+  return new Promise((resolve, reject) => {
+    contentful.fetchBroadcast(req.broadcastId)
+      .then((broadcast) => {
+        if (!broadcast) {
+          const error = new NotFoundError(`Broadcast ${req.broadcastId} not found.`);
+          return reject(error);
+        }
+        return resolve(broadcast);
+      })
+      .catch(err => exports.sendErrorResponse(res, err));
+  });
 };

--- a/lib/helpers/broadcast.js
+++ b/lib/helpers/broadcast.js
@@ -1,7 +1,28 @@
 'use strict';
 
+const underscore = require('underscore');
+
+const config = require('../../config/lib/helpers/broadcast');
+const twilio = require('./twilio');
+
 function getBroadcastId(req) {
   return req.body.broadcastId || req.query.broadcastId;
+}
+/**
+ * getWebhookBody
+ *
+ * @param  {string} message        The content the user will receive
+ * @param  {string} broadcastId The broadcastId associated with this message
+ * @return {string}             The body of the POST request to Twilio as a string
+ * @see https://www.twilio.com/docs/api/messaging/send-messages
+ */
+function getWebhookBody(message, broadcastId) {
+  const tokens = [];
+  tokens.push(`To=${config.customerIo.userPhoneField}`);
+  tokens.push(`Body=${message}`);
+  tokens.push(`MessagingServiceSid=${twilio.getMessageServiceSid()}`);
+  tokens.push(`StatusCallback=${twilio.getStatusCallbackUrl(broadcastId)}`);
+  return tokens.join('&');
 }
 
 /**
@@ -16,5 +37,18 @@ module.exports = {
    */
   parseBody: function parseBody(req) {
     req.broadcastId = getBroadcastId(req);
+  },
+  getSettings: function getSettings(broadcastObject, broadcastId) {
+    return {
+      broadcast: underscore.omit(broadcastObject.fields, ['campaign']),
+      campaign: broadcastObject.fields.campaign.fields,
+      webhook: {
+        url: twilio.getMessagesListResourceUrl(),
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+        body: getWebhookBody(broadcastObject.fields.message, broadcastId),
+      },
+    };
   },
 };

--- a/lib/helpers/index.js
+++ b/lib/helpers/index.js
@@ -7,6 +7,7 @@ const slack = require('./slack');
 const request = require('./request');
 const broadcast = require('./broadcast');
 
+// TODO: Add "Helper" postfix to prevent name confusion with npm modules like twilio.
 module.exports = {
   attachments,
   twilio,

--- a/lib/helpers/twilio.js
+++ b/lib/helpers/twilio.js
@@ -5,6 +5,7 @@ const Promise = require('bluebird');
 const request = require('request-promise');
 
 const attachments = require('./attachments');
+const config = require('../../config/lib/helpers/twilio');
 
 /**
  * Twilio helper
@@ -89,5 +90,15 @@ module.exports = {
         }
         return url;
       });
+  },
+  getMessageServiceSid: function getMessageServiceSid() {
+    return config.messageServiceSid;
+  },
+  getStatusCallbackUrl: function getStatusCallbackUrl(broadcastId, encoded = true) {
+    const url = `${config.blink.smsBroadcastWebhookUrl}?broadcastId=${broadcastId}`;
+    return encoded ? encodeURIComponent(url) : url;
+  },
+  getMessagesListResourceUrl: function getMessagesListResourceUrl() {
+    return `${config.api.authBaseUri}${config.api.messagesListResourceUri}`;
   },
 };

--- a/lib/middleware/broadcast-settings/broadcast.js
+++ b/lib/middleware/broadcast-settings/broadcast.js
@@ -1,0 +1,33 @@
+'use strict';
+
+const logger = require('heroku-logger');
+
+const helpers = require('../../helpers');
+const UnprocessibleEntityError = require('../../../app/exceptions/UnprocessibleEntityError');
+
+function isMessageEmpty(broadcast) {
+  if (typeof broadcast.fields.message !== 'string') {
+    return true;
+  }
+  return !broadcast.fields.message.trim();
+}
+
+module.exports = function getBroadcast() {
+  return (req, res, next) => {
+    logger.info(`Searching for Broadcast: ${req.params.broadcastId}`);
+
+    req.broadcastId = req.params.broadcastId;
+
+    return helpers.getBroadcast(req, res)
+      .then((broadcast) => {
+        // We should never be able to send an empty message to users.
+        if (isMessageEmpty(broadcast)) {
+          const error = new UnprocessibleEntityError('Broadcast misconfigured. Message field is required!');
+          return helpers.sendErrorResponse(res, error);
+        }
+        req.broadcastObject = broadcast;
+        return next();
+      })
+      .catch(err => helpers.sendErrorResponse(res, err));
+  };
+};

--- a/lib/middleware/broadcast-settings/settings.js
+++ b/lib/middleware/broadcast-settings/settings.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const logger = require('heroku-logger');
+
+const helpers = require('../../helpers');
+
+module.exports = function getSettings() {
+  return (req, res) => {
+    logger.debug(`Generating settings for Broadcast: ${req.params.broadcastId}`);
+    let settings;
+    try {
+      settings = helpers.broadcast.getSettings(req.broadcastObject, req.broadcastId);
+    } catch (error) {
+      return helpers.sendErrorResponse(res, error);
+    }
+    return res.send(settings);
+  };
+};


### PR DESCRIPTION
## Summary
This is a medium size PR.

It adds a new protected route to get the Customer.io Webhook setup settings for the given `broadcastId`.

## How to test
GET settings for the broadcastId: `tacosfest`.

```
curl -X "GET" "http://localhost:5100/api/v1/broadcast-settings/tacosfest" \
     -H "Authorization: Basic cHVwcGV0OnRvdGFsbHlzZWNyZXQ="
```
> You might need to change the Authorization header's value.

## Relevant Issues
Fixes #142
Adds more documentation for #123 

## Tasks
- [x] Update LastPass `Gambit-conversations-env-keys` secured note with new env variable values.
- [x] Update Heroku with env variables. 