### PR TITLE
Returns helpers.campaignClosed if keyword campaign is closed

### DIFF
--- a/lib/middleware/receive-message/campaign-keyword.js
+++ b/lib/middleware/receive-message/campaign-keyword.js
@@ -27,6 +27,10 @@ module.exports = function getCampaignForKeyword() {
           return next();
         }
 
+        if (req.campaign.isClosed) {
+          return helpers.campaignClosed(req, res);
+        }
+
         return helpers.continueCampaign(req, res);
       })
       .catch(err => helpers.sendErrorResponse(res, err));


### PR DESCRIPTION
Fixes bug opened in https://github.com/DoSomething/gambit/issues/978, although Gambit Campaigns could use the check to avoid the undefined `draft_reportback_submission` error.

The existing Campaign Closed middleware is checking for when we're loading the Campaign stored on a Conversation: https://github.com/DoSomething/gambit-conversations/blob/0.5.0/lib/middleware/receive-message/campaign-closed.js#L11. When we're sent a keyword, we send the message directly to Gambit Campaigns without checking if it's closed.