### PR TITLE
Adds Github templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,34 @@
+_BUG_
+-------------------
+#### Current Behavior
+- tell us what happened
+
+#### Desired Behavior
+- what should have happened
+
+#### Steps to Replicate
+- how can you make it happen every time?
+
+#### Why This Matters
+
+#### Relevant Screenshots + Links
+
+_FEATURE OVERVIEW_
+-------------------
+#### User Story
+
+#### Additional Information (optional)
+
+#### Why This Matters
+
+#### Current Workaround w/o Feature (if applicable)
+
+_HACK DOCUMENTATION_
+-------------------
+#### Related Issue
+
+#### Affected Pages
+
+#### Hack Explanation
+
+#### Please note if this needs to be undone at some point and why.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,16 @@
+#### What's this PR do?
+tell us, what have you changed?
+
+#### How should this be reviewed?
+tell us, how can we review, to test that this works
+
+#### Any background context you want to provide?
+what else?
+
+#### Relevant tickets
+Fixes #
+
+#### Checklist
+- [ ] Documentation added for new features/changed endpoints.
+- [ ] Tested on staging.
+- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,5 +12,6 @@ Fixes #
 
 #### Checklist
 - [ ] Documentation added for new features/changed endpoints.
+- [ ] Tests added for new features/bug fixes.
 - [ ] Tested on staging.
 - [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.


### PR DESCRIPTION
Copies from [Campaigns](https://github.com/DoSomething/gambit-campaigns/tree/master/.github), which was a copy from [Phoenix](https://github.com/DoSomething/phoenix/blob/dev/issue_template.md) 

Up for edits, discussion, ☕️, also feeling 🆗  to keep as is.