### PR TITLE
Uri encode message sent to user, preserving Liquid tags syntax

### DIFF
--- a/lib/helpers/broadcast.js
+++ b/lib/helpers/broadcast.js
@@ -24,6 +24,42 @@ function getUserPhoneField(req) {
   }
   return mobile;
 }
+
+/**
+ * encodeBody - It preserves Liquid tags integrity while uri encoding all characters included
+ *              in the native encodeURIComponent implementation
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent
+ * @param  {string} text
+ * @return {string}
+ */
+function encodeBody(text) {
+  let parsedText = text;
+  let uriEncodedText = '';
+
+  // Find all Liquid tags in the text
+  const liquidTags = parsedText.match(/(?:{|{{)[^{]+(?:}|}})/g);
+
+  // If no Liquid tags found just return uri encoded text
+  if (!liquidTags) {
+    return encodeURIComponent(parsedText);
+  }
+
+  // use placeholders prior to uri encode all text
+  liquidTags.forEach((tag, idx) => {
+    parsedText = parsedText.replace(tag, `___tag${idx}___`);
+  });
+
+  // uri encode
+  uriEncodedText = encodeURIComponent(parsedText);
+
+  // Replace placeholders with matched Liquid tags
+  liquidTags.forEach((tag, idx) => {
+    uriEncodedText = uriEncodedText.replace(`___tag${idx}___`, tag);
+  });
+
+  return uriEncodedText;
+}
 /**
  * getWebhookBody
  *
@@ -35,7 +71,7 @@ function getUserPhoneField(req) {
 function getWebhookBody(req) {
   const tokens = [];
   tokens.push(`To=${req.userPhoneField || config.customerIo.userPhoneField}`);
-  tokens.push(`Body=${req.broadcastObject.fields.message}`);
+  tokens.push(`Body=${encodeBody(req.broadcastObject.fields.message)}`);
 
   if (req.useTwilioTestCredentials) {
     tokens.push(`From=${config.twilio.testCredentialsFromNumber}`);

--- a/lib/middleware/receive-message/campaign-continue.js
+++ b/lib/middleware/receive-message/campaign-continue.js
@@ -8,7 +8,7 @@ module.exports = function askContinueTemplate() {
       return helpers.continueCampaign(req, res);
     }
 
-    // If we're here, we may have a non-Campaign topic set. 
+    // If we're here, we may have a non-Campaign topic set.
     // Set Campaign to update Conversation topic for confirmedCampaign, declinedCampaign macros.
     return req.conversation.setCampaignTopic()
       // TODO: If Conversation.signupStatus is 'declined', we shouldn't keep asking to continue


### PR DESCRIPTION
# What does this PR do?
It uri encodes the text sent to the user and preserves Liquid tags. It allows formatting of text and offending characters to be preserved while being transported via query parameters to Twilio. Twilio decodes this message and renders the text with the intended formatting and characters.

# How to test?
- Create/Edit a broadcast in Contentful to contain Liquid tags logic and/or templating.
- GET the settings for this broadcast through the `/broadcast-settings/<BROADCAST-ID>` route.
- The value of the `webhook.body` property returned should be uri encoded, **with the exception** of the Liquid tags.
#### Bonus
- Use Customer.io to send yourself a text with these settings. (I already texted myself 👍 :forever_alone: )

# Relevant Issues

Fixes #199 