### PR TITLE
Fix duplicate Conversations bug

### DIFF
--- a/app/models/Conversation.js
+++ b/app/models/Conversation.js
@@ -62,7 +62,7 @@ conversationSchema.statics.createFromReq = function (req) {
  */
 conversationSchema.statics.getFromReq = function (req) {
   const query = { platformUserId: req.platformUserId };
-  // logger.debug('Conversation.getFromReq', query, req);
+  logger.debug('Conversation.getFromReq', query, req);
 
   return this.findOne(query).populate('lastOutboundMessage');
 };

--- a/app/models/Conversation.js
+++ b/app/models/Conversation.js
@@ -62,7 +62,7 @@ conversationSchema.statics.createFromReq = function (req) {
  */
 conversationSchema.statics.getFromReq = function (req) {
   const query = { platformUserId: req.platformUserId };
-  logger.debug('Conversation.getFromReq', query, req);
+  // logger.debug('Conversation.getFromReq', query, req);
 
   return this.findOne(query).populate('lastOutboundMessage');
 };

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -52,7 +52,7 @@ class Logger extends HerokuLogger {
       }
     });
     // Extend the original data with the injected data.
-    const logData = Object.assign(data, injectedProps);
+    const logData = Object.assign({}, data, injectedProps);
     // call super.log to finally output the log with the injected values.
     return super.log(level, message, logData);
   }

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -42,6 +42,7 @@ class Logger extends HerokuLogger {
       return super.log(level, message, data);
     }
     const injectedProps = {};
+    /*
     this.injectorNames.forEach((name) => {
       const result = this.injectors[name](metadataContainer);
 
@@ -52,6 +53,7 @@ class Logger extends HerokuLogger {
       }
     });
     // Extend the original data with the injected data.
+    */
     const logData = Object.assign(data, injectedProps);
     // call super.log to finally output the log with the injected values.
     return super.log(level, message, logData);

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -42,7 +42,6 @@ class Logger extends HerokuLogger {
       return super.log(level, message, data);
     }
     const injectedProps = {};
-    /*
     this.injectorNames.forEach((name) => {
       const result = this.injectors[name](metadataContainer);
 
@@ -53,7 +52,6 @@ class Logger extends HerokuLogger {
       }
     });
     // Extend the original data with the injected data.
-    */
     const logData = Object.assign(data, injectedProps);
     // call super.log to finally output the log with the injected values.
     return super.log(level, message, logData);

--- a/lib/middleware/conversation-get.js
+++ b/lib/middleware/conversation-get.js
@@ -7,7 +7,10 @@ const helpers = require('../helpers');
 module.exports = function getConversation() {
   return (req, res, next) => Conversation.getFromReq(req)
     .then((conversation) => {
-      if (!conversation) return next();
+      if (!conversation) {
+        logger.debug('Conversation not found');
+        return next();
+      }
 
       req.conversation = conversation;
 


### PR DESCRIPTION
#229 is occurring because our [`conversation-get` middleware is never finding a Conversation.](https://github.com/DoSomething/gambit-conversations/blob/04a370c8b2aeb7cd0c748de20100322a8bfdbfb8/lib/middleware/conversation-get.js#L10), therefore creating a new Conversation for each inbound message.

Commenting the `logger.debug` introduced in #228 seems to fix, seems it's throwing an error that we're not handling.