### PR TITLE
Campaign Member Support template

### DIFF
--- a/app/routes/receive-message.js
+++ b/app/routes/receive-message.js
@@ -23,6 +23,7 @@ const forwardSupportMessageMiddleware = require('../../lib/middleware/receive-me
 const campaignMenuMiddleware = require('../../lib/middleware/receive-message/campaign-menu');
 const currentCampaignMiddleware = require('../../lib/middleware/receive-message/campaign-current');
 const closedCampaignMiddleware = require('../../lib/middleware/receive-message/campaign-closed');
+const noCampaignTemplateMiddleware = require('../../lib/middleware/receive-message/template-no-campaign');
 const parseAskSignupMiddleware = require('../../lib/middleware/receive-message/parse-ask-signup-answer');
 const parseAskContinueMiddleware = require('../../lib/middleware/receive-message/parse-ask-continue-answer');
 const continueCampaignMiddleware = require('../../lib/middleware/receive-message/campaign-continue');
@@ -75,7 +76,10 @@ router.use(currentCampaignMiddleware());
 // If QUESTION keyword, pause Conversation and prompt User to send their support question.
 router.use(supportRequestedMiddleware());
 
-// Make sure Campaign isn't closed.
+// Checks if a Campaign has been set.
+router.use(noCampaignTemplateMiddleware());
+
+// Checks that Campaign isn't closed.
 router.use(closedCampaignMiddleware());
 
 // Check for yes/no/invalid responses to sent Ask Signup/Continue messages:

--- a/app/routes/receive-message.js
+++ b/app/routes/receive-message.js
@@ -56,9 +56,6 @@ router.use(infoTemplateMiddleware());
 // If MENU keyword, set random Campaign and ask for Signup.
 router.use(campaignMenuMiddleware());
 
-// If QUESTION keyword, pause Conversation and prompt User to send their support question.
-router.use(supportRequestedMiddleware());
-
 // If Campaign keyword was sent, update Conversation campaign and send continueCampaign.
 router.use(campaignKeywordMiddleware());
 
@@ -74,6 +71,9 @@ router.use(rivescriptTemplateMiddleware());
 
 // Otherwise, load the Campaign stored on the Conversation.
 router.use(currentCampaignMiddleware());
+
+// If QUESTION keyword, pause Conversation and prompt User to send their support question.
+router.use(supportRequestedMiddleware());
 
 // Make sure Campaign isn't closed.
 router.use(closedCampaignMiddleware());

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -324,6 +324,9 @@ module.exports.subscriptionStatusStop = function (req, res) {
 };
 
 module.exports.supportRequested = function (req, res) {
+  if (req.campaign) {
+    return sendReplyWithCampaignTemplate(req, res, 'memberSupport');
+  }
   return sendGambitConversationsTemplate(req, res, 'supportRequested');
 };
 

--- a/lib/middleware/receive-message/campaign-continue.js
+++ b/lib/middleware/receive-message/campaign-continue.js
@@ -8,7 +8,7 @@ module.exports = function askContinueTemplate() {
       return helpers.continueCampaign(req, res);
     }
 
-    // If we're here, we may have a non-Campaign topic set. 
+    // If we're here, we may have a non-Campaign topic set.
     // Set Campaign to update Conversation topic for confirmedCampaign, declinedCampaign macros.
     return req.conversation.setCampaignTopic()
       // TODO: If Conversation.signupStatus is 'declined', we shouldn't keep asking to continue

--- a/lib/middleware/receive-message/campaign-current.js
+++ b/lib/middleware/receive-message/campaign-current.js
@@ -13,18 +13,12 @@ module.exports = function getCurrentCampaign() {
 
     const campaignId = req.conversation.campaignId;
     logger.debug('getCurrentCampaign', { campaignId });
-
-    // If no Campaign has been set, User has never signed up for a Campaign.
     if (!campaignId) {
-      return helpers.noCampaign(req, res);
+      return next();
     }
 
     return gambitCampaigns.getCampaignById(campaignId)
       .then((campaign) => {
-        if (!campaign) {
-          return helpers.noCampaign(req, res);
-        }
-
         req.campaign = campaign;
 
         return next();

--- a/lib/middleware/receive-message/template-no-campaign.js
+++ b/lib/middleware/receive-message/template-no-campaign.js
@@ -1,0 +1,13 @@
+'use strict';
+
+const helpers = require('../../helpers');
+
+module.exports = function sendNoCampaignMessage() {
+  return (req, res, next) => {
+    if (req.campaign) {
+      return next();
+    }
+
+    return helpers.noCampaign(req, res);
+  };
+};


### PR DESCRIPTION
Closes #192 

Test: Run Consolebot with a new user.
* Send Q - verify the hardcoded `memberSupportRequested` message is returned
* Send a keyword, e.g. `tuskbot`
* Send Q - verify the Campaign's `memberSupport` template is returned