### PR TITLE
New Relic parameters

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -139,10 +139,12 @@ module.exports.sendResponseWithStatusCode = function (req, res, code = 200, mess
 /**
  * Sends response with Message.
  * @param {object} req
+ * @param {object} res
  * @param {Message} message
  */
-module.exports.sendResponseWithMessage = function (res, message) {
+module.exports.sendResponseWithMessage = function (req, res, message) {
   logger.debug('sendResponseWithMessage', { messageId: message.id });
+  helpers.request.addNewRelicParameters(req);
 
   const data = { messages: [message] };
 

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -3,7 +3,6 @@
 const logger = require('heroku-logger');
 const Promise = require('bluebird');
 const { PhoneNumberFormat, PhoneNumberUtil } = require('google-libphonenumber');
-const newrelic = require('newrelic');
 
 const contentful = require('./contentful');
 const gambitCampaigns = require('./gambit-campaigns');
@@ -132,7 +131,7 @@ module.exports.sendResponseWithStatusCode = function (req, res, code = 200, mess
   } else {
     logger.error('sendResponseWithStatusCode', { code, response });
   }
-  exports.addNewRelicParameters(req, message);
+  helpers.request.addNewRelicParameters(req, message);
 
   return res.status(code).send(response);
 };
@@ -178,7 +177,7 @@ function sendReply(req, res, messageText, messageTemplate) {
           outbound: [req.conversation.lastOutboundMessage],
         },
       };
-      exports.addNewRelicParameters(req);
+      helpers.request.addNewRelicParameters(req);
 
       return res.send({ data });
     })
@@ -375,22 +374,4 @@ module.exports.formatMobileNumber = function formatMobileNumber(mobile, format =
   const phoneUtil = PhoneNumberUtil.getInstance();
   const phoneNumberObject = phoneUtil.parse(mobile, countryCode);
   return phoneUtil.format(phoneNumberObject, PhoneNumberFormat[format]);
-};
-
-/**
- * Posts variables from given req as New Relic custom parameters. 
- * @param {object} req
- * @param {string} responseMessage
- */
-module.exports.addNewRelicParameters = function (req, responseMessage) {
-  const paramNames = ['campaignId', 'platform', 'platformUserId', 'userId'];
-  const payload = {};
-  paramNames.forEach((paramName) => {
-    payload[paramName] = req[paramName];
-  });
-  if (responseMessage) {
-    payload.gambitResponseMessage = responseMessage;
-  }
-  logger.debug('addNewRelicParameters', payload);
-  newrelic.addCustomParameters(payload);
 };

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -3,6 +3,7 @@
 const logger = require('heroku-logger');
 const Promise = require('bluebird');
 const { PhoneNumberFormat, PhoneNumberUtil } = require('google-libphonenumber');
+const newrelic = require('newrelic');
 
 const contentful = require('./contentful');
 const gambitCampaigns = require('./gambit-campaigns');
