### PR TITLE
Send suppress Blink headers when user has no valid phone number.

### DIFF
--- a/lib/middleware/send-message/user-get.js
+++ b/lib/middleware/send-message/user-get.js
@@ -20,6 +20,7 @@ module.exports = function getNorthstarUser() {
            */
           req.platformUserId = helpers.formatMobileNumber(user.mobile);
         } catch (error) {
+          helpers.addBlinkSuppressHeaders(res);
           logger.error('getNorthstarUser: Fatal error formatting Northstar user\'s mobile.');
           return helpers.sendErrorResponse(res, error);
         }
@@ -27,6 +28,7 @@ module.exports = function getNorthstarUser() {
       })
       .catch((err) => {
         if (err && err.status === 404) {
+          helpers.addBlinkSuppressHeaders(res);
           const error = new NotFoundError('Northstar user not found.');
           return helpers.sendErrorResponse(res, error);
         }


### PR DESCRIPTION
# What does this PR do?
It adds the `x-blink-retry-suppress` headers to the error response to Blink when the user's Northstar profile:
- Is not found.
- Lacks a valid phone number.

# How to review
- 👀 
- send a message using an invalid Northstar Id. The error response should include the suppress headers.
- send a message using a valid Northstar id of an user with no phone number. The error response should include the suppress headers.

# Relevant tickets
Fixes #162 