### PR TITLE
Import Message Broadcast TLC - part 2

### DIFF
--- a/lib/contentful.js
+++ b/lib/contentful.js
@@ -37,8 +37,6 @@ module.exports.createNewClient = function createNewClient() {
   try {
     client = contentful.createClient(config.clientOptions);
   } catch (err) {
-    // TODO: Log this. Send to Stathat, but alert developers that we're in trouble.
-    // @see https://github.com/DoSomething/gambit/issues/714#issuecomment-259838498
     logger.error(exports.contentfulError(err));
   }
   return client;
@@ -116,4 +114,32 @@ module.exports.fetchRivescripts = function () {
     .contentType('rivescript')
     .build();
   return getEntries(query);
+};
+
+/**
+ * @param {object} broadcastObject
+ * @return {string}
+ */
+module.exports.getCampaignIdFromBroadcast = function (broadcastObject) {
+  const campaign = broadcastObject.fields.campaign;
+  if (!campaign.fields) {
+    return null;
+  }
+  return campaign.fields.campaignId;
+};
+
+/**
+ * @param {object} broadcastObject
+ * @return {string}
+ */
+module.exports.getTopicFromBroadcast = function (broadcastObject) {
+  return broadcastObject.fields.topic;
+};
+
+/**
+ * @param {object} broadcastObject
+ * @return {string}
+ */
+module.exports.getMessageTextFromBroadcast = function (broadcastObject) {
+  return broadcastObject.fields.message;
 };

--- a/lib/helpers/analytics.js
+++ b/lib/helpers/analytics.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const logger = require('heroku-logger');
+const logger = require('../logger');
 const newrelic = require('newrelic');
 
 module.exports = {

--- a/lib/middleware/import-message/parse-broadcast.js
+++ b/lib/middleware/import-message/parse-broadcast.js
@@ -1,36 +1,23 @@
 'use strict';
 
 const helpers = require('../../helpers');
+const contentful = require('../../contentful');
 const logger = require('../../logger');
-
-// TODO: Move inside lib/contentful
-function getCampaignId(broadcastObject) {
-  const campaign = broadcastObject.fields.campaign;
-  if (!campaign.fields) {
-    return null;
-  }
-  return campaign.fields.campaignId;
-}
-
-// TODO: Move inside lib/contentful
-function getTopic(broadcastObject) {
-  return broadcastObject.fields.topic;
-}
-
-// TODO: Move inside lib/contentful
-function getMessage(broadcastObject) {
-  return broadcastObject.fields.message;
-}
 
 module.exports = function parseBroadcast() {
   return (req, res, next) => {
     const broadcast = req.broadcast;
-    logger.debug('parseBroadcast', { broadcast });
+    logger.debug('parseBroadcast', { broadcast }, req);
 
     try {
-      req.topic = getTopic(broadcast);
-      req.campaignId = getCampaignId(broadcast);
-      req.outboundMessageText = getMessage(broadcast);
+      req.topic = contentful.getTopicFromBroadcast(broadcast);
+      req.campaignId = contentful.getCampaignIdFromBroadcast(broadcast);
+      req.outboundMessageText = contentful.getMessageTextFromBroadcast(broadcast);
+
+      helpers.analytics.addParameters({
+        broadcastTopic: req.topic,
+        broadcastCampaignId: req.campaignId,
+      });
 
       return next();
     } catch (err) {

--- a/lib/middleware/import-message/parse-broadcast.js
+++ b/lib/middleware/import-message/parse-broadcast.js
@@ -2,12 +2,10 @@
 
 const helpers = require('../../helpers');
 const contentful = require('../../contentful');
-const logger = require('../../logger');
 
 module.exports = function parseBroadcast() {
   return (req, res, next) => {
     const broadcast = req.broadcast;
-    logger.debug('parseBroadcast', { broadcast }, req);
 
     try {
       req.topic = contentful.getTopicFromBroadcast(broadcast);

--- a/test/helpers/factories/broadcast.js
+++ b/test/helpers/factories/broadcast.js
@@ -9,6 +9,15 @@ module.exports.getValidBroadcast = function getValidBroadcast() {
     },
     fields: {
       topic: stubs.getTopic(),
+      message: stubs.getBroadcastMessageText(),
+      campaign: {
+        sys: {
+          id: '4wg9DK69oAiak446OyAuWA',
+        },
+        fields: {
+          campaignId: stubs.getCampaignId(),
+        },
+      },
     },
   };
 };

--- a/test/helpers/stubs.js
+++ b/test/helpers/stubs.js
@@ -35,6 +35,12 @@ module.exports = {
   getBroadcastId: function getBroadcastId() {
     return '72mon4jUeQOaokEIkQMaoa';
   },
+  getBroadcastMessageText: function getBroadcastMessageText() {
+    return 'Winter is coming, will you be prepared? Yes or No.';
+  },
+  getCampaignId: function getCampaignId() {
+    return 2299;
+  },
   getMobileNumber: function getMobileNumber() {
     return mobileNumber;
   },

--- a/test/lib/lib-helpers/analytics.test.js
+++ b/test/lib/lib-helpers/analytics.test.js
@@ -1,0 +1,51 @@
+'use strict';
+
+// libs
+require('dotenv').config();
+const test = require('ava');
+const chai = require('chai');
+const sinon = require('sinon');
+const sinonChai = require('sinon-chai');
+const underscore = require('underscore');
+
+const logger = require('../../../lib/logger');
+const newrelic = require('newrelic');
+const stubs = require('../../helpers/stubs');
+
+const mockPayload = {
+  broadcastId: stubs.getBroadcastId(),
+  campaignId: stubs.getCampaignId(),
+};
+
+// setup "x.should.y" assertion style
+chai.should();
+chai.use(sinonChai);
+
+// module to be tested
+const analyticsHelper = require('../../../lib/helpers/analytics');
+
+// sinon sandbox object
+const sandbox = sinon.sandbox.create();
+
+// Setup!
+test.beforeEach(() => {
+  stubs.stubLogger(sandbox, logger);
+  sandbox.stub(newrelic, 'addCustomParameters')
+    .returns(underscore.noop);
+});
+
+// Cleanup!
+test.afterEach(() => {
+  // reset stubs, spies, and mocks
+  sandbox.restore();
+});
+
+test('addParameters should call newrelic.addCustomParameters', () => {
+  analyticsHelper.addParameters(mockPayload);
+  newrelic.addCustomParameters.should.have.been.called;
+});
+
+test('addParameters should call logger.debug', () => {
+  analyticsHelper.addParameters(mockPayload);
+  logger.debug.should.have.been.called;
+});

--- a/test/lib/middleware/import-message/parse-broadcast.test.js
+++ b/test/lib/middleware/import-message/parse-broadcast.test.js
@@ -1,0 +1,81 @@
+'use strict';
+
+require('dotenv').config();
+
+const test = require('ava');
+const chai = require('chai');
+const sinon = require('sinon');
+const sinonChai = require('sinon-chai');
+const httpMocks = require('node-mocks-http');
+const underscore = require('underscore');
+
+const helpers = require('../../../../lib/helpers');
+const analyticsHelper = require('../../../../lib/helpers/analytics');
+const contentful = require('../../../../lib/contentful');
+const stubs = require('../../../helpers/stubs');
+const broadcastFactory = require('../../../helpers/factories/broadcast');
+
+// setup "x.should.y" assertion style
+chai.should();
+chai.use(sinonChai);
+
+// module to be tested
+const parseBroadcast = require('../../../../lib/middleware/import-message/parse-broadcast');
+
+// sinon sandbox object
+const sandbox = sinon.sandbox.create();
+
+// Setup!
+test.beforeEach((t) => {
+  sandbox.stub(analyticsHelper, 'addParameters')
+    .returns(underscore.noop);
+  sandbox.stub(helpers, 'sendErrorResponse')
+    .returns(underscore.noop);
+
+  // setup req, res mocks
+  t.context.req = httpMocks.createRequest();
+  t.context.req.broadcast = broadcastFactory.getValidBroadcast();
+  t.context.res = httpMocks.createResponse();
+});
+
+// Cleanup!
+test.afterEach((t) => {
+  // reset stubs, spies, and mocks
+  sandbox.restore();
+  t.context = {};
+});
+
+test('parseBroadcast should inject vars into the req object when they exist', async (t) => {
+  // setup
+  const next = sinon.stub();
+  const middleware = parseBroadcast();
+  sandbox.spy(contentful, 'getCampaignIdFromBroadcast');
+  sandbox.spy(contentful, 'getMessageTextFromBroadcast');
+  sandbox.spy(contentful, 'getTopicFromBroadcast');
+
+  // test
+  await middleware(t.context.req, t.context.res, next);
+  analyticsHelper.addParameters.should.have.been.called;
+  contentful.getCampaignIdFromBroadcast.should.have.been.called;
+  t.context.req.campaignId.should.equal(stubs.getCampaignId());
+  contentful.getTopicFromBroadcast.should.have.been.called;
+  t.context.req.topic.should.equal(stubs.getTopic());
+  contentful.getMessageTextFromBroadcast.should.have.been.called;
+  t.context.req.outboundMessageText.should.equal(stubs.getBroadcastMessageText());
+  next.should.have.been.called;
+});
+
+test('parseBroadcast should call sendErrorResponse on error', async (t) => {
+  // setup
+  const next = sinon.stub();
+  const middleware = parseBroadcast();
+  t.context.req.broadcastId = 'notFound';
+  sandbox.stub(contentful, 'getCampaignIdFromBroadcast')
+    .callsFake(new Error());
+
+  // test
+  await middleware(t.context.req, t.context.res, next);
+  helpers.sendErrorResponse.should.have.been.called;
+  t.context.req.should.not.have.property('campaignId');
+  next.should.not.have.been.called;
+});


### PR DESCRIPTION
* Moves parsing functions defined in `parse-broadcast` into `contentful` to complete TODOs in #233 
* Adds more broadcast properties for #206  
* Adds tests for `lib/middleware/import-message/parse-broadcast`, `lib/helpers/analytics`