### PR TITLE
Broadcast cleanup + Receive Message tests

### DIFF
--- a/config/lib/middleware/broadcast-settings/settings.js
+++ b/config/lib/middleware/broadcast-settings/settings.js
@@ -1,7 +1,0 @@
-'use strict';
-
-module.exports = {
-  customerIo: {
-    userPhoneField: '{{customer.phone}}',
-  },
-};

--- a/lib/contentful.js
+++ b/lib/contentful.js
@@ -112,7 +112,10 @@ module.exports.fetchBroadcasts = function () {
   const query = exports.getQueryBuilder()
     .contentType('broadcast')
     // The message field wasn't required pre-Conversations, filter all pre-TGM broadcast entries.
-    .custom({ 'fields.message[exists]': true })
+    .custom({
+      'fields.message[exists]': true,
+      order: '-sys.createdAt',
+    })
     .build();
   return getEntries(query);
 };

--- a/lib/middleware/broadcasts-single/webhook.js
+++ b/lib/middleware/broadcasts-single/webhook.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const logger = require('../../logger');
-
 const helpers = require('../../helpers');
 
 module.exports = function broadcastWebhook() {

--- a/lib/middleware/receive-message/template-crisis.js
+++ b/lib/middleware/receive-message/template-crisis.js
@@ -4,10 +4,14 @@ const helpers = require('../../helpers');
 
 module.exports = function sendCrisisMessage() {
   return (req, res, next) => {
-    if (helpers.macro.isSendCrisisMessage(req.macro)) {
-      return helpers.replies.crisisMessage(req, res);
-    }
+    try {
+      if (helpers.macro.isSendCrisisMessage(req.macro)) {
+        return helpers.replies.crisisMessage(req, res);
+      }
 
-    return next();
+      return next();
+    } catch (err) {
+      return helpers.sendErrorResponse(res, err);
+    }
   };
 };

--- a/lib/middleware/receive-message/template-crisis.js
+++ b/lib/middleware/receive-message/template-crisis.js
@@ -8,7 +8,6 @@ module.exports = function sendCrisisMessage() {
       if (helpers.macro.isSendCrisisMessage(req.macro)) {
         return helpers.replies.crisisMessage(req, res);
       }
-
       return next();
     } catch (err) {
       return helpers.sendErrorResponse(res, err);

--- a/lib/middleware/receive-message/template-info.js
+++ b/lib/middleware/receive-message/template-info.js
@@ -4,10 +4,13 @@ const helpers = require('../../helpers');
 
 module.exports = function sendInfoMessage() {
   return (req, res, next) => {
-    if (helpers.macro.isSendInfoMessage(req.macro)) {
-      return helpers.replies.infoMessage(req, res);
+    try {
+      if (helpers.macro.isSendInfoMessage(req.macro)) {
+        return helpers.replies.infoMessage(req, res);
+      }
+      return next();
+    } catch (err) {
+      return helpers.sendErrorResponse(res, err);
     }
-
-    return next();
   };
 };

--- a/test/lib/middleware/receive-message/template-crisis.test.js
+++ b/test/lib/middleware/receive-message/template-crisis.test.js
@@ -67,3 +67,36 @@ test('crisisTemplate should call next if macro.isSendCrisisMessage is false', as
   replies.crisisMessage.should.not.have.been.called;
   next.should.have.been.called;
 });
+
+test('crisisTemplate should call sendErrorResponse if macro.isSendCrisisMessage throws', async (t) => {
+  // setup
+  const next = sinon.stub();
+  const middleware = crisisTemplate();
+  sandbox.stub(macroHelper, 'isSendCrisisMessage')
+    .throws();
+  sandbox.stub(replies, 'crisisMessage')
+    .returns(underscore.noop);
+
+  // test
+  await middleware(t.context.req, t.context.res, next);
+
+  helpers.sendErrorResponse.should.have.been.called;
+  replies.crisisMessage.should.not.have.been.called;
+  next.should.not.have.been.called;
+});
+
+test('crisisTemplate should call sendErrorResponse if replies.crisisMessage throws', async (t) => {
+  // setup
+  const next = sinon.stub();
+  const middleware = crisisTemplate();
+  sandbox.stub(macroHelper, 'isSendCrisisMessage')
+    .returns(true);
+  sandbox.stub(replies, 'crisisMessage')
+    .throws();
+
+  // test
+  await middleware(t.context.req, t.context.res, next);
+
+  helpers.sendErrorResponse.should.have.been.called;
+  next.should.not.have.been.called;
+});

--- a/test/lib/middleware/receive-message/template-crisis.test.js
+++ b/test/lib/middleware/receive-message/template-crisis.test.js
@@ -1,0 +1,69 @@
+'use strict';
+
+require('dotenv').config();
+
+const test = require('ava');
+const chai = require('chai');
+const sinon = require('sinon');
+const sinonChai = require('sinon-chai');
+const httpMocks = require('node-mocks-http');
+const underscore = require('underscore');
+
+const helpers = require('../../../../lib/helpers');
+
+const macroHelper = helpers.macro;
+const replies = helpers.replies;
+
+chai.should();
+chai.use(sinonChai);
+
+// module to be tested
+const crisisTemplate = require('../../../../lib/middleware/receive-message/template-crisis');
+
+const sandbox = sinon.sandbox.create();
+
+test.beforeEach((t) => {
+  sandbox.stub(helpers, 'sendErrorResponse')
+    .returns(underscore.noop);
+  t.context.req = httpMocks.createRequest();
+  t.context.req.macro = 'trialByCombat';
+  t.context.res = httpMocks.createResponse();
+});
+
+test.afterEach((t) => {
+  // reset stubs, spies, and mocks
+  sandbox.restore();
+  t.context = {};
+});
+
+test('crisisTemplate should call replies.crisisMessage if macro.isSendCrisisMessage is true', async (t) => {
+  // setup
+  const next = sinon.stub();
+  const middleware = crisisTemplate();
+  sandbox.stub(macroHelper, 'isSendCrisisMessage')
+    .returns(true);
+  sandbox.stub(replies, 'crisisMessage')
+    .returns(underscore.noop);
+
+  // test
+  await middleware(t.context.req, t.context.res, next);
+
+  replies.crisisMessage.should.have.been.called;
+  next.should.not.have.been.called;
+});
+
+test('crisisTemplate should call next if macro.isSendCrisisMessage is false', async (t) => {
+  // setup
+  const next = sinon.stub();
+  const middleware = crisisTemplate();
+  sandbox.stub(macroHelper, 'isSendCrisisMessage')
+    .returns(false);
+  sandbox.stub(replies, 'crisisMessage')
+    .returns(underscore.noop);
+
+  // test
+  await middleware(t.context.req, t.context.res, next);
+
+  replies.crisisMessage.should.not.have.been.called;
+  next.should.have.been.called;
+});

--- a/test/lib/middleware/receive-message/template-info.test.js
+++ b/test/lib/middleware/receive-message/template-info.test.js
@@ -1,0 +1,102 @@
+'use strict';
+
+require('dotenv').config();
+
+const test = require('ava');
+const chai = require('chai');
+const sinon = require('sinon');
+const sinonChai = require('sinon-chai');
+const httpMocks = require('node-mocks-http');
+const underscore = require('underscore');
+
+const helpers = require('../../../../lib/helpers');
+
+const macroHelper = helpers.macro;
+const replies = helpers.replies;
+
+chai.should();
+chai.use(sinonChai);
+
+// module to be tested
+const infoTemplate = require('../../../../lib/middleware/receive-message/template-info');
+
+const sandbox = sinon.sandbox.create();
+
+test.beforeEach((t) => {
+  sandbox.stub(helpers, 'sendErrorResponse')
+    .returns(underscore.noop);
+  t.context.req = httpMocks.createRequest();
+  t.context.req.macro = 'trialByCombat';
+  t.context.res = httpMocks.createResponse();
+});
+
+test.afterEach((t) => {
+  // reset stubs, spies, and mocks
+  sandbox.restore();
+  t.context = {};
+});
+
+test('infoTemplate should call replies.infoMessage if macro.isSendInfoMessage is true', async (t) => {
+  // setup
+  const next = sinon.stub();
+  const middleware = infoTemplate();
+  sandbox.stub(macroHelper, 'isSendInfoMessage')
+    .returns(true);
+  sandbox.stub(replies, 'infoMessage')
+    .returns(underscore.noop);
+
+  // test
+  await middleware(t.context.req, t.context.res, next);
+
+  replies.infoMessage.should.have.been.called;
+  next.should.not.have.been.called;
+});
+
+test('infoTemplate should call next if macro.isSendInfoMessage is false', async (t) => {
+  // setup
+  const next = sinon.stub();
+  const middleware = infoTemplate();
+  sandbox.stub(macroHelper, 'isSendInfoMessage')
+    .returns(false);
+  sandbox.stub(replies, 'infoMessage')
+    .returns(underscore.noop);
+
+  // test
+  await middleware(t.context.req, t.context.res, next);
+
+  replies.infoMessage.should.not.have.been.called;
+  next.should.have.been.called;
+});
+
+test('infoTemplate should call sendErrorResponse if macro.isSendInfoMessage throws', async (t) => {
+  // setup
+  const next = sinon.stub();
+  const middleware = infoTemplate();
+  sandbox.stub(macroHelper, 'isSendInfoMessage')
+    .throws();
+  sandbox.stub(replies, 'infoMessage')
+    .returns(underscore.noop);
+
+  // test
+  await middleware(t.context.req, t.context.res, next);
+
+  helpers.sendErrorResponse.should.have.been.called;
+  replies.infoMessage.should.not.have.been.called;
+  next.should.not.have.been.called;
+});
+
+test('infoTemplate should call sendErrorResponse if replies.infoMessage throws', async (t) => {
+  // setup
+  const next = sinon.stub();
+  const middleware = infoTemplate();
+  sandbox.stub(macroHelper, 'isSendInfoMessage')
+    .returns(true);
+  sandbox.stub(replies, 'infoMessage')
+    .throws();
+
+  // test
+  await middleware(t.context.req, t.context.res, next);
+
+  helpers.sendErrorResponse.should.have.been.called;
+  next.should.not.have.been.called;
+});


### PR DESCRIPTION
Broadcasts:
* Sort by most recent on `GET /broadcasts`
* Remove unused `config/lib/middleware/broadcast-settings`

Receive Message:
* Add error catching to  `template-info` and `template-crisis` middleware
* Add tests for each