@@ -94,7 +95,7 @@ module.exports.subscriptionStatusStopValue = function () {
  * @param  {Object} res
  * @param  {Error} err
  */
-module.exports.sendErrorResponse = function (res, err) {
+module.exports.sendErrorResponse = function (req, res, err) {
   let status = err.status;
   if (!status) {
     status = 500;
@@ -113,23 +114,25 @@ module.exports.sendErrorResponse = function (res, err) {
     exports.addBlinkSuppressHeaders(res);
   }
 
-  return this.sendResponseWithStatusCode(res, status, message);
+  return this.sendResponseWithStatusCode(req, res, status, message);
 };
 
 /**
  * Sends response with custom status code and message
  *
+ * @param  {Object} req
  * @param  {Object} res
  * @param  {Number} code = 200
  * @param  {String} message = 'OK'
  */
-module.exports.sendResponseWithStatusCode = function (res, code = 200, message = 'OK') {
+module.exports.sendResponseWithStatusCode = function (req, res, code = 200, message = 'OK') {
   const response = { message };
   if (code < 300) {
     logger.debug('sendResponseWithStatusCode', { code, response });
   } else {
     logger.error('sendResponseWithStatusCode', { code, response });
   }
+  exports.addNewRelicParameters(req, message);
 
   return res.status(code).send(response);
 };
@@ -175,10 +178,11 @@ function sendReply(req, res, messageText, messageTemplate) {
           outbound: [req.conversation.lastOutboundMessage],
         },
       };
+      exports.addNewRelicParameters(req);
 
       return res.send({ data });
     })
-    .catch(err => exports.sendErrorResponse(res, err));
+    .catch(err => exports.sendErrorResponse(req, res, err));
 }
 
 /**
@@ -208,12 +212,12 @@ function replaceQuantity(string, signup) {
 function sendReplyWithCampaignTemplate(req, res, messageTemplate) {
   const campaign = req.campaign;
   if (!campaign.id) {
-    return exports.sendErrorResponse(res, 'req.campaign undefined');
+    return exports.sendErrorResponse(req, res, 'req.campaign undefined');
   }
 
   const template = campaign.templates[messageTemplate];
   if (!template) {
-    return exports.sendErrorResponse(res, `req.campaign.templates.${messageTemplate} undefined`);
+    return exports.sendErrorResponse(req, res, `req.campaign.templates.${messageTemplate} undefined`);
   }
   let messageText = template.rendered;
 
@@ -232,7 +236,7 @@ function sendReplyWithCampaignTemplate(req, res, messageTemplate) {
 module.exports.continueCampaign = function (req, res) {
   const campaignId = req.campaign.id;
   if (!campaignId) {
-    return exports.sendErrorResponse(res, 'req.campaign undefined');
+    return exports.sendErrorResponse(req, res, 'req.campaign undefined');
   }
 
   return gambitCampaigns.postReceiveMessage(req)
@@ -241,7 +245,7 @@ module.exports.continueCampaign = function (req, res) {
       logger.debug('continueCampaign', { signupId: req.signup.id });
       return sendReplyWithCampaignTemplate(req, res, gambitCampaignsRes.replyTemplate);
     })
-    .catch(err => exports.sendErrorResponse(res, err));
+    .catch(err => exports.sendErrorResponse(req, res, err));
 };
 
 module.exports.askContinue = function (req, res) {
@@ -352,7 +356,7 @@ module.exports.getBroadcast = function getBroadcast(req, res) {
         }
         return resolve(broadcast);
       })
-      .catch(err => exports.sendErrorResponse(res, err));
+      .catch(err => exports.sendErrorResponse(req, res, err));
   });
 };
 
@@ -371,4 +375,22 @@ module.exports.formatMobileNumber = function formatMobileNumber(mobile, format =
   const phoneUtil = PhoneNumberUtil.getInstance();
   const phoneNumberObject = phoneUtil.parse(mobile, countryCode);
   return phoneUtil.format(phoneNumberObject, PhoneNumberFormat[format]);
+};
+
+/**
+ * Posts variables from given req as New Relic custom parameters. 
+ * @param {object} req
+ * @param {string} responseMessage
+ */
+module.exports.addNewRelicParameters = function (req, responseMessage) {
+  const paramNames = ['campaignId', 'platform', 'platformUserId', 'userId'];
+  const payload = {};
+  paramNames.forEach((paramName) => {
+    payload[paramName] = req[paramName];
+  });
+  if (responseMessage) {
+    payload.gambitResponseMessage = responseMessage;
+  }
+  logger.debug('addNewRelicParameters', payload);
+  newrelic.addCustomParameters(payload);
 };

