### PR TITLE
Route `send-message` queries Northstar when a `northstarId` is passed instead of a `mobile`.

### DIFF
--- a/app/models/Conversation.js
+++ b/app/models/Conversation.js
@@ -310,6 +310,7 @@ conversationSchema.methods.getNorthstarUser = function () {
  * @return {Promise}
  */
 conversationSchema.methods.createNorthstarUser = function () {
+  // TODO: return promise! Or risk getting "TypeError: Cannot read property 'then' of null"
   // For now, we only need to support creating new Users by a mobile number.
   if (this.platform === 'sms' || this.platform === 'api') {
     return northstar.createUserForMobile(this.platformUserId);

--- a/app/routes/send-message.js
+++ b/app/routes/send-message.js
@@ -10,6 +10,7 @@ const outboundMessageConfig = require('../../config/lib/middleware/send-message/
 // Middleware
 const supportParamsMiddleware = require('../../lib/middleware/send-message/params-support');
 const campaignParamsMiddleware = require('../../lib/middleware/send-message/params-campaign');
+const getUserMiddleware = require('../../lib/middleware/send-message/user-get');
 const getConversationMiddleware = require('../../lib/middleware/conversation-get');
 const createConversationMiddleware = require('../../lib/middleware/conversation-create');
 const campaignMiddleware = require('../../lib/middleware/send-message/campaign');
@@ -19,6 +20,9 @@ const createOutboundMessageMiddleware = require('../../lib/middleware/message-ou
 
 router.use(supportParamsMiddleware());
 router.use(campaignParamsMiddleware());
+
+// Fetch Northstar User.
+router.use(getUserMiddleware());
 
 router.use(getConversationMiddleware());
 router.use(createConversationMiddleware());

--- a/documentation/endpoints/send-message.md
+++ b/documentation/endpoints/send-message.md
@@ -7,7 +7,7 @@ Sends either a Support or Campaign outbound message in a Conversation.
 
 ## Support
 
-Sending Support messages requires a `x-front-signature` header. See [Support wiki](https://github.com/DoSomething/gambit-conversations/wiki/Support). 
+Sending Support messages requires a `x-front-signature` header. See [Support wiki](https://github.com/DoSomething/gambit-conversations/wiki/Support).
 
 ## Campaign
 
@@ -21,20 +21,20 @@ Supported templates:
 
 Name | Type | Description
 --- | --- | ---
-`mobile` | `string` | Mobile number of User to send outbound message to
+`mobile` or `northstarId` | `string` | Mobile number or Northstar id of User to send outbound message to
 `slackId` | `string` | Slack Id of User to send outbound message to
 `campaignId` | `number` | Campaign Id of outbound message
 `template` | `string` | Campaign message template to send
 
 <details>
-<summary><strong>Example Response</strong></summary>
+<summary><strong>Example Request using User's mobile phone</strong></summary>
 
 ```
 curl -X "POST" "http://localhost:5100/api/v1/send-message" \
      -H "Content-Type: application/json; charset=utf-8" \
      -u puppet:totallysecret \
      -d $'{
-  "phone": "+15555550750",
+  "mobile": "+15555550750",
   "campaignId": "48",
   "template": "externalSignupMenu"
 }'
@@ -51,16 +51,62 @@ curl -X "POST" "http://localhost:5100/api/v1/send-message" \
   "data": {
     "messages": [
       {
-        "__v": 0,
-        "updatedAt": "2017-08-31T19:07:02.312Z",
-        "createdAt": "2017-08-31T19:07:02.312Z",
-        "conversationId": "59a5c175717a2f25fc628811",
-        "campaignId": 7,
-        "topic": "campaign",
-        "text": "Hey - this is Freddie from DoSomething. Thanks for joining a movement to spread positivity in school. You can do something simple to make a big impact for a stranger.\n\nLet's do this: post encouraging notes in places that can trigger low self-esteem, like school bathrooms.\n\nThen, text START to share a photo of the messages you posted (and you'll be entered to win a $1000 scholarship)!",
-        "template": "externalSignupMenuMessage",
+        "_id": "59d552716dc3ceaee1fbaf78",
+        "updatedAt": "2017-10-04T21:28:17.472Z",
+        "createdAt": "2017-10-04T21:28:17.472Z",
+        "text": "Hey - this is Freddie from DoSomething. Thanks for joining Pride Over Prejudice!\n\nA new White House executive order denies all new refugees entry to the US for 120 days and places a 90-day travel ban on six Muslim-majority nations.\n\nThe solution is simple: Post a selfie to stand in solidarity with refugees and immigrants.\n\nMake sure to take a photo of what you did! When you have Shared some Pictures, text START to share your photo.",
         "direction": "outbound-api-send",
-        "_id": "59a85e56d975b4080974ab2d",
+        "template": "externalSignupMenu",
+        "conversationId": "59c41ce4675e5b3497f606c0",
+        "campaignId": 48,
+        "topic": "campaign",
+        "broadcastId": null,
+        "__v": 0,
+        "attachments": []
+      }
+    ]
+  }
+}
+```
+
+</details>
+
+<details>
+<summary><strong>Example Request using User's Northstar id</strong></summary>
+
+```
+curl -X "POST" "http://localhost:5100/api/v1/send-message" \
+     -H "Content-Type: application/json; charset=utf-8" \
+     -u puppet:totallysecret \
+     -d $'{
+  "northstarId": "59c41ce4675e05b3497f606c0",
+  "campaignId": "48",
+  "template": "externalSignupMenu"
+}'
+```
+
+</details>
+
+
+<details>
+<summary><strong>Example Response</strong></summary>
+
+```
+{
+  "data": {
+    "messages": [
+      {
+        "_id": "59d552716dc3ceaee1fbaf78",
+        "updatedAt": "2017-10-04T21:28:17.472Z",
+        "createdAt": "2017-10-04T21:28:17.472Z",
+        "text": "Hey - this is Freddie from DoSomething. Thanks for joining Pride Over Prejudice!\n\nA new White House executive order denies all new refugees entry to the US for 120 days and places a 90-day travel ban on six Muslim-majority nations.\n\nThe solution is simple: Post a selfie to stand in solidarity with refugees and immigrants.\n\nMake sure to take a photo of what you did! When you have Shared some Pictures, text START to share your photo.",
+        "direction": "outbound-api-send",
+        "template": "externalSignupMenu",
+        "conversationId": "59c41ce4675e5b3497f606c0",
+        "campaignId": 48,
+        "topic": "campaign",
+        "broadcastId": null,
+        "__v": 0,
         "attachments": []
       }
     ]

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -2,6 +2,7 @@
 
 const logger = require('heroku-logger');
 const Promise = require('bluebird');
+const { PhoneNumberFormat, PhoneNumberUtil } = require('google-libphonenumber');
 
 const contentful = require('./contentful');
 const gambitCampaigns = require('./gambit-campaigns');
@@ -306,4 +307,10 @@ module.exports.getBroadcast = function getBroadcast(req, res) {
       })
       .catch(err => exports.sendErrorResponse(res, err));
   });
+};
+
+module.exports.formatMobileNumber = function formatMobileNumber(mobile, format = 'E164', countryCode = 'US') {
+  const phoneUtil = PhoneNumberUtil.getInstance();
+  const phoneNumberObject = phoneUtil.parse(mobile, countryCode);
+  return phoneUtil.format(phoneNumberObject, PhoneNumberFormat[format]);
 };

--- a/lib/middleware/send-message/params-campaign.js
+++ b/lib/middleware/send-message/params-campaign.js
@@ -31,6 +31,13 @@ module.exports = function campaignParams() {
       return next();
     }
 
+    if (body.northstarId) {
+      req.userId = body.northstarId;
+      req.platform = 'sms';
+
+      return next();
+    }
+
     if (body.slackId) {
       req.platform = 'slack';
       req.platformUserId = body.slackId;

--- a/lib/middleware/send-message/user-get.js
+++ b/lib/middleware/send-message/user-get.js
@@ -1,0 +1,37 @@
+'use strict';
+
+const logger = require('heroku-logger');
+
+const helpers = require('../../helpers');
+const northstar = require('../../northstar');
+const NotFoundError = require('../../../app/exceptions/NotFoundError');
+
+module.exports = function getNorthstarUser() {
+  return (req, res, next) => {
+    if (!req.userId) {
+      return next();
+    }
+    return northstar.fetchUserById(req.userId)
+      .then((user) => {
+        try {
+          /**
+           * Phone number in Northstar profile is not guaranteed to be returned in E.164 format?
+           * Mobile returned from a Northstar-thor user was not E.164 compliant
+           */
+          req.platformUserId = helpers.formatMobileNumber(user.mobile);
+        } catch (error) {
+          logger.error('getNorthstarUser: Fatal error formatting Northstar user\'s mobile.');
+          return helpers.sendErrorResponse(res, error);
+        }
+        return next();
+      })
+      .catch((err) => {
+        if (err && err.status === 404) {
+          const error = new NotFoundError('Northstar user not found.');
+          return helpers.sendErrorResponse(res, error);
+        }
+
+        return helpers.sendErrorResponse(res, err);
+      });
+  };
+};

--- a/lib/northstar.js
+++ b/lib/northstar.js
@@ -80,6 +80,16 @@ module.exports.createUserForMobile = function (mobile) {
 };
 
 /**
+ * @param {string} id The Northstar id for this user
+ * @return {Promise}
+ */
+module.exports.fetchUserById = function (id) {
+  logger.debug('fetchUserById', { id });
+
+  return exports.getClient().Users.get('id', id);
+};
+
+/**
  * @param {string} email
  * @return {Promise}
  */

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "express": "^4.15.3",
     "express-restify-mongoose": "^4.1.3",
     "fb": "^2.0.0",
+    "google-libphonenumber": "^3.0.5",
     "heroku-logger": "^0.1.1",
     "mongoose": "^4.10.6",
     "newrelic": "^2.0.2",


### PR DESCRIPTION
## Summary
This PR adds a middleware named `user-get` to the `send-message` route. When a POST request is made to this route, containing a `northstarId`, the middleware queries Northstar by this id. It parses out the mobile number and stores it as the `req.platformUserId` in the request object.

If the user is not found. The route responds with a 404 error.

Few things to note:
- There is room for growth in this route based on the conversation inside this issue #154. Let's keep it in mind for when we come back and cleanup/refactor parts of the Conversations API after launch.
- I left the ability to send a message by receiving only a `mobile` number. This is based on the last conversation we had about relative reminder messages potentially being sent from Customer.io.

## Tasks
- [x] Implement lookup to NS when a `northstarId` is sent.
- [x] Update documentation.

## Relevant Issues
Fixes #154 