### PR TITLE
Revert "Set req.userCommand in params"

### DIFF
--- a/lib/middleware/receive-message/message-inbound-create.js
+++ b/lib/middleware/receive-message/message-inbound-create.js
@@ -9,6 +9,11 @@ module.exports = function createInboundMessage() {
       return next();
     }
 
+    // TODO: This should be moved to receive-message/params middleware
+    if (req.inboundMessageText) {
+      req.userCommand = req.inboundMessageText.trim();
+    }
+
     return req.conversation.createMessage('inbound', req.inboundMessageText, null, req)
       .then((message) => {
         req.inboundMessage = message;

--- a/lib/middleware/receive-message/params.js
+++ b/lib/middleware/receive-message/params.js
@@ -43,10 +43,6 @@ module.exports = function params() {
       helpers.attachments.add(req, attachmentObject, 'inbound');
     }
 
-    if (req.inboundMessageText) {
-      req.userCommand = req.inboundMessageText.trim();
-    }
-
     return next();
   };
 };


### PR DESCRIPTION
This reverts commit 84ac348a3e421fe1059d63130b0181197b235ce5 in #174 

Keywords were working for Consolebot, but not for Slack or SMS. Not sure why this fixes yet 