--- a/lib/helpers/request.js
+++ b/lib/helpers/request.js
@@ -7,9 +7,6 @@ const newrelic = require('newrelic');
  * Request helper
  */
 module.exports = {
-  /**
-   * Platform checks.
-   */
   isTwilio: function isTwilio(req) {
     return !!req.body.MessageSid;
   },
@@ -34,20 +31,31 @@ module.exports = {
     return messageStatus === 'delivered';
   },
   /**
-   * New Relic.
+   * @param {object} req
+   * @param {string} gambitApiResponseMessage
+   * @return {object}
    */
   formatNewRelicPayload: function formatNewRelicPayload(req, gambitApiResponseMessage) {
-    const paramNames = ['campaignId', 'platform', 'platformUserId', 'userId'];
     const payload = {};
-    paramNames.forEach((paramName) => {
-      payload[paramName] = req[paramName];
-    });
+    if (req.metadata) {
+      payload.retryCount = req.metadata.retryCount;
+      payload.requestId = req.metadata.requestId;
+    }
     if (gambitApiResponseMessage) {
       payload.gambitApiResponseMessage = gambitApiResponseMessage;
     }
+    // Variables defined on req.
+    const paramNames = ['broadcastId', 'campaignId', 'platform', 'platformUserId', 'userId'];
+    paramNames.forEach((paramName) => {
+      payload[paramName] = req[paramName];
+    });
 
     return payload;
   },
+  /**
+   * @param {object} req
+   * @param {string} gambitApiResponseMessage
+   */
   addNewRelicParameters: function addNewRelicParameters(req, gambitApiResponseMessage) {
     const payload = this.formatNewRelicPayload(req, gambitApiResponseMessage);
     logger.debug('addNewRelicParameters', payload);

--- a/lib/helpers/request.js
+++ b/lib/helpers/request.js
@@ -1,9 +1,15 @@
 'use strict';
 
+const logger = require('heroku-logger');
+const newrelic = require('newrelic');
+
 /**
  * Request helper
  */
 module.exports = {
+  /**
+   * Platform checks.
+   */
   isTwilio: function isTwilio(req) {
     return !!req.body.MessageSid;
   },
@@ -26,5 +32,25 @@ module.exports = {
      * @see https://www.twilio.com/docs/api/messaging/message#message-status-values
      */
     return messageStatus === 'delivered';
+  },
+  /**
+   * New Relic.
+   */
+  formatNewRelicPayload: function formatNewRelicPayload(req, gambitApiResponseMessage) {
+    const paramNames = ['campaignId', 'platform', 'platformUserId', 'userId'];
+    const payload = {};
+    paramNames.forEach((paramName) => {
+      payload[paramName] = req[paramName];
+    });
+    if (gambitApiResponseMessage) {
+      payload.gambitApiResponseMessage = gambitApiResponseMessage;
+    }
+
+    return payload;
+  },
+  addNewRelicParameters: function addNewRelicParameters(req, gambitApiResponseMessage) {
+    const payload = this.formatNewRelicPayload(req, gambitApiResponseMessage);
+    logger.debug('addNewRelicParameters', payload);
+    newrelic.addCustomParameters(payload);
   },
 };

--- a/lib/middleware/authenticate.js
+++ b/lib/middleware/authenticate.js
@@ -18,7 +18,7 @@ function sendUnauthorizedResponse(req, res) {
   logger.debug('Unauthorized request query', req.query);
   logger.debug('Unauthorized request body', req.body);
   res.setHeader('WWW-Authenticate', 'Basic');
-  return helpers.sendResponseWithStatusCode(res, 401, unauthorizedErrorMessage);
+  return helpers.sendResponseWithStatusCode(req, res, 401, unauthorizedErrorMessage);
 }
 
 module.exports = function authenticate() {

--- a/lib/middleware/broadcast-settings/broadcast.js
+++ b/lib/middleware/broadcast-settings/broadcast.js
@@ -20,11 +20,11 @@ module.exports = function getBroadcast() {
         // We should never be able to send an empty message to users.
         if (isMessageEmpty(broadcast)) {
           const error = new UnprocessibleEntityError('Broadcast misconfigured. Message field is required!');
-          return helpers.sendErrorResponse(res, error);
+          return helpers.sendErrorResponse(req, res, error);
         }
         req.broadcastObject = broadcast;
         return next();
       })
-      .catch(err => helpers.sendErrorResponse(res, err));
+      .catch(err => helpers.sendErrorResponse(req, res, err));
   };
 };

--- a/lib/middleware/broadcast-settings/params.js
+++ b/lib/middleware/broadcast-settings/params.js
@@ -10,7 +10,7 @@ module.exports = function params() {
       // get broadcast properties
       helpers.broadcast.parseBody(req);
     } catch (error) {
-      helpers.sendErrorResponse(res, error);
+      helpers.sendErrorResponse(req, res, error);
     }
     return next();
   };

--- a/lib/middleware/broadcast-settings/settings.js
+++ b/lib/middleware/broadcast-settings/settings.js
@@ -11,7 +11,7 @@ module.exports = function getSettings() {
     try {
       settings = helpers.broadcast.getSettings(req);
     } catch (error) {
-      return helpers.sendErrorResponse(res, error);
+      return helpers.sendErrorResponse(req, res, error);
     }
     return res.send(settings);
   };

