### PR TITLE
Fixes logging in Northstar.createNewClient

### DIFF
--- a/lib/northstar.js
+++ b/lib/northstar.js
@@ -25,9 +25,9 @@ module.exports.createNewClient = function createNewClient() {
       baseURI: opts.baseUri,
       apiKey: opts.apiKey,
     });
-    logger.info(`${loggerMsg} success`, client);
+    logger.info(`${loggerMsg} success`, { client });
   } catch (err) {
-    logger.error(`${loggerMsg} error`, err);
+    logger.error(`${loggerMsg} error`, { err });
   }
   return client;
 };

--- a/lib/northstar.js
+++ b/lib/northstar.js
@@ -25,7 +25,7 @@ module.exports.createNewClient = function createNewClient() {
       baseURI: opts.baseUri,
       apiKey: opts.apiKey,
     });
-    logger.info(`${loggerMsg} success`, { client });
+    logger.info(`${loggerMsg} success`);
   } catch (err) {
     logger.error(`${loggerMsg} error`, { err });
   }

--- a/lib/twilio.js
+++ b/lib/twilio.js
@@ -17,7 +17,7 @@ module.exports.createNewClient = function createNewClient() {
 
   try {
     client = new Twilio(config.accountSid, config.authToken);
-    logger.info(`${loggerMsg} success`, client);
+    logger.info(`${loggerMsg} success`);
   } catch (err) {
     logger.error(`${loggerMsg} error`, err);
   }


### PR DESCRIPTION
Helps to debug errors like #221 - missed this from copy/paste from Gambit Campaigns (which uses `winston`, not the `heroku-logger` we're using here in Conversations)