### PR TITLE
Adds validate user middleware to Send Message

### DIFF
--- a/app/routes/send-message.js
+++ b/app/routes/send-message.js
@@ -11,6 +11,7 @@ const outboundMessageConfig = require('../../config/lib/middleware/send-message/
 const supportParamsMiddleware = require('../../lib/middleware/send-message/params-support');
 const campaignParamsMiddleware = require('../../lib/middleware/send-message/params-campaign');
 const getUserMiddleware = require('../../lib/middleware/send-message/user-get');
+const validateUserMiddleware = require('../../lib/middleware/send-message/user-validate');
 const getConversationMiddleware = require('../../lib/middleware/conversation-get');
 const createConversationMiddleware = require('../../lib/middleware/conversation-create');
 const campaignMiddleware = require('../../lib/middleware/send-message/campaign');
@@ -23,6 +24,7 @@ router.use(campaignParamsMiddleware());
 
 // Fetch Northstar User.
 router.use(getUserMiddleware());
+router.use(validateUserMiddleware());
 
 router.use(getConversationMiddleware());
 router.use(createConversationMiddleware());

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -125,7 +125,11 @@ module.exports.sendErrorResponse = function (res, err) {
  */
 module.exports.sendResponseWithStatusCode = function (res, code = 200, message = 'OK') {
   const response = { message };
-  logger.debug('sendResponseWithStatusCode', { code, response });
+  if (code < 300) {
+    logger.debug('sendResponseWithStatusCode', { code, response });
+  } else {
+    logger.error('sendResponseWithStatusCode', { code, response });
+  }
 
   return res.status(code).send(response);
 };

--- a/lib/middleware/send-message/campaign.js
+++ b/lib/middleware/send-message/campaign.js
@@ -10,11 +10,6 @@ module.exports = function sendCampaignTemplate() {
       return next();
     }
 
-    if (req.conversation.paused) {
-      const err = new UnprocessibleEntityError('Conversation is paused.');
-      return helpers.sendErrorResponse(res, err);
-    }
-
     return gambitCampaigns.getCampaignById(req.campaignId)
       .then((campaign) => {
         if (!campaign) {

--- a/lib/middleware/send-message/user-get.js
+++ b/lib/middleware/send-message/user-get.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const logger = require('heroku-logger');
-
 const helpers = require('../../helpers');
 const northstar = require('../../northstar');
 const NotFoundError = require('../../../app/exceptions/NotFoundError');
@@ -11,19 +9,11 @@ module.exports = function getNorthstarUser() {
     if (!req.userId) {
       return next();
     }
+
     return northstar.fetchUserById(req.userId)
       .then((user) => {
-        try {
-          /**
-           * Phone number in Northstar profile is not guaranteed to be returned in E.164 format?
-           * Mobile returned from a Northstar-thor user was not E.164 compliant
-           */
-          req.platformUserId = helpers.formatMobileNumber(user.mobile);
-        } catch (error) {
-          helpers.addBlinkSuppressHeaders(res);
-          logger.error('getNorthstarUser: Fatal error formatting Northstar user\'s mobile.');
-          return helpers.sendErrorResponse(res, error);
-        }
+        req.user = user;
+
         return next();
       })
       .catch((err) => {

--- a/lib/middleware/send-message/user-validate.js
+++ b/lib/middleware/send-message/user-validate.js
@@ -1,0 +1,34 @@
+'use strict';
+
+const helpers = require('../../helpers');
+const UnprocessibleEntityError = require('../../../app/exceptions/UnprocessibleEntityError');
+
+module.exports = function validateUser() {
+  return (req, res, next) => {
+    if (!req.user) {
+      return next();
+    }
+
+    if (req.user.sms_status === helpers.subscriptionStatusStopValue()) {
+      const error = new UnprocessibleEntityError('Northstar User is unsubscribed.');
+      return helpers.sendErrorResponse(res, error);
+    }
+
+    if (req.user.sms_paused) {
+      const error = new UnprocessibleEntityError('Northstar User conversation is paused.');
+      return helpers.sendErrorResponse(res, error);
+    }
+
+    try {
+      /**
+       * Sanity check E.164 format.
+       */
+      req.platformUserId = helpers.formatMobileNumber(req.user.mobile);
+    } catch (err) {
+      const error = new UnprocessibleEntityError('Cannot format Northstar User mobile.');
+      return helpers.sendErrorResponse(res, error);
+    }
+
+    return next();
+  };
+};


### PR DESCRIPTION
* Fixes #209 by checking User's subscription status
* Fixes #205 - throws a 422 if given User doesn't have a valid mobile US number

How to test:
* Send a stop keyword to update Northstar User's `sms_status`
* `POST /send-message` for your User, and an active Campaign with keywords
* Verify a 422 is returned