--- a/lib/middleware/conversation-create.js
+++ b/lib/middleware/conversation-create.js
@@ -15,6 +15,6 @@ module.exports = function createConversation() {
 
         return next();
       })
-      .catch(err => helpers.sendErrorResponse(res, err));
+      .catch(err => helpers.sendErrorResponse(req, res, err));
   };
 };

--- a/lib/middleware/conversation-get.js
+++ b/lib/middleware/conversation-get.js
@@ -24,6 +24,6 @@ module.exports = function getConversation() {
 
         return next();
       })
-      .catch(err => helpers.sendErrorResponse(res, err));
+      .catch(err => helpers.sendErrorResponse(req, res, err));
   };
 };

--- a/lib/middleware/import-message/broadcast.js
+++ b/lib/middleware/import-message/broadcast.js
@@ -66,7 +66,7 @@ module.exports = function getBroadcast() {
     // this requirement here and call next()
     if (!req.broadcastId) {
       const error = new UnprocessibleEntityError('broadcastId is a required property.');
-      return helpers.sendErrorResponse(res, error);
+      return helpers.sendErrorResponse(req, res, error);
     }
 
     return cache.get(req.broadcastId)
@@ -82,7 +82,7 @@ module.exports = function getBroadcast() {
         // Process async parsers
         return Promise.all(asyncProperties)
           .then(() => next())
-          .catch(err => helpers.sendErrorResponse(res, err));
+          .catch(err => helpers.sendErrorResponse(req, res, err));
       });
   };
 };

--- a/lib/middleware/import-message/conversation-update.js
+++ b/lib/middleware/import-message/conversation-update.js
@@ -21,6 +21,6 @@ module.exports = function updateConversation() {
         req.outboundTemplate = 'askSignup';
         return next();
       })
-      .catch(err => helpers.sendErrorResponse(res, err));
+      .catch(err => helpers.sendErrorResponse(req, res, err));
   };
 };

--- a/lib/middleware/import-message/params.js
+++ b/lib/middleware/import-message/params.js
@@ -8,7 +8,7 @@ module.exports = function params() {
   return (req, res, next) => {
     if (!helpers.request.isTwilioStatusCallback(req)) {
       const error = new UnprocessibleEntityError('Not a valid import request.');
-      return helpers.sendErrorResponse(res, error);
+      return helpers.sendErrorResponse(req, res, error);
     }
     logger.debug('Importing \'Delivered\' Twilio message');
     // parse twilio properties

--- a/lib/middleware/message-outbound-create.js
+++ b/lib/middleware/message-outbound-create.js
@@ -17,7 +17,7 @@ module.exports = function createOutboundMessage(config) {
         }
         return promise;
       })
-      .then(() => helpers.sendResponseWithMessage(res, req.conversation.lastOutboundMessage))
+      .then(() => helpers.sendResponseWithMessage(req, res, req.conversation.lastOutboundMessage))
       .catch(err => helpers.sendErrorResponse(req, res, err));
   };
 };

--- a/lib/middleware/message-outbound-create.js
+++ b/lib/middleware/message-outbound-create.js
@@ -18,6 +18,6 @@ module.exports = function createOutboundMessage(config) {
         return promise;
       })
       .then(() => helpers.sendResponseWithMessage(res, req.conversation.lastOutboundMessage))
-      .catch(err => helpers.sendErrorResponse(res, err));
+      .catch(err => helpers.sendErrorResponse(req, res, err));
   };
 };

--- a/lib/middleware/message-outbound-load.js
+++ b/lib/middleware/message-outbound-load.js
@@ -36,7 +36,7 @@ module.exports = function loadOutboundMessage(config) {
             }
             return promise;
           })
-          .then(() => helpers.sendResponseWithMessage(res, req.conversation.lastOutboundMessage))
+          .then(() => helpers.sendResponseWithMessage(req, res, message))
           .catch(err => helpers.sendErrorResponse(req, res, err));
       })
       .catch(err => helpers.sendErrorResponse(req, res, err));

