### PR TITLE
Support message hotfix

### DIFF
--- a/lib/helpers/tags.js
+++ b/lib/helpers/tags.js
@@ -28,11 +28,11 @@ module.exports = {
     return result;
   },
   getCustomUrlQueryParamValue: function getCustomUrlQueryParamValue(req) {
+    const data = [];
     const userIdField = module.exports.getUserIdCustomUrlQueryValueField(req);
-    const data = [userIdField];
-
-    // The CampaignRunId field could be empty -- add this check to avoid joining on an empty string
-    // in our return.
+    if (userIdField) {
+      data.push(userIdField);
+    }
     const campaignRunIdField = module.exports.getCampaignRunIdCustomUrlQueryValueField(req);
     if (campaignRunIdField) {
       data.push(campaignRunIdField);
@@ -49,9 +49,10 @@ module.exports = {
   },
   getUserIdCustomUrlQueryValueField: function getUserIdCustomUrlQueryValueField(req) {
     const fieldName = config.customUrl.queryValue.fields.userId;
-    // Without a User ID, we'd lose the ability to associate the current req User to the URL, so
-    // don't check for existence of req.user.
-    return module.exports.formatCustomUrlQueryValueField(fieldName, req.user.id);
+    if (req.user && req.user.id) {
+      return module.exports.formatCustomUrlQueryValueField(fieldName, req.user.id);
+    }
+    return '';
   },
   getCampaignRunIdCustomUrlQueryValueField: function getCampaignRunIdCustomUrlQueryValueField(req) {
     const fieldName = config.customUrl.queryValue.fields.campaignRunId;

--- a/test/lib/lib-helpers/tags.test.js
+++ b/test/lib/lib-helpers/tags.test.js
@@ -143,8 +143,9 @@ test('getUserIdCustomUrlQueryValueField should return string for req.user', (t) 
   t.truthy(result.includes(mockUser.id));
 });
 
-test('getUserIdCustomUrlQueryValueField throws if req.user undefined', (t) => {
-  t.throws(() => tagsHelper.getUserIdCustomUrlQueryValueField(t.context.req));
+test('getUserIdCustomUrlQueryValueField returns empty string if req.user undefined', (t) => {
+  const result = tagsHelper.getUserIdCustomUrlQueryValueField(t.context.req);
+  result.should.equal('');
 });
 
 test('getCampaignRunIdCustomUrlQueryValueField should return string for req.user', (t) => {


### PR DESCRIPTION
#### What's this PR do?
Adds a check for `req.user`in our tags helper `render` function to hotfix Support messages.

#### How should this be reviewed?
Will deploy to staging - test that Front responses work for paused Conversations.

#### Relevant tickets
Fixes #260 

#### Checklist
- [x] Tests added for new features/bug fixes.
- [x] Tested on staging.
