### PR TITLE
New Relic parameter for API response messages

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -10,7 +10,6 @@ const helpers = require('./helpers/index');
 const Message = require('../app/models/Message');
 const InternalServerError = require('../app/exceptions/InternalServerError');
 
-
 // TODO: Move contents of this helper.js file into lib/helpers/index.js or to modular helpers
 
 // register helpers
@@ -126,6 +125,7 @@ module.exports.sendResponseWithStatusCode = function (res, code = 200, message =
   } else {
     logger.error('sendResponseWithStatusCode', { code, response }, res);
   }
+  helpers.analytics.addParameters({ gambitApiResponseMessage: message });
 
   return res.status(code).send(response);
 };

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -120,7 +120,7 @@ module.exports.sendErrorResponse = function (res, err) {
  */
 module.exports.sendResponseWithStatusCode = function (res, code = 200, message = 'OK') {
   const response = { message };
-  if (code < 300) {
+  if (code < 400) {
     logger.debug('sendResponseWithStatusCode', { code, response }, res);
   } else {
     logger.error('sendResponseWithStatusCode', { code, response }, res);

--- a/test/lib/helpers.test.js
+++ b/test/lib/helpers.test.js
@@ -19,12 +19,16 @@ const sandbox = sinon.sandbox.create();
 // Module to test
 const helpers = require('../../lib/helpers');
 
+const analyticsHelper = helpers.analytics;
+
 test.afterEach(() => {
   // reset stubs, spies, and mocks
   sandbox.restore();
 });
 
 // Tests
+
+// sendErrorResponse
 
 test('helpers.sendErrorResponse(res, anyString): should respond with error status 500 and anyString\'s value as message', () => {
   const res = httpMocks.createResponse();
@@ -63,4 +67,15 @@ test('helpers.sendErrorResponse(res): not sending an error should use a Generic 
   helpers.sendResponseWithStatusCode.should.have.been.called;
   callArgs[1].should.be.equal(genericError.status);
   callArgs[2].should.be.equal(genericError.message);
+});
+
+// sendResponseWithStatusCode
+test('helpers.sendResponseWithStatusCode(res, code, msg): should call analyticsHelper.addParameters', () => {
+  const res = httpMocks.createResponse();
+  sandbox.stub(analyticsHelper, 'addParameters').returns(true);
+  const message = 'Epic fail :-(';
+
+  helpers.sendErrorResponse(res, 500, message);
+
+  analyticsHelper.addParameters.should.have.been.called;
 });

--- a/test/lib/helpers.test.js
+++ b/test/lib/helpers.test.js
@@ -16,10 +16,12 @@ chai.use(sinonChai);
 
 const sandbox = sinon.sandbox.create();
 
+// App modules
+const analyticsHelper = require('../../lib/helpers').analytics;
+const logger = require('../../lib/logger');
+
 // Module to test
 const helpers = require('../../lib/helpers');
-
-const analyticsHelper = helpers.analytics;
 
 test.afterEach(() => {
   // reset stubs, spies, and mocks
@@ -70,12 +72,45 @@ test('helpers.sendErrorResponse(res): not sending an error should use a Generic 
 });
 
 // sendResponseWithStatusCode
-test('helpers.sendResponseWithStatusCode(res, code, msg): should call analyticsHelper.addParameters', () => {
+test('helpers.sendResponseWithStatusCode(res, code, msg): should call res.status and res.send', () => {
   const res = httpMocks.createResponse();
+  sandbox.spy(res, 'status');
+  sandbox.spy(res, 'send');
   sandbox.stub(analyticsHelper, 'addParameters').returns(true);
+  const statusCode = 501;
   const message = 'Epic fail :-(';
 
-  helpers.sendErrorResponse(res, 500, message);
-
+  helpers.sendResponseWithStatusCode(res, statusCode, message);
+  res.status.should.have.been.called;
+  res.send.should.have.been.called;
+  res.statusCode.should.be.equal(statusCode);
+  const body = res._getData(); // eslint-disable-line no-underscore-dangle
+  body.message.should.be.equal(message);
   analyticsHelper.addParameters.should.have.been.called;
+});
+
+test('helpers.sendResponseWithStatusCode(res, code, msg): should call logger.error for errors', () => {
+  const res = httpMocks.createResponse();
+  sandbox.stub(logger, 'debug').returns(true);
+  sandbox.stub(logger, 'error').returns(true);
+  sandbox.stub(analyticsHelper, 'addParameters').returns(true);
+  const statusCode = 501;
+  const message = 'Oh noes another epic fail D:';
+
+  helpers.sendResponseWithStatusCode(res, statusCode, message);
+  logger.debug.should.not.have.been.called;
+  logger.error.should.have.been.called;
+});
+
+test('helpers.sendResponseWithStatusCode(res, code, msg): should call logger.debug if success', () => {
+  const res = httpMocks.createResponse();
+  sandbox.stub(logger, 'debug').returns(true);
+  sandbox.stub(logger, 'error').returns(true);
+  sandbox.stub(analyticsHelper, 'addParameters').returns(true);
+  const statusCode = 201;
+  const message = 'Great job';
+
+  helpers.sendResponseWithStatusCode(res, statusCode, message);
+  logger.error.should.not.have.been.called;
+  logger.debug.should.have.been.called;
 });


### PR DESCRIPTION
* Adds a call to pass the API response `body.message` to New Relic from `helpers.sendResponseWithStatusCode` - refs #206 
* Adds tests for `helpers.sendResponseWithStatusCode`