### PR TITLE
Fix sendErrorResponse Cannot read property 'status' of undefined

### DIFF
--- a/app/exceptions/InternalServerError.js
+++ b/app/exceptions/InternalServerError.js
@@ -1,0 +1,10 @@
+'use strict';
+
+class InternalServerError extends Error {
+  constructor(message = 'Generic Internal Server Error') {
+    super(message);
+    this.status = 500;
+  }
+}
+
+module.exports = InternalServerError;

--- a/app/exceptions/NotFoundError.js
+++ b/app/exceptions/NotFoundError.js
@@ -1,7 +1,7 @@
 'use strict';
 
 class NotFoundError extends Error {
-  constructor(message) {
+  constructor(message = 'Generic Not Found Error') {
     super(message);
     this.status = 404;
   }

--- a/app/exceptions/UnprocessibleEntityError.js
+++ b/app/exceptions/UnprocessibleEntityError.js
@@ -1,7 +1,7 @@
 'use strict';
 
 class UnprocessibleEntityError extends Error {
-  constructor(message) {
+  constructor(message = 'Generic Unprocessible Error') {
     super(message);
     this.status = 422;
   }

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -8,6 +8,8 @@ const gambitCampaigns = require('./gambit-campaigns');
 const config = require('../config/lib/helpers');
 const helpers = require('./helpers/index');
 const Message = require('../app/models/Message');
+const InternalServerError = require('../app/exceptions/InternalServerError');
+
 
 // TODO: Move contents of this helper.js file into lib/helpers/index.js or to modular helpers
 
@@ -93,21 +95,17 @@ module.exports.subscriptionStatusStopValue = function () {
  * @param  {Error} err
  */
 module.exports.sendErrorResponse = function (res, err) {
-  let status = err.status;
-  if (!status) {
-    status = 500;
-  }
-  let message = err.message;
-  if (!message) {
-    message = err;
-  }
+  const error = err || new InternalServerError();
+
+  const status = error.status || 500;
+  const message = error.message || error.toString();
 
   /**
    * If the error has a response and the response contain the Blink Suppress headers,
-   * this error is being relayed to Blink from Campaigns. We have to also relay the Suppress
-   * headers.
+   * this error is being relayed to Blink from Campaigns through Conversations.
+   * We have to also relay the Suppress headers.
    */
-  if (err.response && err.response.get && err.response.get(config.blinkSupressHeaders)) {
+  if (error.response && error.response.get && error.response.get(config.blinkSupressHeaders)) {
     exports.addBlinkSuppressHeaders(res);
   }
 

--- a/test/lib/helpers.test.js
+++ b/test/lib/helpers.test.js
@@ -1,0 +1,66 @@
+'use strict';
+
+require('dotenv').config();
+
+const test = require('ava');
+const chai = require('chai');
+const sinon = require('sinon');
+const sinonChai = require('sinon-chai');
+const httpMocks = require('node-mocks-http');
+
+const InternalServerError = require('../../app/exceptions/InternalServerError');
+const UnprocessibleEntityError = require('../../app/exceptions/UnprocessibleEntityError.js');
+
+chai.should();
+chai.use(sinonChai);
+
+const sandbox = sinon.sandbox.create();
+
+// Module to test
+const helpers = require('../../lib/helpers');
+
+test.afterEach(() => {
+  // reset stubs, spies, and mocks
+  sandbox.restore();
+});
+
+// Tests
+
+test('helpers.sendErrorResponse(res, anyString): should respond with error status 500 and anyString\'s value as message', () => {
+  const res = httpMocks.createResponse();
+  const errorString = 'omgError';
+  sandbox.stub(helpers, 'sendResponseWithStatusCode').returns(true);
+
+  helpers.sendErrorResponse(res, errorString);
+
+  const callArgs = helpers.sendResponseWithStatusCode.getCall(0).args;
+  helpers.sendResponseWithStatusCode.should.have.been.called;
+  callArgs[1].should.be.equal(500);
+  callArgs[2].should.be.equal(errorString);
+});
+
+test('helpers.sendErrorResponse(res, error): should respond with error status and error message', () => {
+  const res = httpMocks.createResponse();
+  const genericError = new UnprocessibleEntityError();
+  sandbox.stub(helpers, 'sendResponseWithStatusCode').returns(true);
+
+  helpers.sendErrorResponse(res, genericError);
+
+  const callArgs = helpers.sendResponseWithStatusCode.getCall(0).args;
+  helpers.sendResponseWithStatusCode.should.have.been.called;
+  callArgs[1].should.be.equal(genericError.status);
+  callArgs[2].should.be.equal(genericError.message);
+});
+
+test('helpers.sendErrorResponse(res): not sending an error should use a Generic Internal Server Error response', () => {
+  const res = httpMocks.createResponse();
+  const genericError = new InternalServerError();
+  sandbox.stub(helpers, 'sendResponseWithStatusCode').returns(true);
+
+  helpers.sendErrorResponse(res);
+
+  const callArgs = helpers.sendResponseWithStatusCode.getCall(0).args;
+  helpers.sendResponseWithStatusCode.should.have.been.called;
+  callArgs[1].should.be.equal(genericError.status);
+  callArgs[2].should.be.equal(genericError.message);
+});


### PR DESCRIPTION
#### What's this PR do?
It handles the case when `sendErrorResponse` receives a `res` but no `err` argument.

#### How to test?
- 👀 
- Run `npm run all-tests`

#### Relevant issues
Fixes #237 