### PR TITLE
Update SMS status if doesn't exist

### DIFF
--- a/lib/middleware/receive-message/user-update.js
+++ b/lib/middleware/receive-message/user-update.js
@@ -21,8 +21,9 @@ module.exports = function updateNorthstarUser() {
       statusUpdate = stopValue;
     } else if (helpers.isSubscriptionStatusLessMacro(replyText)) {
       statusUpdate = lessValue;
-    // If User is set to undeliverable but we've now received a message from them:
-    } else if (currentStatus === stopValue) {
+    // If User is set to undeliverable but we've now received a message from them OR we don't
+    // have a status set at all:
+    } else if (currentStatus === stopValue || !currentStatus) {
       // TODO: There's an edge case here, if a User sends STOP while they're paused.
       // We'll want to update the Conversation.paused to true by default if we're bringing someone
       // back to life.


### PR DESCRIPTION
For new users created without SMS status ( #202 ), we'd never update status the Active value because we only check for a Stop status value.