### PR TITLE
Adds Message.macro

### DIFF
--- a/app/models/Conversation.js
+++ b/app/models/Conversation.js
@@ -217,7 +217,9 @@ conversationSchema.methods.getMessagePayloadFromReq = function (req = {}, direct
   if (req.rivescriptMatch) {
     data.match = req.rivescriptMatch;
   }
-
+  if (req.macro) {
+    data.macro = req.macro;
+  }
   return data;
 };
 

--- a/app/models/Message.js
+++ b/app/models/Message.js
@@ -27,6 +27,7 @@ const messageSchema = new mongoose.Schema({
   broadcastId: String,
   agentId: String,
   match: String,
+  macro: String,
   metadata: {
     requestId: { type: String, index: true },
     retryCount: Number,

--- a/app/routes/receive-message.js
+++ b/app/routes/receive-message.js
@@ -38,12 +38,12 @@ router.use(createConversationMiddleware());
 router.use(getUserMiddleware());
 router.use(createUserIfNotFoundMiddleware());
 
+// Send inbound message text to Rivescript for a reply.
+router.use(getRivescriptReplyMiddleware());
+
 // Load/create inbound message.
 router.use(loadInboundMessageMiddleware());
 router.use(createInboundMessageMiddleware());
-
-// Send our inbound message to Rivescript bot for a reply.
-router.use(getRivescriptReplyMiddleware());
 
 // Updates Last Messaged At, Subscription Status, Paused.
 router.use(updateUserMiddleware());

--- a/brain/keywords.rive
+++ b/brain/keywords.rive
@@ -10,7 +10,7 @@
 @ info
 
 + menu
-- pitchCampaign
+- campaignMenu
 
 + q
 - supportRequested

--- a/brain/keywords.rive
+++ b/brain/keywords.rive
@@ -9,6 +9,9 @@
 + help
 @ info
 
++ menu
+- pitchCampaign
+
 + q
 - supportRequested
 

--- a/config/lib/helpers.js
+++ b/config/lib/helpers.js
@@ -1,9 +1,6 @@
 'use strict';
 
-const menuCommand = 'menu';
-
 module.exports = {
-  menuCommand,
   subscriptionStatusValues: {
     active: 'active',
     less: 'less',

--- a/config/lib/helpers/macro.js
+++ b/config/lib/helpers/macro.js
@@ -5,6 +5,7 @@ module.exports = {
     confirmedCampaign: 'confirmedCampaign',
     declinedCampaign: 'declinedCampaign',
     gambit: 'gambit',
+    pitchCampaign: 'pitchCampaign',
     sendCrisisMessage: 'sendCrisisMessage',
     sendInfoMessage: 'sendInfoMessage',
     subscriptionStatusLess: 'subscriptionStatusLess',

--- a/config/lib/helpers/macro.js
+++ b/config/lib/helpers/macro.js
@@ -2,10 +2,10 @@
 
 module.exports = {
   macros: {
+    campaignMenu: 'campaignMenu',
     confirmedCampaign: 'confirmedCampaign',
     declinedCampaign: 'declinedCampaign',
     gambit: 'gambit',
-    pitchCampaign: 'pitchCampaign',
     sendCrisisMessage: 'sendCrisisMessage',
     sendInfoMessage: 'sendInfoMessage',
     subscriptionStatusLess: 'subscriptionStatusLess',

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -14,11 +14,6 @@ Object.keys(helpers).forEach((helperName) => {
   module.exports[helperName] = helpers[helperName];
 });
 
-
-module.exports.isMenuCommand = function (text = '') {
-  return (text.toLowerCase() === config.menuCommand);
-};
-
 function getSubscriptionStatusValueForKey(key) {
   return config.subscriptionStatusValues[key];
 }

--- a/lib/helpers/macro.js
+++ b/lib/helpers/macro.js
@@ -8,7 +8,7 @@ const config = require('../../config/lib/helpers/macro');
  */
 module.exports.isMacro = function (text) {
   const result = config.macros[text];
-  logger.debug('isMacro', { text, result });
+  logger.debug('helpers.macro.isMacro', { result });
 
   return result;
 };
@@ -24,9 +24,12 @@ module.exports.isDeclinedCampaign = function (text) {
   return (text === config.macros.declinedCampaign);
 };
 
+module.exports.isPitchCampaign = function (text) {
+  return (text === config.macros.pitchCampaign);
+};
+
 module.exports.isSendCrisisMessage = function (text) {
-  const result = (text === config.macros.sendCrisisMessage);
-  return result;
+  return (text === config.macros.sendCrisisMessage);
 };
 
 module.exports.isSendInfoMessage = function (text) {

--- a/lib/helpers/macro.js
+++ b/lib/helpers/macro.js
@@ -24,8 +24,8 @@ module.exports.isDeclinedCampaign = function (text) {
   return (text === config.macros.declinedCampaign);
 };
 
-module.exports.isPitchCampaign = function (text) {
-  return (text === config.macros.pitchCampaign);
+module.exports.isCampaignMenu = function (text) {
+  return (text === config.macros.campaignMenu);
 };
 
 module.exports.isSendCrisisMessage = function (text) {

--- a/lib/helpers/request.js
+++ b/lib/helpers/request.js
@@ -24,4 +24,11 @@ module.exports = {
      */
     return messageStatus === 'delivered';
   },
+  parseCampaignKeyword: function parseCampaignKeyword(req) {
+    const text = req.inboundMessageText;
+    if (!text) {
+      return null;
+    }
+    return text.trim().toLowerCase();
+  },
 };

--- a/lib/middleware/receive-message/campaign-keyword.js
+++ b/lib/middleware/receive-message/campaign-keyword.js
@@ -6,18 +6,16 @@ const gambitCampaigns = require('../../gambit-campaigns');
 
 module.exports = function getCampaignForKeyword() {
   return (req, res, next) => {
-    const loggerMessage = 'getCampaignForKeyword';
-    let keyword = req.userCommand;
+    const keyword = helpers.request.parseCampaignKeyword(req);
     if (!keyword) {
       return next();
     }
 
-    keyword = keyword.toLowerCase();
-    // Did User send a Campaign keyword?
+    // Check if this is a Campaign Keyword.
     return gambitCampaigns.getCampaignByKeyword(keyword)
       .then((campaign) => {
         if (!campaign) {
-          logger.debug(`${loggerMessage} not found`, { keyword }, req);
+          logger.debug('No campaigns found for keyword', { keyword }, req);
           return next();
         }
         req.campaign = campaign;

--- a/lib/middleware/receive-message/campaign-menu.js
+++ b/lib/middleware/receive-message/campaign-menu.js
@@ -5,7 +5,7 @@ const gambitCampaigns = require('../../gambit-campaigns.js');
 
 module.exports = function campaignMenu() {
   return (req, res, next) => {
-    if (!helpers.isMenuCommand(req.userCommand)) {
+    if (!helpers.macro.isPitchCampaign(req.rivescriptReplyText)) {
       return next();
     }
 

--- a/lib/middleware/receive-message/campaign-menu.js
+++ b/lib/middleware/receive-message/campaign-menu.js
@@ -5,7 +5,7 @@ const gambitCampaigns = require('../../gambit-campaigns.js');
 
 module.exports = function campaignMenu() {
   return (req, res, next) => {
-    if (!helpers.macro.isPitchCampaign(req.rivescriptReplyText)) {
+    if (!helpers.macro.isCampaignMenu(req.macro)) {
       return next();
     }
 

--- a/lib/middleware/receive-message/message-inbound-create.js
+++ b/lib/middleware/receive-message/message-inbound-create.js
@@ -9,11 +9,6 @@ module.exports = function createInboundMessage() {
       return next();
     }
 
-    // TODO: This should be moved to receive-message/params middleware
-    if (req.inboundMessageText) {
-      req.userCommand = req.inboundMessageText.trim();
-    }
-
     return req.conversation.createMessage('inbound', req.inboundMessageText, null, req)
       .then((message) => {
         req.inboundMessage = message;

--- a/lib/middleware/receive-message/message-inbound-load.js
+++ b/lib/middleware/receive-message/message-inbound-load.js
@@ -10,11 +10,6 @@ module.exports = function loadInboundMessage() {
       return next();
     }
 
-    // TODO: This should be moved to receive-message/params middleware
-    if (req.inboundMessageText) {
-      req.userCommand = req.inboundMessageText.trim();
-    }
-
     return Message.updateInboundMessageMetadataByRequestId(req.metadata.requestId,
       req.metadata)
       .then((message) => {

--- a/lib/middleware/receive-message/parse-ask-continue-answer.js
+++ b/lib/middleware/receive-message/parse-ask-continue-answer.js
@@ -9,7 +9,7 @@ module.exports = function parseAskContinueResponse() {
       return next();
     }
 
-    const text = req.rivescriptReplyText;
+    const text = req.macro;
     if (helpers.macro.isConfirmedCampaign(text)) {
       return helpers.replies.confirmedContinue(req, res);
     }

--- a/lib/middleware/receive-message/parse-ask-signup-answer.js
+++ b/lib/middleware/receive-message/parse-ask-signup-answer.js
@@ -9,7 +9,7 @@ module.exports = function parseAskSignupResponse() {
       return next();
     }
 
-    const text = req.rivescriptReplyText;
+    const text = req.macro;
     if (helpers.macro.isConfirmedCampaign(text)) {
       return helpers.replies.confirmedSignup(req, res);
     }

--- a/lib/middleware/receive-message/rivescript-reply-get.js
+++ b/lib/middleware/receive-message/rivescript-reply-get.js
@@ -9,9 +9,15 @@ module.exports = function getRivescriptReply() {
     rivescript.getReply(req.conversation, req.inboundMessageText)
       .then((rivescriptRes) => {
         logger.debug('rivescript.getReply', rivescriptRes, req);
-        req.rivescriptReplyText = rivescriptRes.text;
+        const replyText = rivescriptRes.text;
+        req.rivescriptReplyText = replyText;
         req.rivescriptMatch = rivescriptRes.match;
         req.rivescriptReplyTopic = rivescriptRes.topic;
+        const isMacro = helpers.macro.isMacro(replyText);
+        if (isMacro) {
+          req.macro = replyText;
+        }
+
         return next();
       })
       .catch(err => helpers.sendErrorResponse(res, err));

--- a/lib/middleware/receive-message/rivescript-reply-get.js
+++ b/lib/middleware/receive-message/rivescript-reply-get.js
@@ -5,21 +5,19 @@ const helpers = require('../../helpers');
 const rivescript = require('../../rivescript');
 
 module.exports = function getRivescriptReply() {
-  return (req, res, next) => {
-    rivescript.getReply(req.conversation, req.inboundMessageText)
-      .then((rivescriptRes) => {
-        logger.debug('rivescript.getReply', rivescriptRes, req);
-        const replyText = rivescriptRes.text;
-        req.rivescriptReplyText = replyText;
-        req.rivescriptMatch = rivescriptRes.match;
-        req.rivescriptReplyTopic = rivescriptRes.topic;
-        const isMacro = helpers.macro.isMacro(replyText);
-        if (isMacro) {
-          req.macro = replyText;
-        }
+  return (req, res, next) => rivescript.getReply(req.conversation, req.inboundMessageText)
+    .then((rivescriptRes) => {
+      logger.debug('rivescript.getReply', rivescriptRes, req);
+      const replyText = rivescriptRes.text;
+      req.rivescriptReplyText = replyText;
+      req.rivescriptMatch = rivescriptRes.match;
+      req.rivescriptReplyTopic = rivescriptRes.topic;
+      const isMacro = helpers.macro.isMacro(replyText);
+      if (isMacro) {
+        req.macro = replyText;
+      }
 
-        return next();
-      })
-      .catch(err => helpers.sendErrorResponse(res, err));
-  };
+      return next();
+    })
+    .catch(err => helpers.sendErrorResponse(res, err));
 };

--- a/lib/middleware/receive-message/rivescript-reply-get.js
+++ b/lib/middleware/receive-message/rivescript-reply-get.js
@@ -12,7 +12,14 @@ module.exports = function getRivescriptReply() {
       req.rivescriptReplyText = replyText;
       req.rivescriptMatch = rivescriptRes.match;
       req.rivescriptReplyTopic = rivescriptRes.topic;
-      const isMacro = helpers.macro.isMacro(replyText);
+
+      let isMacro;
+      try {
+        isMacro = helpers.macro.isMacro(replyText);
+      } catch (err) {
+        return helpers.sendErrorResponse(res, err);
+      }
+
       if (isMacro) {
         req.macro = replyText;
       }

--- a/lib/middleware/receive-message/support-requested.js
+++ b/lib/middleware/receive-message/support-requested.js
@@ -4,7 +4,7 @@ const helpers = require('../../helpers');
 
 module.exports = function requestSupport() {
   return (req, res, next) => {
-    if (!helpers.macro.isSupportRequested(req.rivescriptReplyText)) {
+    if (!helpers.macro.isSupportRequested(req.macro)) {
       return next();
     }
 

--- a/lib/middleware/receive-message/template-crisis.js
+++ b/lib/middleware/receive-message/template-crisis.js
@@ -4,7 +4,7 @@ const helpers = require('../../helpers');
 
 module.exports = function sendCrisisMessage() {
   return (req, res, next) => {
-    if (helpers.macro.isSendCrisisMessage(req.rivescriptReplyText)) {
+    if (helpers.macro.isSendCrisisMessage(req.macro)) {
       return helpers.replies.crisisMessage(req, res);
     }
 

--- a/lib/middleware/receive-message/template-info.js
+++ b/lib/middleware/receive-message/template-info.js
@@ -4,7 +4,7 @@ const helpers = require('../../helpers');
 
 module.exports = function sendInfoMessage() {
   return (req, res, next) => {
-    if (helpers.macro.isSendInfoMessage(req.rivescriptReplyText)) {
+    if (helpers.macro.isSendInfoMessage(req.macro)) {
       return helpers.replies.infoMessage(req, res);
     }
 

--- a/lib/middleware/receive-message/template-rivescript.js
+++ b/lib/middleware/receive-message/template-rivescript.js
@@ -4,7 +4,7 @@ const helpers = require('../../helpers');
 
 module.exports = function sendRivescriptReply() {
   return (req, res, next) => {
-    if (helpers.macro.isMacro(req.rivescriptReplyText)) {
+    if (req.macro) {
       return next();
     }
 

--- a/test/helpers/factories/conversation.js
+++ b/test/helpers/factories/conversation.js
@@ -1,13 +1,13 @@
 'use strict';
 
 const ObjectID = require('mongoose').Types.ObjectId;
-
+const Conversation = require('../../../app/models/Conversation');
 const stubs = require('../stubs');
 
 module.exports.getValidConversation = function getValidConversation(phoneNumber) {
   const id = new ObjectID();
   const date = new Date();
-  return {
+  return new Conversation({
     id,
     _id: id,
     platform: stubs.getPlatform(),
@@ -16,5 +16,5 @@ module.exports.getValidConversation = function getValidConversation(phoneNumber)
     paused: false,
     createdAt: date,
     updatedAt: date,
-  };
+  });
 };

--- a/test/lib/lib-helpers/macro.test.js
+++ b/test/lib/lib-helpers/macro.test.js
@@ -39,6 +39,11 @@ test('isMacro should return falsy for undefined macro', (t) => {
   t.falsy(macroHelper.isMacro(undefinedMacroName));
 });
 
+test('isCampaignMenu should return boolean', (t) => {
+  t.true(macroHelper.isCampaignMenu(macros.campaignMenu));
+  t.falsy(macroHelper.isCampaignMenu(undefinedMacroName));
+});
+
 test('isConfirmedCampaign should return boolean', (t) => {
   t.true(macroHelper.isConfirmedCampaign(macros.confirmedCampaign));
   t.falsy(macroHelper.isConfirmedCampaign(undefinedMacroName));

--- a/test/lib/lib-helpers/request.test.js
+++ b/test/lib/lib-helpers/request.test.js
@@ -1,0 +1,40 @@
+'use strict';
+
+// libs
+require('dotenv').config();
+const test = require('ava');
+const chai = require('chai');
+const sinon = require('sinon');
+const sinonChai = require('sinon-chai');
+
+// setup "x.should.y" assertion style
+chai.should();
+chai.use(sinonChai);
+
+// module to be tested
+const requestHelper = require('../../../lib/helpers/request');
+
+// sinon sandbox object
+const sandbox = sinon.sandbox.create();
+
+// Cleanup
+test.afterEach(() => {
+  // reset stubs, spies, and mocks
+  sandbox.restore();
+});
+
+test('parseCampaignKeyword(req) should return trimmed lowercase req.inboundMessageText', () => {
+  const text = 'Winter ';
+  const trimSpy = sandbox.spy(String.prototype, 'trim');
+  const toLowerCaseSpy = sandbox.spy(String.prototype, 'toLowerCase');
+  const result = requestHelper.parseCampaignKeyword({ inboundMessageText: text });
+
+  trimSpy.should.have.been.called;
+  toLowerCaseSpy.should.have.been.called;
+  result.should.equal('winter');
+});
+
+test('parseCampaignKeyword(req) should return null when req.inboundMessageText undefined', (t) => {
+  const result = requestHelper.parseCampaignKeyword({});
+  t.falsy(result);
+});

--- a/test/lib/middleware/receive-message/campaign-keyword.test.js
+++ b/test/lib/middleware/receive-message/campaign-keyword.test.js
@@ -7,11 +7,18 @@ const chai = require('chai');
 const sinon = require('sinon');
 const sinonChai = require('sinon-chai');
 const httpMocks = require('node-mocks-http');
+const underscore = require('underscore');
 
 const helpers = require('../../../../lib/helpers');
 const gambitCampaigns = require('../../../../lib/gambit-campaigns');
+const stubs = require('../../../helpers/stubs');
+const conversationFactory = require('../../../helpers/factories/conversation');
 
 const requestHelper = helpers.request;
+const replies = helpers.replies;
+const mockConversation = conversationFactory.getValidConversation();
+const mockCampaign = { id: stubs.getCampaignId() };
+const mockKeyword = 'winter';
 
 chai.should();
 chai.use(sinonChai);
@@ -23,8 +30,14 @@ const getCampaignByKeyword = require('../../../../lib/middleware/receive-message
 const sandbox = sinon.sandbox.create();
 
 test.beforeEach((t) => {
-  // setup req, res mocks
+  sandbox.stub(replies, 'campaignClosed')
+    .returns(underscore.noop);
+  sandbox.stub(replies, 'continueCampaign')
+    .returns(underscore.noop);
   t.context.req = httpMocks.createRequest();
+  t.context.req.conversation = mockConversation;
+  sandbox.stub(mockConversation, 'setCampaign')
+    .returns(Promise.resolve(true));
   t.context.req.inboundMessageText = 'winter';
   t.context.res = httpMocks.createResponse();
 });
@@ -47,17 +60,70 @@ test('getCampaignByKeyword should not call gambitCampaigns.getCampaignByKeyword 
   await middleware(t.context.req, t.context.res, next);
   next.should.have.been.called;
   gambitCampaigns.getCampaignByKeyword.should.not.have.been.called;
+  t.falsy(t.context.req.campaign);
+  t.falsy(t.context.req.keyword);
 });
 
-test('getCampaignByKeyword should call gambitCampaigns.getCampaignByKeyword if requestHelper.parseCampaignKeyword', async (t) => {
+test('getCampaignByKeyword should call next if gambitCampaigns.getCampaignByKeyword returns null', async (t) => {
   // setup
   const next = sinon.stub();
   const middleware = getCampaignByKeyword();
   sandbox.stub(requestHelper, 'parseCampaignKeyword')
-    .returns('winter');
-  sandbox.stub(gambitCampaigns, 'getCampaignByKeyword').returns(Promise.resolve(true));
+    .returns(mockKeyword);
+  sandbox.stub(gambitCampaigns, 'getCampaignByKeyword')
+    .returns(Promise.resolve(null));
 
   // test
   await middleware(t.context.req, t.context.res, next);
   gambitCampaigns.getCampaignByKeyword.should.have.been.called;
+  t.context.req.conversation.setCampaign.should.not.have.been.called;
+  next.should.have.been.called;
+  t.falsy(t.context.req.campaign);
+  t.falsy(t.context.req.keyword);
+});
+
+test('getCampaignByKeyword should call replies.campaignClosed if keyword Campaign is closed', async (t) => {
+  // setup
+  const next = sinon.stub();
+  const middleware = getCampaignByKeyword();
+
+  sandbox.stub(requestHelper, 'parseCampaignKeyword')
+    .returns(mockKeyword);
+  sandbox.stub(gambitCampaigns, 'getCampaignByKeyword')
+    .returns(Promise.resolve(mockCampaign));
+  sandbox.stub(gambitCampaigns, 'isClosedCampaign')
+    .returns(true);
+
+  // test
+  await middleware(t.context.req, t.context.res, next);
+  gambitCampaigns.getCampaignByKeyword.should.have.been.called;
+  t.context.req.conversation.setCampaign.should.have.been.called;
+  gambitCampaigns.isClosedCampaign.should.have.been.called;
+  t.context.req.campaign.should.equal(mockCampaign);
+  t.context.req.keyword.should.equal(mockKeyword);
+  replies.continueCampaign.should.not.have.been.called;
+  replies.campaignClosed.should.have.been.called;
+});
+
+test('getCampaignByKeyword should call replies.continueCampaign if keyword Campaign is active', async (t) => {
+  // setup
+  const next = sinon.stub();
+  const middleware = getCampaignByKeyword();
+
+  sandbox.stub(requestHelper, 'parseCampaignKeyword')
+    .returns(mockKeyword);
+  sandbox.stub(gambitCampaigns, 'getCampaignByKeyword')
+    .returns(Promise.resolve(mockCampaign));
+  sandbox.stub(gambitCampaigns, 'isClosedCampaign')
+    .returns(false);
+
+  // test
+  await middleware(t.context.req, t.context.res, next);
+  gambitCampaigns.getCampaignByKeyword.should.have.been.called;
+  t.context.req.conversation.setCampaign.should.have.been.called;
+  gambitCampaigns.isClosedCampaign.should.have.been.called;
+  t.context.req.campaign.should.equal(mockCampaign);
+  t.context.req.keyword.should.equal(mockKeyword);
+  replies.continueCampaign.should.have.been.called;
+  replies.campaignClosed.should.not.have.been.called;
 });

--- a/test/lib/middleware/receive-message/campaign-keyword.test.js
+++ b/test/lib/middleware/receive-message/campaign-keyword.test.js
@@ -1,0 +1,63 @@
+'use strict';
+
+require('dotenv').config();
+
+const test = require('ava');
+const chai = require('chai');
+const sinon = require('sinon');
+const sinonChai = require('sinon-chai');
+const httpMocks = require('node-mocks-http');
+
+const helpers = require('../../../../lib/helpers');
+const gambitCampaigns = require('../../../../lib/gambit-campaigns');
+
+const requestHelper = helpers.request;
+
+chai.should();
+chai.use(sinonChai);
+
+// module to be tested
+const getCampaignByKeyword = require('../../../../lib/middleware/receive-message/campaign-keyword');
+
+// sinon sandbox object
+const sandbox = sinon.sandbox.create();
+
+test.beforeEach((t) => {
+  // setup req, res mocks
+  t.context.req = httpMocks.createRequest();
+  t.context.req.inboundMessageText = 'winter';
+  t.context.res = httpMocks.createResponse();
+});
+
+test.afterEach((t) => {
+  // reset stubs, spies, and mocks
+  sandbox.restore();
+  t.context = {};
+});
+
+test('getCampaignByKeyword should not call gambitCampaigns.getCampaignByKeyword if requestHelper.parseCampaignKeyword is null', async (t) => {
+  // setup
+  const next = sinon.stub();
+  const middleware = getCampaignByKeyword();
+  sandbox.stub(requestHelper, 'parseCampaignKeyword')
+    .returns(null);
+  sandbox.spy(gambitCampaigns, 'getCampaignByKeyword');
+
+  // test
+  await middleware(t.context.req, t.context.res, next);
+  next.should.have.been.called;
+  gambitCampaigns.getCampaignByKeyword.should.not.have.been.called;
+});
+
+test('getCampaignByKeyword should call gambitCampaigns.getCampaignByKeyword if requestHelper.parseCampaignKeyword', async (t) => {
+  // setup
+  const next = sinon.stub();
+  const middleware = getCampaignByKeyword();
+  sandbox.stub(requestHelper, 'parseCampaignKeyword')
+    .returns('winter');
+  sandbox.stub(gambitCampaigns, 'getCampaignByKeyword').returns(Promise.resolve(true));
+
+  // test
+  await middleware(t.context.req, t.context.res, next);
+  gambitCampaigns.getCampaignByKeyword.should.have.been.called;
+});

--- a/test/lib/middleware/receive-message/rivescript-reply-get.test.js
+++ b/test/lib/middleware/receive-message/rivescript-reply-get.test.js
@@ -1,0 +1,81 @@
+'use strict';
+
+require('dotenv').config();
+
+const test = require('ava');
+const chai = require('chai');
+const sinon = require('sinon');
+const sinonChai = require('sinon-chai');
+const httpMocks = require('node-mocks-http');
+const underscore = require('underscore');
+
+const helpers = require('../../../../lib/helpers');
+const rivescript = require('../../../../lib/rivescript');
+const conversationFactory = require('../../../helpers/factories/conversation');
+
+const mockConversation = conversationFactory.getValidConversation();
+const mockText = 'The one true king';
+const mockTopic = 'winterfell';
+const mockMatch = '*';
+const mockRivescriptReply = {
+  text: mockText,
+  topic: mockTopic,
+  match: mockMatch,
+};
+
+// setup "x.should.y" assertion style
+chai.should();
+chai.use(sinonChai);
+
+// module to be tested
+const getRivescriptReply = require('../../../../lib/middleware/receive-message/rivescript-reply-get');
+
+// sinon sandbox object
+const sandbox = sinon.sandbox.create();
+
+test.beforeEach((t) => {
+  sandbox.stub(helpers, 'sendErrorResponse')
+    .returns(underscore.noop);
+  t.context.req = httpMocks.createRequest();
+  t.context.req.conversation = mockConversation;
+  t.context.req.inboundMessageText = 'King of the North';
+  t.context.res = httpMocks.createResponse();
+});
+
+test.afterEach((t) => {
+  // reset stubs, spies, and mocks
+  sandbox.restore();
+  t.context = {};
+});
+
+test('getRivescriptReply should inject vars into req', async (t) => {
+  // setup
+  const next = sinon.stub();
+  const middleware = getRivescriptReply();
+
+  sandbox.stub(rivescript, 'getReply')
+    .returns(Promise.resolve(mockRivescriptReply));
+
+  // test
+  await middleware(t.context.req, t.context.res, next);
+  rivescript.getReply.should.have.been.called;
+  t.context.req.rivescriptReplyText.should.equal(mockText);
+  t.context.req.rivescriptReplyTopic.should.equal(mockTopic);
+  t.context.req.rivescriptMatch.should.equal(mockMatch);
+  next.should.have.been.called;
+  helpers.sendErrorResponse.should.not.have.been.called;
+});
+
+test('getRivescriptReply should call sendErrorResponse if rivescript.getReply fails', async (t) => {
+  // setup
+  const next = sinon.stub();
+  const middleware = getRivescriptReply();
+
+  sandbox.stub(rivescript, 'getReply')
+    .returns(Promise.reject(new Error()));
+
+  // test
+  await middleware(t.context.req, t.context.res, next);
+  next.should.not.have.been.called;
+  helpers.sendErrorResponse.should.have.been.called;
+});


### PR DESCRIPTION
#### Changes:

* Fixes #245: Adds a `macro` property to the Message model.
    * If an inbound message triggers a Rivescript macro, it's saved to a new `req.macro` property and saved for inbound and outbound messages. This unblocks querying by Yes/No/Unsubscribe in #243 -- we'll be running count queries where the macro has been set to `'confirmedCampaign'`, `'declinedCampaign'`, or `'subscriptionStatusStop'` for a `broadcastId`.
    * Changes sequence of middleware in `POST /receive-message` so we set the macro before creating/loading inbound message

* Refactors the MENU command as a Rivescript macro, to keep consistent with keywords like INFO, HELP, STOP, etc., deprecating `helpers.isMenuCommand`

* Adds test coverage for `rivescript-get-reply`, `campaign-keyword` middleware in `lib/middleware/receive-message`

* Adds a `helpers.request.parseCampaignKeyword` to parse a request for value to query for a Contentful Campaign Signup Keyword, deprecating the `req.userCommand` property. Adds test coverage

#### Testing:

* Local: Open Consolebot and send a few messages that trigger macros (info, menu, help, saying yes to a Menu `askSignup` message) and confirm the `Message.macro` is set on both inbound and outbound messages.

* Staging: I'll be opening up a Gambit Admin request that exposes the `macro` accordingly to make it easy to validate expected behavior on staging (upon a staging deploy of each app).