### PR TITLE
added stop as the subscriptionStatusValue for stop

### DIFF
--- a/config/lib/helpers.js
+++ b/config/lib/helpers.js
@@ -1,10 +1,5 @@
 'use strict';
 
 module.exports = {
-  subscriptionStatusValues: {
-    active: 'active',
-    less: 'less',
-    stop: 'undeliverable',
-  },
   blinkSupressHeaders: 'x-blink-retry-suppress',
 };

--- a/config/lib/helpers/subscription.js
+++ b/config/lib/helpers/subscription.js
@@ -1,9 +1,10 @@
 'use strict';
 
 module.exports = {
-  subscriptionStatusValues: {
+  subscriptionStatuses: {
     active: 'active',
     less: 'less',
     stop: 'stop',
+    undeliverable: 'undeliverable',
   },
 };

--- a/config/lib/helpers/subscription.js
+++ b/config/lib/helpers/subscription.js
@@ -1,0 +1,9 @@
+'use strict';
+
+module.exports = {
+  subscriptionStatusValues: {
+    active: 'active',
+    less: 'less',
+    stop: 'stop',
+  },
+};

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -14,22 +14,6 @@ Object.keys(helpers).forEach((helperName) => {
   module.exports[helperName] = helpers[helperName];
 });
 
-function getSubscriptionStatusValueForKey(key) {
-  return config.subscriptionStatusValues[key];
-}
-
-module.exports.subscriptionStatusActiveValue = function () {
-  return getSubscriptionStatusValueForKey('active');
-};
-
-module.exports.subscriptionStatusLessValue = function () {
-  return getSubscriptionStatusValueForKey('less');
-};
-
-module.exports.subscriptionStatusStopValue = function () {
-  return getSubscriptionStatusValueForKey('stop');
-};
-
 /**
  * Sends response with err code and message.
  *

--- a/lib/helpers/index.js
+++ b/lib/helpers/index.js
@@ -9,6 +9,7 @@ const replies = require('./replies');
 const slack = require('./slack');
 const template = require('./template');
 const twilio = require('./twilio');
+const subscription = require('./subscription');
 
 // TODO: Add "Helper" postfix to prevent name confusion with npm modules like twilio.
 module.exports = {
@@ -21,4 +22,5 @@ module.exports = {
   slack,
   template,
   twilio,
+  subscription,
 };

--- a/lib/helpers/subscription.js
+++ b/lib/helpers/subscription.js
@@ -2,14 +2,15 @@
 
 const config = require('../../config/lib/helpers/subscription');
 
-function getStatusValueForKey(key) {
-  return config.subscriptionStatusValues[key];
+function getStatusForKey(key) {
+  return config.subscriptionStatuses[key];
 }
 
 module.exports = {
   statuses: {
-    active: () => getStatusValueForKey('active'),
-    less: () => getStatusValueForKey('less'),
-    stop: () => getStatusValueForKey('stop'),
+    active: () => getStatusForKey('active'),
+    less: () => getStatusForKey('less'),
+    stop: () => getStatusForKey('stop'),
+    undeliverable: () => getStatusForKey('undeliverable'),
   },
 };

--- a/lib/helpers/subscription.js
+++ b/lib/helpers/subscription.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const config = require('../../config/lib/helpers/subscription');
+
+function getStatusValueForKey(key) {
+  return config.subscriptionStatusValues[key];
+}
+
+module.exports = {
+  statuses: {
+    active: () => getStatusValueForKey('active'),
+    less: () => getStatusValueForKey('less'),
+    stop: () => getStatusValueForKey('stop'),
+  },
+};

--- a/lib/middleware/receive-message/user-update.js
+++ b/lib/middleware/receive-message/user-update.js
@@ -10,8 +10,8 @@ module.exports = function updateNorthstarUser() {
     // Note: We're setting SMS status for Slack users. If we ever integrate with another platform,
     // we'll want to store separate platform subscription values on a Northstar User.
     const currentStatus = req.user.sms_status;
-    const lessValue = helpers.subscriptionStatusLessValue();
-    const stopValue = helpers.subscriptionStatusStopValue();
+    const lessValue = helpers.subscription.statuses.less();
+    const stopValue = helpers.subscription.statuses.stop();
     let statusUpdate = null;
 
     if (helpers.macro.isSubscriptionStatusStop(replyText)) {
@@ -24,7 +24,7 @@ module.exports = function updateNorthstarUser() {
       // TODO: There's an edge case here, if a User sends STOP while they're paused.
       // We'll want to update the Conversation.paused to true by default if we're bringing someone
       // back to life.
-      statusUpdate = helpers.subscriptionStatusActiveValue();
+      statusUpdate = helpers.subscription.statuses.active();
     }
 
     const data = {

--- a/lib/middleware/receive-message/user-update.js
+++ b/lib/middleware/receive-message/user-update.js
@@ -12,6 +12,7 @@ module.exports = function updateNorthstarUser() {
     const currentStatus = req.user.sms_status;
     const lessValue = helpers.subscription.statuses.less();
     const stopValue = helpers.subscription.statuses.stop();
+    const undeliverableValue = helpers.subscription.statuses.undeliverable();
     let statusUpdate = null;
 
     if (helpers.macro.isSubscriptionStatusStop(replyText)) {
@@ -20,7 +21,8 @@ module.exports = function updateNorthstarUser() {
       statusUpdate = lessValue;
     // If User is set to undeliverable but we've now received a message from them OR we don't
     // have a status set at all:
-    } else if (currentStatus === stopValue || !currentStatus) {
+    } else if (currentStatus === stopValue ||
+      currentStatus === undeliverableValue || !currentStatus) {
       // TODO: There's an edge case here, if a User sends STOP while they're paused.
       // We'll want to update the Conversation.paused to true by default if we're bringing someone
       // back to life.

--- a/lib/middleware/send-message/user-validate.js
+++ b/lib/middleware/send-message/user-validate.js
@@ -9,7 +9,7 @@ module.exports = function validateUser() {
       return next();
     }
 
-    if (req.user.sms_status === helpers.subscriptionStatusStopValue()) {
+    if (req.user.sms_status === helpers.subscription.statuses.stop()) {
       const error = new UnprocessibleEntityError('Northstar User is unsubscribed.');
       return helpers.sendErrorResponse(res, error);
     }

--- a/test/lib/lib-helpers/subscription.test.js
+++ b/test/lib/lib-helpers/subscription.test.js
@@ -1,0 +1,36 @@
+'use strict';
+
+// libs
+require('dotenv').config();
+const test = require('ava');
+const chai = require('chai');
+const sinon = require('sinon');
+const sinonChai = require('sinon-chai');
+
+// setup "x.should.y" assertion style
+chai.should();
+chai.use(sinonChai);
+
+// app modules
+const config = require('../../../config/lib/helpers/subscription');
+
+const statuses = config.subscriptionStatusValues;
+// const undefinedMacroName = 'trialByCombat';
+
+// module to be tested
+const subscriptionHelper = require('../../../lib/helpers/subscription');
+
+// sinon sandbox object
+const sandbox = sinon.sandbox.create();
+
+// Cleanup
+test.afterEach(() => {
+  // reset stubs, spies, and mocks
+  sandbox.restore();
+});
+
+test('subscriptionHelper.statuses.x() should be equal to config.subscriptionStatusValues.x', () => {
+  Object.keys(statuses).forEach((statusName) => {
+    subscriptionHelper.statuses[statusName]().should.be.equal(statusName);
+  });
+});

--- a/test/lib/lib-helpers/subscription.test.js
+++ b/test/lib/lib-helpers/subscription.test.js
@@ -14,8 +14,7 @@ chai.use(sinonChai);
 // app modules
 const config = require('../../../config/lib/helpers/subscription');
 
-const statuses = config.subscriptionStatusValues;
-// const undefinedMacroName = 'trialByCombat';
+const statuses = config.subscriptionStatuses;
 
 // module to be tested
 const subscriptionHelper = require('../../../lib/helpers/subscription');


### PR DESCRIPTION
#### What does this PR do?
It changes the value of the stop subscription status from `undeliverable` to `stop`.

#### How should this be reviewed?
- Run `npm run all-tests`

#### Relevant Issues
- Pivotal #152612003

#### Tasks
- [x] Test on staging
- [x] User updated to sms_status: `stop` in Customer.io
- [x] User updated to sms_status: `stop` in Northstar.