--- a/lib/middleware/message-outbound-load.js
+++ b/lib/middleware/message-outbound-load.js
@@ -37,8 +37,8 @@ module.exports = function loadOutboundMessage(config) {
             return promise;
           })
           .then(() => helpers.sendResponseWithMessage(res, req.conversation.lastOutboundMessage))
-          .catch(err => helpers.sendErrorResponse(res, err));
+          .catch(err => helpers.sendErrorResponse(req, res, err));
       })
-      .catch(err => helpers.sendErrorResponse(res, err));
+      .catch(err => helpers.sendErrorResponse(req, res, err));
   };
 };

--- a/lib/middleware/receive-message/campaign-continue.js
+++ b/lib/middleware/receive-message/campaign-continue.js
@@ -14,6 +14,6 @@ module.exports = function askContinueTemplate() {
       // TODO: If Conversation.signupStatus is 'declined', we shouldn't keep asking to continue
       // the same Campaign -- send Ask Signup for a random Campaign instead?
       .then(() => helpers.askContinue(req, res))
-      .catch(err => helpers.sendErrorResponse(res, err));
+      .catch(err => helpers.sendErrorResponse(req, res, err));
   };
 };

--- a/lib/middleware/receive-message/campaign-current.js
+++ b/lib/middleware/receive-message/campaign-current.js
@@ -23,6 +23,6 @@ module.exports = function getCurrentCampaign() {
 
         return next();
       })
-      .catch(err => helpers.sendErrorResponse(res, err));
+      .catch(err => helpers.sendErrorResponse(req, res, err));
   };
 };

--- a/lib/middleware/receive-message/campaign-keyword.js
+++ b/lib/middleware/receive-message/campaign-keyword.js
@@ -31,6 +31,6 @@ module.exports = function getCampaignForKeyword() {
             return helpers.continueCampaign(req, res);
           });
       })
-      .catch(err => helpers.sendErrorResponse(res, err));
+      .catch(err => helpers.sendErrorResponse(req, res, err));
   };
 };

--- a/lib/middleware/receive-message/campaign-menu.js
+++ b/lib/middleware/receive-message/campaign-menu.js
@@ -18,6 +18,6 @@ module.exports = function campaignMenu() {
         return req.conversation.setCampaign(randomCampaign);
       })
       .then(() => helpers.askSignup(req, res))
-      .catch(err => helpers.sendErrorResponse(res, err));
+      .catch(err => helpers.sendErrorResponse(req, res, err));
   };
 };

--- a/lib/middleware/receive-message/message-inbound-create.js
+++ b/lib/middleware/receive-message/message-inbound-create.js
@@ -20,6 +20,6 @@ module.exports = function createInboundMessage() {
 
         return next();
       })
-      .catch(err => helpers.sendErrorResponse(res, err));
+      .catch(err => helpers.sendErrorResponse(req, res, err));
   };
 };

--- a/lib/middleware/receive-message/message-inbound-load.js
+++ b/lib/middleware/receive-message/message-inbound-load.js
@@ -22,6 +22,6 @@ module.exports = function loadInboundMessage() {
 
         return next();
       })
-      .catch(err => helpers.sendErrorResponse(res, err));
+      .catch(err => helpers.sendErrorResponse(req, res, err));
   };
 };

--- a/lib/middleware/receive-message/params.js
+++ b/lib/middleware/receive-message/params.js
@@ -22,7 +22,7 @@ module.exports = function params() {
     if (helpers.request.isTwilio(req)) {
       return helpers.twilio.parseBody(req)
         .then(() => next())
-        .catch(error => helpers.sendErrorResponse(res, error));
+        .catch(error => helpers.sendErrorResponse(req, res, error));
     }
 
     // Facebook Messenger

--- a/lib/middleware/receive-message/parse-ask-signup-answer.js
+++ b/lib/middleware/receive-message/parse-ask-signup-answer.js
@@ -20,6 +20,6 @@ module.exports = function parseAskSignupResponse() {
 
     return req.conversation.declineSignup()
       .then(() => helpers.declinedSignup(req, res))
-      .catch(err => helpers.sendErrorResponse(res, err));
+      .catch(err => helpers.sendErrorResponse(req, res, err));
   };
 };

