### PR TITLE
encode characters '!()* in statusCallback URI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,7 @@ DS_GAMBIT_CAMPAIGNS_API_BASEURI=http://ds-mdata-responder-staging.herokuapp.com/
 DS_GAMBIT_CONVERSATIONS_API_BASIC_AUTH_NAME=puppet
 DS_GAMBIT_CONVERSATIONS_API_BASIC_AUTH_PASS=totallysecret
 
-DS_BLINK_SMS_BROADCAST_WEBHOOK_URL=http://localhost:5050/api/v1
+DS_BLINK_SMS_BROADCAST_WEBHOOK_URL=http://puppet:totallysecret@localhost:5050/api/v1
 
 DS_NORTHSTAR_API_KEY=totallysecret
 DS_NORTHSTAR_API_BASEURI=https://northstar-slothbot4eva.dosomething.org/v1

--- a/lib/helpers/twilio.js
+++ b/lib/helpers/twilio.js
@@ -12,8 +12,8 @@ const config = require('../../config/lib/helpers/twilio');
  * fixedEncodeURIComponent - A more strict implementation of
  * RFC 3986 (which reserves !, ', (, ), and *) when URI encoding
  *
- * @param  {type} str description
- * @return {type}     description
+ * @param  {type} str string to be encoded
+ * @return {type}     URI encoded string
  * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent
  */
 function fixedEncodeURIComponent(str) {

--- a/lib/helpers/twilio.js
+++ b/lib/helpers/twilio.js
@@ -7,6 +7,19 @@ const request = require('request-promise');
 const attachments = require('./attachments');
 const config = require('../../config/lib/helpers/twilio');
 
+
+/**
+ * fixedEncodeURIComponent - A more strict implementation of
+ * RFC 3986 (which reserves !, ', (, ), and *) when URI encoding
+ *
+ * @param  {type} str description
+ * @return {type}     description
+ * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent
+ */
+function fixedEncodeURIComponent(str) {
+  return encodeURIComponent(str).replace(/[!'()*]/g, char => `%${char.charCodeAt(0).toString(16)}`);
+}
+
 /**
  * Twilio helper
  */
@@ -96,7 +109,7 @@ module.exports = {
   },
   getStatusCallbackUrl: function getStatusCallbackUrl(broadcastId, encoded = true) {
     const url = `${config.blink.smsBroadcastWebhookUrl}?broadcastId=${broadcastId}`;
-    return encoded ? encodeURIComponent(url) : url;
+    return encoded ? fixedEncodeURIComponent(url) : url;
   },
   getMessagesListResourceUrl: function getMessagesListResourceUrl() {
     return `${config.api.authBaseUri}${config.api.messagesListResourceUri}`;


### PR DESCRIPTION
## Summary
Fixes statusCallback URI triggering [invalid-statuscallback-url 21609](https://www.twilio.com/docs/api/errors/21609#invalid-statuscallback-url) Twilio errors. Implements a more stringent form of `encodeURIComponent` suggested in [MDN Docs for encodeURIComponent](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent).