### PR TITLE
Fixes Relay of Blink suppress headers and unrejected error in Conversations.

### DIFF
--- a/config/lib/helpers.js
+++ b/config/lib/helpers.js
@@ -45,4 +45,5 @@ module.exports = {
     less: 'less',
     stop: 'undeliverable',
   },
+  blinkSupressHeaders: 'x-blink-retry-suppress',
 };

--- a/lib/gambit-campaigns.js
+++ b/lib/gambit-campaigns.js
@@ -63,6 +63,9 @@ module.exports.postReceiveMessage = function (req) {
         logger.trace(`${loggerMessage} res.data`, res.data);
         return resolve(res.data);
       })
-      .catch(err => reject(err));
+      .catch((err, res) => {
+        logger.debug('headers:', res ? res.headers : 'no headers here dummy.');
+        return reject(err);
+      });
   });
 };

--- a/lib/gambit-campaigns.js
+++ b/lib/gambit-campaigns.js
@@ -22,7 +22,7 @@ module.exports.post = function (endpoint, data) {
     .set('x-gambit-api-key', apiKey)
     .send(data)
     .then(res => res.body)
-    .catch(err => err);
+    .catch(err => Promise.reject(err));
 };
 
 module.exports.getActiveCampaigns = function () {
@@ -63,9 +63,6 @@ module.exports.postReceiveMessage = function (req) {
         logger.trace(`${loggerMessage} res.data`, res.data);
         return resolve(res.data);
       })
-      .catch((err, res) => {
-        logger.debug('headers:', res ? res.headers : 'no headers here dummy.');
-        return reject(err);
-      });
+      .catch(err => reject(err));
   });
 };

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -90,6 +90,11 @@ module.exports.sendErrorResponse = function (res, err) {
   if (!message) {
     message = err;
   }
+
+  if (err.response && err.response.get(config.blinkSupressHeaders)) {
+    exports.addBlinkSuppressHeaders(res);
+  }
+
   return this.sendResponseWithStatusCode(res, status, message);
 };
 
@@ -306,4 +311,15 @@ module.exports.getBroadcast = function getBroadcast(req, res) {
       })
       .catch(err => exports.sendErrorResponse(res, err));
   });
+};
+
+/**
+ * addBlinkSuppressHeaders
+ *
+ * @param  {object} res The response object
+ * @return {object}     Response
+ */
+module.exports.addBlinkSuppressHeaders = function addBlinkSuppressHeaders(res) {
+  logger.trace('Adding Blink supress headers');
+  return res.setHeader('x-blink-retry-suppress', true);
 };

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -92,6 +92,11 @@ module.exports.sendErrorResponse = function (res, err) {
     message = err;
   }
 
+  /**
+   * If the error has a response and the response contain the Blink Suppress headers,
+   * this error is being relayed to Blink from Campaigns. We have to also relay the Suppress
+   * headers.
+   */
   if (err.response && err.response.get(config.blinkSupressHeaders)) {
     exports.addBlinkSuppressHeaders(res);
   }


### PR DESCRIPTION
## BUG
Rejects the error when receiving an error from Campaigns. Also relays the Blink suppress headers from Campaigns to Blink to prevent unwanted retries.

## How should it be tested
- 👀 

## Related issues
Fixes #156