### PR TITLE
adding indexes to Conversation and Message models

### DIFF
--- a/app/models/Conversation.js
+++ b/app/models/Conversation.js
@@ -35,6 +35,9 @@ const conversationSchema = new mongoose.Schema({
   slackChannel: String,
 }, { timestamps: true });
 
+conversationSchema.index({ createdAt: 1 });
+conversationSchema.index({ updatedAt: 1 });
+
 /**
  * @param {Object} req - Express request
  * @return {Promise}

--- a/app/models/Message.js
+++ b/app/models/Message.js
@@ -33,6 +33,9 @@ const messageSchema = new mongoose.Schema({
   },
 }, { timestamps: true });
 
+messageSchema.index({ createdAt: 1 });
+messageSchema.index({ updatedAt: 1 });
+
 /**
  * Gets the message that matches this metadata.requestId and direction.
  * Updates it with the new properties passed in the update object.


### PR DESCRIPTION
# What does this PR do?
It adds ascending timestamp indexes to Conversation and Message models. Important to efficiently sort through both collections by createdAt and updatedAt.

# How to test?
- 👀 

# Relevant Issues
Fixes #216 