--- a/lib/middleware/receive-message/rivescript-reply-get.js
+++ b/lib/middleware/receive-message/rivescript-reply-get.js
@@ -14,6 +14,6 @@ module.exports = function getRivescriptReply() {
         req.rivescriptReplyTopic = rivescriptRes.topic;
         return next();
       })
-      .catch(err => helpers.sendErrorResponse(res, err));
+      .catch(err => helpers.sendErrorResponse(req, res, err));
   };
 };

--- a/lib/middleware/receive-message/support-message.js
+++ b/lib/middleware/receive-message/support-message.js
@@ -16,6 +16,6 @@ module.exports = function postMessageToFront() {
 
         return helpers.noReply(req, res);
       })
-      .catch(err => helpers.sendErrorResponse(res, err));
+      .catch(err => helpers.sendErrorResponse(req, res, err));
   };
 };

--- a/lib/middleware/receive-message/support-requested.js
+++ b/lib/middleware/receive-message/support-requested.js
@@ -10,6 +10,6 @@ module.exports = function requestSupport() {
 
     return req.conversation.supportRequested()
       .then(() => helpers.supportRequested(req, res))
-      .catch(err => helpers.sendErrorResponse(res, err));
+      .catch(err => helpers.sendErrorResponse(req, res, err));
   };
 };

--- a/lib/middleware/receive-message/template-rivescript.js
+++ b/lib/middleware/receive-message/template-rivescript.js
@@ -10,6 +10,6 @@ module.exports = function sendRivescriptReply() {
 
     return req.conversation.setTopic(req.rivescriptReplyTopic)
       .then(() => helpers.rivescriptReply(req, res, req.rivescriptReplyText))
-      .catch(err => helpers.sendErrorResponse(res, err));
+      .catch(err => helpers.sendErrorResponse(req, res, err));
   };
 };

--- a/lib/middleware/receive-message/user-create.js
+++ b/lib/middleware/receive-message/user-create.js
@@ -19,6 +19,6 @@ module.exports = function createNorthstarUserIfNotFound() {
 
         return next();
       })
-      .catch(err => helpers.sendErrorResponse(res, err));
+      .catch(err => helpers.sendErrorResponse(req, res, err));
   };
 };

--- a/lib/middleware/receive-message/user-get.js
+++ b/lib/middleware/receive-message/user-get.js
@@ -19,7 +19,7 @@ module.exports = function getNorthstarUser() {
           return next();
         }
 
-        return helpers.sendErrorResponse(res, err);
+        return helpers.sendErrorResponse(req, res, err);
       });
   };
 };

--- a/lib/middleware/receive-message/user-update.js
+++ b/lib/middleware/receive-message/user-update.js
@@ -56,7 +56,7 @@ module.exports = function updateNorthstarUser() {
         if (err.response && err.response.body) {
           error = err.response.body.error;
         }
-        return helpers.sendErrorResponse(res, error);
+        return helpers.sendErrorResponse(req, res, error);
       });
   };
 };

--- a/lib/middleware/send-message/campaign.js
+++ b/lib/middleware/send-message/campaign.js
@@ -13,27 +13,27 @@ module.exports = function sendCampaignTemplate() {
     return gambitCampaigns.getCampaignById(req.campaignId)
       .then((campaign) => {
         if (!campaign) {
-          return helpers.sendResponseWithStatusCode(res, 404, 'Campaign not found.');
+          return helpers.sendResponseWithStatusCode(req, res, 404, 'Campaign not found.');
         }
         if (gambitCampaigns.isClosedCampaign(campaign)) {
           const err = new UnprocessibleEntityError('Campaign is closed.');
-          return helpers.sendErrorResponse(res, err);
+          return helpers.sendErrorResponse(req, res, err);
         }
         if (campaign.keywords.length === 0) {
           helpers.addBlinkSuppressHeaders(res);
-          return helpers.sendResponseWithStatusCode(res, 204, 'Campaign does not have keywords.');
+          return helpers.sendResponseWithStatusCode(req, res, 204, 'Campaign does not have keywords.');
         }
 
         req.outboundMessageText = campaign.templates[req.outboundTemplate].rendered;
         if (!req.outboundMessageText) {
           const err = new UnprocessibleEntityError('Campaign template undefined.');
-          return helpers.sendErrorResponse(res, err);
+          return helpers.sendErrorResponse(req, res, err);
         }
 
         return req.conversation.setCampaign(campaign)
           .then(() => next())
-          .catch(err => helpers.sendErrorResponse(res, err));
+          .catch(err => helpers.sendErrorResponse(req, res, err));
       })
-      .catch(err => helpers.sendErrorResponse(res, err));
+      .catch(err => helpers.sendErrorResponse(req, res, err));
   };
 };

