### PR TITLE
Cacheman consolidation

### DIFF
--- a/config/lib/gambit-campaigns.js
+++ b/config/lib/gambit-campaigns.js
@@ -2,7 +2,6 @@
 
 module.exports = {
   activeCampaignsCacheKey: 'active',
-  cacheTtl: process.env.DS_GAMBIT_CONVERSATIONS_CAMPAIGNS_CACHE_TTL || 300,
   clientOptions: {
     baseUri: process.env.DS_GAMBIT_CAMPAIGNS_API_BASEURI,
     apiKey: process.env.DS_GAMBIT_CAMPAIGNS_API_KEY,

--- a/config/lib/helpers/broadcast.js
+++ b/config/lib/helpers/broadcast.js
@@ -20,5 +20,4 @@ module.exports = {
      */
     smsBroadcastWebhookUrl: process.env.DS_BLINK_SMS_BROADCAST_WEBHOOK_URL || 'http://localhost:5050/api/v1',
   },
-  statsCacheTtl: process.env.DS_GAMBIT_CONVERSATIONS_BROADCAST_STATS_CACHE_TTL || 300,
 };

--- a/config/lib/helpers/cache.js
+++ b/config/lib/helpers/cache.js
@@ -1,7 +1,17 @@
 'use strict';
 
+function ttl(value) {
+  if (!value) return 300;
+  return value;
+}
+
 module.exports = {
-  ttl: {
-    broadcastStats: process.env.DS_GAMBIT_CONVERSATIONS_BROADCAST_STATS_CACHE_TTL || 300,
+  broadcastStats: {
+    name: 'broadcastStats',
+    ttl: ttl(process.env.DS_GAMBIT_CONVERSATIONS_BROADCAST_STATS_CACHE_TTL),
+  },
+  campaigns: {
+    name: 'campaigns',
+    ttl: ttl(process.env.DS_GAMBIT_CONVERSATIONS_CAMPAIGNS_CACHE_TTL),
   },
 };

--- a/config/lib/helpers/cache.js
+++ b/config/lib/helpers/cache.js
@@ -6,6 +6,10 @@ function ttl(value) {
 }
 
 module.exports = {
+  broadcasts: {
+    name: 'broadcasts',
+    ttl: ttl(process.env.DS_GAMBIT_CONVERSATIONS_BROADCASTS_CACHE_TTL),
+  },
   broadcastStats: {
     name: 'broadcastStats',
     ttl: ttl(process.env.DS_GAMBIT_CONVERSATIONS_BROADCAST_STATS_CACHE_TTL),

--- a/config/lib/middleware/import-message/broadcast.js
+++ b/config/lib/middleware/import-message/broadcast.js
@@ -1,6 +1,0 @@
-'use strict';
-
-module.exports = {
-  // seconds
-  cacheTtl: process.env.DS_GAMBIT_CONVERSATIONS_BROADCASTS_CACHE_TTL || 300,
-};

--- a/lib/gambit-campaigns.js
+++ b/lib/gambit-campaigns.js
@@ -2,12 +2,12 @@
 
 const superagent = require('superagent');
 const Promise = require('bluebird');
-const Cacheman = require('cacheman');
-const logger = require('heroku-logger');
 const underscore = require('underscore');
+
+const helpers = require('./helpers');
+const logger = require('./logger');
 const config = require('../config/lib/gambit-campaigns');
 
-const cache = new Cacheman('campaigns', { ttl: config.cacheTtl });
 const activeCampaignsCacheKey = config.activeCampaignsCacheKey;
 const uri = config.clientOptions.baseUri;
 const apiKey = config.clientOptions.apiKey;
@@ -87,7 +87,10 @@ function fetchActiveCampaigns() {
 
   return new Promise((resolve, reject) => {
     executeGet('campaigns?exclude=true')
-      .then(res => cache.set(activeCampaignsCacheKey, parseCampaignsIndexResponse(res)))
+      .then((res) => {
+        const data = parseCampaignsIndexResponse(res);
+        helpers.cache.campaigns.set(activeCampaignsCacheKey, data);
+      })
       .then(activeCampaigns => resolve(activeCampaigns))
       .catch(error => reject(error));
   });
@@ -97,7 +100,7 @@ function fetchActiveCampaigns() {
  * @return {Promise}
  */
 function getActiveCampaigns() {
-  return cache.get(activeCampaignsCacheKey)
+  return helpers.cache.campaigns.get(activeCampaignsCacheKey)
     .then((activeCampaigns) => {
       if (activeCampaigns) {
         logger.debug('activeCampaigns cache hit');
@@ -135,12 +138,12 @@ function parseReceiveMessageRequest(req) {
 module.exports.postReceiveMessage = function (req) {
   const data = parseReceiveMessageRequest(req);
   const loggerMessage = 'gambitCampaigns.postReceiveMessage';
-  logger.debug(loggerMessage, data);
+  logger.debug(loggerMessage, data, req);
 
   return new Promise((resolve, reject) => {
     executePost('receive-message', data)
       .then((res) => {
-        logger.trace(`${loggerMessage} res.data`, res.data);
+        logger.debug(`${loggerMessage} response`, res.data, req);
         return resolve(res.data);
       })
       .catch(err => reject(err));
@@ -156,7 +159,7 @@ function fetchCampaignById(campaignId) {
 
   return new Promise((resolve, reject) => {
     executeGet(endpoint)
-      .then(res => cache.set(`${campaignId}`, res))
+      .then(res => helpers.cache.campaigns.set(`${campaignId}`, res))
       .then(campaign => resolve(campaign))
       .catch(error => reject(error));
   });
@@ -169,7 +172,7 @@ function fetchCampaignById(campaignId) {
 module.exports.getCampaignById = function (campaignId) {
   logger.debug('getCampaignById', { campaignId });
 
-  return cache.get(`${campaignId}`)
+  return helpers.cache.campaigns.get(`${campaignId}`)
     .then((campaign) => {
       if (campaign) {
         logger.debug('Campaigns cache hit', { campaignId });

--- a/lib/helpers/cache.js
+++ b/lib/helpers/cache.js
@@ -4,11 +4,19 @@ const Cacheman = require('cacheman');
 
 const config = require('../../config/lib/helpers/cache');
 
-// TODO: Broadcast cache into this helper.
+const broadcastsCache = new Cacheman(config.broadcasts.name, config.broadcasts.ttl);
 const broadcastStatsCache = new Cacheman(config.broadcastStats.name, config.broadcastStats.ttl);
 const campaignsCache = new Cacheman(config.campaigns.name, config.campaigns.ttl);
 
 module.exports = {
+  broadcasts: {
+    get: function get(id) {
+      return broadcastsCache.get(id);
+    },
+    set: function set(id, data) {
+      return broadcastsCache.set(id, data);
+    },
+  },
   broadcastStats: {
     get: function get(id) {
       return broadcastStatsCache.get(id);

--- a/lib/helpers/cache.js
+++ b/lib/helpers/cache.js
@@ -4,17 +4,25 @@ const Cacheman = require('cacheman');
 
 const config = require('../../config/lib/helpers/cache');
 
-const ttl = config.ttl;
-// TODO: Move Campaign and Broadcast cache into this helper.
-const broadcastStatsCache = new Cacheman('broadcastStats', ttl.broadcastStats);
+// TODO: Broadcast cache into this helper.
+const broadcastStatsCache = new Cacheman(config.broadcastStats.name, config.broadcastStats.ttl);
+const campaignsCache = new Cacheman(config.campaigns.name, config.campaigns.ttl);
 
 module.exports = {
   broadcastStats: {
-    get: function get(broadcastId) {
-      return broadcastStatsCache.get(broadcastId);
+    get: function get(id) {
+      return broadcastStatsCache.get(id);
     },
-    set: function set(broadcastId, data) {
-      return broadcastStatsCache.set(broadcastId, data);
+    set: function set(id, data) {
+      return broadcastStatsCache.set(id, data);
+    },
+  },
+  campaigns: {
+    get: function get(id) {
+      return campaignsCache.get(id);
+    },
+    set: function set(id, data) {
+      return campaignsCache.set(id, data);
     },
   },
 };

--- a/lib/middleware/import-message/broadcast-get.js
+++ b/lib/middleware/import-message/broadcast-get.js
@@ -37,6 +37,7 @@ module.exports = function getBroadcast() {
               });
           })
           .catch(err => helpers.sendErrorResponse(res, err));
-      });
+      })
+      .catch(err => helpers.sendErrorResponse(res, err));
   };
 };

--- a/lib/middleware/import-message/broadcast-get.js
+++ b/lib/middleware/import-message/broadcast-get.js
@@ -1,12 +1,6 @@
 'use strict';
 
-const Cacheman = require('cacheman');
 const logger = require('../../logger');
-
-const config = require('../../../config/lib/middleware/import-message/broadcast');
-
-const cache = new Cacheman('broadcasts', { ttl: config.cacheTtl });
-
 const helpers = require('../../helpers');
 const contentful = require('../../contentful');
 const UnprocessibleEntityError = require('../../../app/exceptions/UnprocessibleEntityError');
@@ -24,7 +18,7 @@ module.exports = function getBroadcast() {
     }
     helpers.analytics.addParameters({ broadcastId });
 
-    return cache.get(broadcastId)
+    return helpers.cache.broadcasts.get(broadcastId)
       .then((broadcast) => {
         if (broadcast) {
           logger.debug('Broadcasts cache hit', { broadcastId: req.broadcastId }, req);
@@ -36,7 +30,7 @@ module.exports = function getBroadcast() {
         return contentful.fetchBroadcast(broadcastId)
           .then((broadcastObj) => {
             logger.debug('contentful.fetchBroadcast success', { broadcastId }, req);
-            return cache.set(broadcastId, broadcastObj)
+            return helpers.cache.broadcasts.set(broadcastId, broadcastObj)
               .then((cachedBroadcast) => {
                 req.broadcast = cachedBroadcast;
                 return next();

--- a/test/lib/lib-helpers/cache.test.js
+++ b/test/lib/lib-helpers/cache.test.js
@@ -19,6 +19,8 @@ const cacheHelper = rewire('../../../lib/helpers/cache');
 
 const broadcastId = stubs.getBroadcastId();
 const broadcastStats = stubs.getBroadcastStats();
+const campaignId = stubs.getCampaignId();
+const campaign = { id: campaignId, title: 'Winter' };
 
 // sinon sandbox object
 const sandbox = sinon.sandbox.create();
@@ -36,7 +38,10 @@ test.afterEach(() => {
   cacheHelper.__set__('broadcastStatsCache', undefined);
 });
 
-test('broadcastStats.get should return object when stats cache exists', async () => {
+/**
+ * Broadcast Stats
+ */
+test('broadcastStats.get should return object when cache exists', async () => {
   cacheHelper.__set__('broadcastStatsCache', {
     get: () => Promise.resolve(broadcastStats),
   });
@@ -44,7 +49,7 @@ test('broadcastStats.get should return object when stats cache exists', async ()
   result.should.deep.equal(broadcastStats);
 });
 
-test('broadcastStats.get should return falsy when stats cache undefined', async (t) => {
+test('broadcastStats.get should return falsy when cache undefined', async (t) => {
   cacheHelper.__set__('broadcastStatsCache', {
     get: () => Promise.resolve(null),
   });
@@ -67,9 +72,43 @@ test('broadcastStats.set should return an object', async () => {
   result.should.deep.equal(broadcastStats);
 });
 
-test('broadcastStats.set should throw if statsCache.set fails', async (t) => {
+test('broadcastStats.set should throw if broadcastStats.set fails', async (t) => {
   cacheHelper.__set__('broadcastStatsCache', {
     set: () => Promise.reject(new Error()),
   });
   await t.throws(cacheHelper.broadcastStats.set(broadcastId));
+});
+
+/**
+ * Campaigns
+ */
+test('campaigns.get should return object when cache exists', async () => {
+  cacheHelper.__set__('campaignsCache', {
+    get: () => Promise.resolve(campaign),
+  });
+  const result = await cacheHelper.campaigns.get(campaignId);
+  result.should.deep.equal(campaign);
+});
+
+test('campaigns.get should return falsy when cache undefined', async (t) => {
+  cacheHelper.__set__('campaignsCache', {
+    get: () => Promise.resolve(null),
+  });
+  const result = await cacheHelper.campaigns.get(campaignId);
+  t.falsy(result);
+});
+
+test('campaigns.get should return an object', async () => {
+  cacheHelper.__set__('campaignsCache', {
+    set: () => Promise.resolve(campaign),
+  });
+  const result = await cacheHelper.campaigns.set(campaignId);
+  result.should.deep.equal(campaign);
+});
+
+test('campaigns.set should throw if campaignsCache.set fails', async (t) => {
+  cacheHelper.__set__('campaignsCache', {
+    set: () => Promise.reject(new Error()),
+  });
+  await t.throws(cacheHelper.campaigns.set(campaignId));
 });

--- a/test/lib/lib-helpers/cache.test.js
+++ b/test/lib/lib-helpers/cache.test.js
@@ -17,25 +17,22 @@ chai.use(sinonChai);
 // module to be tested
 const cacheHelper = rewire('../../../lib/helpers/cache');
 
+// stubs
 const broadcastId = stubs.getBroadcastId();
 const broadcastStats = stubs.getBroadcastStats();
 const campaignId = stubs.getCampaignId();
 const campaign = { id: campaignId, title: 'Winter' };
 
-// sinon sandbox object
 const sandbox = sinon.sandbox.create();
 
-// Setup!
 test.beforeEach(() => {
   stubs.stubLogger(sandbox, logger);
 });
 
-// Cleanup!
 test.afterEach(() => {
-  // reset stubs, spies, and mocks
   sandbox.restore();
-  // reset statsCache on each test
   cacheHelper.__set__('broadcastStatsCache', undefined);
+  cacheHelper.__set__('campaignsCache', undefined);
 });
 
 /**
@@ -57,7 +54,7 @@ test('broadcastStats.get should return falsy when cache undefined', async (t) =>
   t.falsy(result);
 });
 
-test('broadcastStats.get should throw when statsCache.get fails', async (t) => {
+test('broadcastStats.get should throw when cache set fails', async (t) => {
   cacheHelper.__set__('broadcastStatsCache', {
     get: () => Promise.reject(new Error()),
   });
@@ -72,7 +69,7 @@ test('broadcastStats.set should return an object', async () => {
   result.should.deep.equal(broadcastStats);
 });
 
-test('broadcastStats.set should throw if broadcastStats.set fails', async (t) => {
+test('broadcastStats.set should throw when cache set fails', async (t) => {
   cacheHelper.__set__('broadcastStatsCache', {
     set: () => Promise.reject(new Error()),
   });
@@ -106,7 +103,7 @@ test('campaigns.get should return an object', async () => {
   result.should.deep.equal(campaign);
 });
 
-test('campaigns.set should throw if campaignsCache.set fails', async (t) => {
+test('campaigns.set should throw when cache set fails', async (t) => {
   cacheHelper.__set__('campaignsCache', {
     set: () => Promise.reject(new Error()),
   });

--- a/test/lib/lib-helpers/cache.test.js
+++ b/test/lib/lib-helpers/cache.test.js
@@ -9,6 +9,7 @@ const logger = require('heroku-logger');
 const rewire = require('rewire');
 
 const stubs = require('../../helpers/stubs');
+const broadcastFactory = require('../../helpers/factories/broadcast');
 
 // setup "x.should.y" assertion style
 chai.should();
@@ -19,6 +20,7 @@ const cacheHelper = rewire('../../../lib/helpers/cache');
 
 // stubs
 const broadcastId = stubs.getBroadcastId();
+const broadcast = broadcastFactory.getValidBroadcast();
 const broadcastStats = stubs.getBroadcastStats();
 const campaignId = stubs.getCampaignId();
 const campaign = { id: campaignId, title: 'Winter' };
@@ -31,8 +33,50 @@ test.beforeEach(() => {
 
 test.afterEach(() => {
   sandbox.restore();
+  cacheHelper.__set__('broadcastsCache', undefined);
   cacheHelper.__set__('broadcastStatsCache', undefined);
   cacheHelper.__set__('campaignsCache', undefined);
+});
+
+/**
+ * Broadcasts
+ */
+test('broadcasts.get should return object when cache exists', async () => {
+  cacheHelper.__set__('broadcastsCache', {
+    get: () => Promise.resolve(broadcast),
+  });
+  const result = await cacheHelper.broadcasts.get(broadcastId);
+  result.should.deep.equal(broadcast);
+});
+
+test('broadcasts.get should return falsy when cache undefined', async (t) => {
+  cacheHelper.__set__('broadcastsCache', {
+    get: () => Promise.resolve(null),
+  });
+  const result = await cacheHelper.broadcasts.get(broadcastId);
+  t.falsy(result);
+});
+
+test('broadcasts.get should throw when cache set fails', async (t) => {
+  cacheHelper.__set__('broadcastsCache', {
+    get: () => Promise.reject(new Error()),
+  });
+  await t.throws(cacheHelper.broadcasts.get(broadcastId));
+});
+
+test('broadcasts.set should return an object', async () => {
+  cacheHelper.__set__('broadcastsCache', {
+    set: () => Promise.resolve(broadcast),
+  });
+  const result = await cacheHelper.broadcasts.set(broadcastId);
+  result.should.deep.equal(broadcast);
+});
+
+test('broadcasts.set should throw when cache set fails', async (t) => {
+  cacheHelper.__set__('broadcastsCache', {
+    set: () => Promise.reject(new Error()),
+  });
+  await t.throws(cacheHelper.broadcasts.set(broadcastId));
 });
 
 /**

--- a/test/lib/middleware/import-message/broadcast-get.test.js
+++ b/test/lib/middleware/import-message/broadcast-get.test.js
@@ -9,12 +9,23 @@ const sinonChai = require('sinon-chai');
 const httpMocks = require('node-mocks-http');
 const underscore = require('underscore');
 const Promise = require('bluebird');
+const logger = require('heroku-logger');
 
 const helpers = require('../../../../lib/helpers');
 const analyticsHelper = require('../../../../lib/helpers/analytics');
+const cacheHelper = require('../../../../lib/helpers/cache');
 const contentful = require('../../../../lib/contentful');
 const stubs = require('../../../helpers/stubs');
 const broadcastFactory = require('../../../helpers/factories/broadcast');
+
+// stubs
+const broadcastId = stubs.getBroadcastId();
+const cache = cacheHelper.broadcasts;
+const sendErrorResponseStub = underscore.noop;
+const mockBroadcast = broadcastFactory.getValidBroadcast();
+const broadcastLookupStub = () => Promise.resolve(mockBroadcast);
+const broadcastLookupFailStub = () => Promise.reject({ message: 'Epic fail' });
+const broadcastLookupNotFoundStub = () => Promise.reject({ status: 404 });
 
 // setup "x.should.y" assertion style
 chai.should();
@@ -26,43 +37,65 @@ const getBroadcast = require('../../../../lib/middleware/import-message/broadcas
 // sinon sandbox object
 const sandbox = sinon.sandbox.create();
 
-// stubs
-const sendErrorResponseStub = underscore.noop;
-const mockBroadcast = broadcastFactory.getValidBroadcast();
-const broadcastLookupStub = () => Promise.resolve(mockBroadcast);
-const broadcastLookupFailStub = () => Promise.reject({ message: 'Epic fail' });
-const broadcastLookupNotFoundStub = () => Promise.reject({ status: 404 });
-
-// Setup!
 test.beforeEach((t) => {
+  stubs.stubLogger(sandbox, logger);
   sandbox.stub(analyticsHelper, 'addParameters')
     .returns(underscore.noop);
   sandbox.stub(helpers, 'sendErrorResponse')
     .returns(sendErrorResponseStub);
-
   // setup req, res mocks
   t.context.req = httpMocks.createRequest();
+  t.context.req.broadcastId = broadcastId;
   t.context.res = httpMocks.createResponse();
 });
 
-// Cleanup!
 test.afterEach((t) => {
   // reset stubs, spies, and mocks
   sandbox.restore();
   t.context = {};
 });
 
-test('getBroadcast should inject vars into the req object when found in Contentful', async (t) => {
+/**
+ * Tests
+ */
+test('getBroadcast should set broadcast from cache if cached', async (t) => {
   // setup
   const next = sinon.stub();
   const middleware = getBroadcast();
-  t.context.req.broadcastId = stubs.getBroadcastId();
+  sandbox.stub(cache, 'get')
+    .returns(Promise.resolve(mockBroadcast));
   sandbox.stub(contentful, 'fetchBroadcast')
     .callsFake(broadcastLookupStub);
+  sandbox.stub(cache, 'set')
+    .returns(Promise.resolve(mockBroadcast));
 
   // test
   await middleware(t.context.req, t.context.res, next);
+  cache.get.should.have.been.called;
   analyticsHelper.addParameters.should.have.been.called;
+  contentful.fetchBroadcast.should.not.have.been.called;
+  cache.set.should.not.have.been.called;
+  t.context.req.broadcast.should.deep.equal(mockBroadcast);
+  next.should.have.been.called;
+});
+
+test('getBroadcast should fetch from Contentful to set broadcast if not cached', async (t) => {
+  // setup
+  const next = sinon.stub();
+  const middleware = getBroadcast();
+  sandbox.stub(cache, 'get')
+    .returns(Promise.resolve(null));
+  sandbox.stub(contentful, 'fetchBroadcast')
+    .callsFake(broadcastLookupStub);
+  sandbox.stub(cache, 'set')
+    .returns(Promise.resolve(mockBroadcast));
+
+  // test
+  await middleware(t.context.req, t.context.res, next);
+  cache.get.should.have.been.called;
+  analyticsHelper.addParameters.should.have.been.called;
+  contentful.fetchBroadcast.should.have.been.called;
+  cache.set.should.have.been.called;
   t.context.req.broadcast.should.deep.equal(mockBroadcast);
   next.should.have.been.called;
 });
@@ -71,9 +104,23 @@ test('getBroadcast should call sendErrorResponse if broadcastId not found', asyn
   // setup
   const next = sinon.stub();
   const middleware = getBroadcast();
-  t.context.req.broadcastId = 'notFound';
   sandbox.stub(contentful, 'fetchBroadcast')
     .callsFake(broadcastLookupNotFoundStub);
+
+  // test
+  await middleware(t.context.req, t.context.res, next);
+  analyticsHelper.addParameters.should.have.been.called;
+  helpers.sendErrorResponse.should.have.been.called;
+  t.context.req.should.not.have.property('broadcast');
+  next.should.not.have.been.called;
+});
+
+test('getBroadcast should call sendErrorResponse if cache.get fails', async (t) => {
+  // setup
+  const next = sinon.stub();
+  const middleware = getBroadcast();
+  sandbox.stub(cache, 'get')
+    .returns(Promise.reject(new Error()));
 
   // test
   await middleware(t.context.req, t.context.res, next);

--- a/test/lib/middleware/import-message/broadcast-get.test.js
+++ b/test/lib/middleware/import-message/broadcast-get.test.js
@@ -145,3 +145,25 @@ test('getBroadcast should call sendErrorResponse if contentful.fetchBroadcast fa
   t.context.req.should.not.have.property('broadcast');
   next.should.not.have.been.called;
 });
+
+test('getBroadcast should call sendErrorResponse if cache.set fails', async (t) => {
+  // setup
+  const next = sinon.stub();
+  const middleware = getBroadcast();
+  sandbox.stub(cache, 'get')
+    .returns(Promise.resolve(null));
+  sandbox.stub(contentful, 'fetchBroadcast')
+    .callsFake(broadcastLookupStub);
+  sandbox.stub(cache, 'set')
+    .returns(Promise.reject(new Error()));
+
+  // test
+  await middleware(t.context.req, t.context.res, next);
+  analyticsHelper.addParameters.should.have.been.called;
+  cache.get.should.have.been.called;
+  contentful.fetchBroadcast.should.have.been.called;
+  helpers.sendErrorResponse.should.have.been.called;
+
+  t.context.req.should.not.have.property('broadcast');
+  next.should.not.have.been.called;
+});


### PR DESCRIPTION
#### What's this PR do?

* Refactors the Broadcasts cache defined in `lib/middleware/import-message/broadcast-get` and Campaigns cache defined in `lib/gambit-campaigns` as properties of the cache helper (`lib/helpers/cache`) introduced in #252.

#### How should this be reviewed?
* Post to local `/send-message` and `/import-message` endpoints to verify expected responses.

#### Any background context you want to provide?
Per discussion in https://github.com/DoSomething/gambit-conversations/pull/252#issuecomment-351107604, eventually we'll want to replace using Cacheman with Redis -- this moves all cache into a single location (adding setter and getter tests)


#### Checklist
- [ ] Tests added for new features/bug fixes.
- [ ] Tested on staging.