--- a/lib/middleware/send-message/params-campaign.js
+++ b/lib/middleware/send-message/params-campaign.js
@@ -15,13 +15,13 @@ module.exports = function campaignParams() {
     req.campaignId = body.campaignId;
     if (!req.campaignId) {
       error = new UnprocessibleEntityError('Missing required campaignId.');
-      return helpers.sendErrorResponse(res, error);
+      return helpers.sendErrorResponse(req, res, error);
     }
 
     req.outboundTemplate = body.template;
     if (!req.outboundTemplate) {
       error = new UnprocessibleEntityError('Missing required template.');
-      return helpers.sendErrorResponse(res, error);
+      return helpers.sendErrorResponse(req, res, error);
     }
 
     if (body.mobile) {
@@ -46,6 +46,6 @@ module.exports = function campaignParams() {
     }
 
     error = new UnprocessibleEntityError('Missing required mobile or slackId.');
-    return helpers.sendErrorResponse(res, error);
+    return helpers.sendErrorResponse(req, res, error);
   };
 };

--- a/lib/middleware/send-message/params-support.js
+++ b/lib/middleware/send-message/params-support.js
@@ -29,7 +29,7 @@ module.exports = function supportParams() {
     }
 
     if (!isValidFrontSignature(body, frontSignature)) {
-      return helpers.sendResponseWithStatusCode(res, 401, 'X-Front-Signature is not valid.');
+      return helpers.sendResponseWithStatusCode(req, res, 401, 'X-Front-Signature is not valid.');
     }
 
     // TODO: Create helpers.front and move this to its parseBody method

--- a/lib/middleware/send-message/user-get.js
+++ b/lib/middleware/send-message/user-get.js
@@ -20,10 +20,10 @@ module.exports = function getNorthstarUser() {
         if (err && err.status === 404) {
           helpers.addBlinkSuppressHeaders(res);
           const error = new NotFoundError('Northstar user not found.');
-          return helpers.sendErrorResponse(res, error);
+          return helpers.sendErrorResponse(req, res, error);
         }
 
-        return helpers.sendErrorResponse(res, err);
+        return helpers.sendErrorResponse(req, res, err);
       });
   };
 };

--- a/lib/middleware/send-message/user-validate.js
+++ b/lib/middleware/send-message/user-validate.js
@@ -11,12 +11,12 @@ module.exports = function validateUser() {
 
     if (req.user.sms_status === helpers.subscriptionStatusStopValue()) {
       const error = new UnprocessibleEntityError('Northstar User is unsubscribed.');
-      return helpers.sendErrorResponse(res, error);
+      return helpers.sendErrorResponse(req, res, error);
     }
 
     if (req.user.sms_paused) {
       const error = new UnprocessibleEntityError('Northstar User conversation is paused.');
-      return helpers.sendErrorResponse(res, error);
+      return helpers.sendErrorResponse(req, res, error);
     }
 
     try {
@@ -26,7 +26,7 @@ module.exports = function validateUser() {
       req.platformUserId = helpers.formatMobileNumber(req.user.mobile);
     } catch (err) {
       const error = new UnprocessibleEntityError('Cannot format Northstar User mobile.');
-      return helpers.sendErrorResponse(res, error);
+      return helpers.sendErrorResponse(req, res, error);
     }
 
     return next();


### PR DESCRIPTION
* Adds a `helpers.request.addNewRelicParameters(req)` function to pass middleware variables we add to an Express request `req` as New Relic custom parameters.
* Adds a `req` argument to our `helpers.sendReply`, `helpers.sendErrorResponse`, etc response functions, to call `addNewRelicParameters` before sending the HTTP response

If this approach looks good to close #206, the last TODO's left are
* [ ] Moving the variables to pass into a `config/lib/helpers/request.js`
* [ ] Add test coverage