### PR TITLE
Update Northstar User address with Twilio data

### DIFF
--- a/lib/helpers/index.js
+++ b/lib/helpers/index.js
@@ -12,6 +12,7 @@ const tags = require('./tags');
 const template = require('./template');
 const twilio = require('./twilio');
 const subscription = require('./subscription');
+const user = require('./user');
 
 // TODO: Add "Helper" postfix to prevent name confusion with npm modules like twilio.
 module.exports = {
@@ -27,4 +28,5 @@ module.exports = {
   template,
   twilio,
   subscription,
+  user,
 };

--- a/lib/helpers/twilio.js
+++ b/lib/helpers/twilio.js
@@ -6,6 +6,8 @@ const request = require('request-promise');
 
 const attachments = require('./attachments');
 
+const platform = 'sms';
+
 /**
  * Twilio helper
  */
@@ -18,10 +20,11 @@ module.exports = {
    * @return {promise}
    */
   parseBody: function parseBody(req) {
-    req.platform = 'sms';
+    req.platform = platform;
     req.inboundMessageText = req.body.Body;
     req.platformMessageId = req.body.MessageSid;
     req.platformUserId = req.body.From;
+    req.platformUserLocation = this.parseUserLocationFromReq(req);
 
     /**
      * Inspect baseUrl to check if it's an import request
@@ -89,5 +92,26 @@ module.exports = {
         }
         return url;
       });
+  },
+
+  /**
+   * parseUserLocationFromReq - parses Northstar User location properties from Twilio request
+   *
+   * @param  {object} req
+   * @return {object}
+   */
+  parseUserLocationFromReq: function parseUserLocationFromReq(req) {
+    const body = req.body;
+    // @see https://github.com/DoSomething/northstar/blob/dev/documentation/endpoints/users.md#create-a-user
+    const data = {
+      addr_city: body.FromCity,
+      addr_state: body.FromState,
+      addr_zip: body.FromZip,
+      country: body.FromCountry,
+      addr_source: platform,
+    };
+    logger.debug('parseUserLocationFromReq', { data });
+
+    return data;
   },
 };

--- a/lib/helpers/twilio.js
+++ b/lib/helpers/twilio.js
@@ -24,7 +24,7 @@ module.exports = {
     req.inboundMessageText = req.body.Body;
     req.platformMessageId = req.body.MessageSid;
     req.platformUserId = req.body.From;
-    req.platformUserLocation = this.parseUserLocationFromReq(req);
+    req.platformUserAddress = this.parseUserAddressFromReq(req);
 
     /**
      * Inspect baseUrl to check if it's an import request
@@ -95,12 +95,10 @@ module.exports = {
   },
 
   /**
-   * parseUserLocationFromReq - parses Northstar User location properties from Twilio request
-   *
-   * @param  {object} req
+   * @param {object} req
    * @return {object}
    */
-  parseUserLocationFromReq: function parseUserLocationFromReq(req) {
+  parseUserAddressFromReq: function parseUserAddressFromReq(req) {
     const body = req.body;
     // @see https://github.com/DoSomething/northstar/blob/dev/documentation/endpoints/users.md#create-a-user
     const data = {
@@ -110,7 +108,6 @@ module.exports = {
       country: body.FromCountry,
       addr_source: platform,
     };
-    logger.debug('parseUserLocationFromReq', { data });
 
     return data;
   },

--- a/lib/helpers/user.js
+++ b/lib/helpers/user.js
@@ -5,7 +5,7 @@ module.exports = {
    * @param {object} user
    * @return {boolean}
    */
-  hasLocation: function hasLocation(user) {
+  hasAddress: function hasAddress(user) {
     if (user.addr_city && user.addr_state && user.addr_zip && user.country) {
       return true;
     }

--- a/lib/helpers/user.js
+++ b/lib/helpers/user.js
@@ -1,0 +1,8 @@
+'use strict';
+
+module.exports = {
+  hasLocation: function hasLocation(user) {
+    const result = user.addr_city && user.addr_state && user.addr_zip && user.country;
+    return result;
+  },
+};

--- a/lib/helpers/user.js
+++ b/lib/helpers/user.js
@@ -1,8 +1,14 @@
 'use strict';
 
 module.exports = {
+  /**
+   * @param {object} user
+   * @return {boolean}
+   */
   hasLocation: function hasLocation(user) {
-    const result = user.addr_city && user.addr_state && user.addr_zip && user.country;
-    return result;
+    if (user.addr_city && user.addr_state && user.addr_zip && user.country) {
+      return true;
+    }
+    return false;
   },
 };

--- a/lib/middleware/receive-message/user-update.js
+++ b/lib/middleware/receive-message/user-update.js
@@ -14,7 +14,7 @@ module.exports = function updateNorthstarUser() {
     };
 
     /**
-     * Check if User subscription status has changed.
+     * Check for User subscription status updates.
      */
     const replyText = req.rivescriptReplyText;
     // Note: We're setting SMS status for Slack users. If we ever integrate with another platform,
@@ -43,7 +43,7 @@ module.exports = function updateNorthstarUser() {
     }
 
     /**
-     * Check for User location.
+     * Check for User location updates.
      */
     if (req.platformUserLocation && !helpers.user.hasLocation(req.user)) {
       underscore.extend(data, req.platformUserLocation);

--- a/lib/middleware/receive-message/user-update.js
+++ b/lib/middleware/receive-message/user-update.js
@@ -47,7 +47,7 @@ module.exports = function updateNorthstarUser() {
      * Check if we need to update User address.
      */
     if (req.platformUserAddress && !helpers.user.hasAddress(req.user)) {
-      underscore.extend(data, req.platformUserLocation);
+      underscore.extend(data, req.platformUserAddress);
       logger.debug('update userLocation', { data });
     }
 

--- a/lib/middleware/receive-message/user-update.js
+++ b/lib/middleware/receive-message/user-update.js
@@ -1,11 +1,21 @@
 'use strict';
 
+const underscore = require('underscore');
 const logger = require('../../logger');
 const helpers = require('../../helpers');
 const northstar = require('../../northstar');
 
 module.exports = function updateNorthstarUser() {
   return (req, res, next) => {
+    // Initialize update data.
+    const data = {
+      last_messaged_at: req.inboundMessage.createdAt.toISOString(),
+      sms_paused: req.conversation.paused,
+    };
+
+    /**
+     * Check if User subscription status has changed.
+     */
     const replyText = req.rivescriptReplyText;
     // Note: We're setting SMS status for Slack users. If we ever integrate with another platform,
     // we'll want to store separate platform subscription values on a Northstar User.
@@ -28,13 +38,16 @@ module.exports = function updateNorthstarUser() {
       // back to life.
       statusUpdate = helpers.subscription.statuses.active();
     }
-
-    const data = {
-      last_messaged_at: req.inboundMessage.createdAt.toISOString(),
-      sms_paused: req.conversation.paused,
-    };
     if (statusUpdate) {
       data.sms_status = statusUpdate;
+    }
+
+    /**
+     * Check for User location.
+     */
+    if (req.platformUserLocation && !helpers.user.hasLocation(req.user)) {
+      underscore.extend(data, req.platformUserLocation);
+      logger.debug('update userLocation', { data });
     }
 
     return northstar.updateUser(req.userId, data)

--- a/lib/middleware/receive-message/user-update.js
+++ b/lib/middleware/receive-message/user-update.js
@@ -14,7 +14,8 @@ module.exports = function updateNorthstarUser() {
     };
 
     /**
-     * Check for User subscription status updates.
+     * Check if User subscription status has changed.
+     * TODO: Extract this into user helper.
      */
     const replyText = req.rivescriptReplyText;
     // Note: We're setting SMS status for Slack users. If we ever integrate with another platform,
@@ -43,9 +44,9 @@ module.exports = function updateNorthstarUser() {
     }
 
     /**
-     * Check for User location updates.
+     * Check if we need to update User address.
      */
-    if (req.platformUserLocation && !helpers.user.hasLocation(req.user)) {
+    if (req.platformUserAddress && !helpers.user.hasAddress(req.user)) {
       underscore.extend(data, req.platformUserLocation);
       logger.debug('update userLocation', { data });
     }

--- a/test/helpers/factories/user.js
+++ b/test/helpers/factories/user.js
@@ -1,8 +1,10 @@
 'use strict';
 
+const Chance = require('chance');
 const ObjectID = require('mongoose').Types.ObjectId;
-
 const stubs = require('../stubs');
+
+const chance = new Chance();
 
 module.exports.getValidUser = function getValidUser(phoneNumber) {
   return {
@@ -10,4 +12,14 @@ module.exports.getValidUser = function getValidUser(phoneNumber) {
     mobile: phoneNumber || stubs.getMobileNumber(),
     sms_status: 'active',
   };
+};
+
+module.exports.getValidUserWithLocation = function getValidUserWithLocation(phoneNumber) {
+  const user = exports.getValidUser(phoneNumber);
+  user.country = 'US';
+  user.addr_city = chance.city();
+  user.addr_state = chance.state({ country: 'us' });
+  user.addr_zip = chance.zip();
+  user.addr_source = 'sms';
+  return user;
 };

--- a/test/helpers/factories/user.js
+++ b/test/helpers/factories/user.js
@@ -14,7 +14,7 @@ module.exports.getValidUser = function getValidUser(phoneNumber) {
   };
 };
 
-module.exports.getValidUserWithLocation = function getValidUserWithLocation(phoneNumber) {
+module.exports.getValidUserWithAddress = function getValidUserWithAddress(phoneNumber) {
   const user = exports.getValidUser(phoneNumber);
   user.country = 'US';
   user.addr_city = chance.city();

--- a/test/helpers/stubs.js
+++ b/test/helpers/stubs.js
@@ -5,6 +5,7 @@ const url = require('url');
 const Chance = require('chance');
 
 const chance = new Chance();
+const country = 'US';
 const mobileNumber = '+1555910832';
 const totalInbound = 52;
 const totalOutbound = 209;
@@ -82,6 +83,24 @@ module.exports = {
   },
   getCampaignRunId: function getCampaignRunId() {
     return 6441;
+  },
+  getMockInboundTwilioRequestBody: function getMockInboundTwilioRequestBody() {
+    return {
+      Body: this.getRandomMessageText(),
+      From: this.getMobileNumber(),
+      FromCity: chance.city(),
+      FromCountry: country,
+      FromState: chance.state(),
+      FromZip: chance.zip(),
+      NumMedia: 0,
+      ToCity: chance.city(),
+      ToCountry: country,
+      ToState: chance.state(),
+      ToZip: chance.zip(),
+      SmsMessageSid: 'SMe62bd767ea4438d7f7f307ff9d3212e0',
+      SmsSid: 'SMe62bd767ea4438d7f7f307ff9d3212e0',
+      SmsStatus: 'received',
+    };
   },
   getRandomMessageText: function getRandomMessageText() {
     return chance.paragraph({ sentences: 2 });

--- a/test/lib/lib-helpers/twilio.test.js
+++ b/test/lib/lib-helpers/twilio.test.js
@@ -1,0 +1,48 @@
+'use strict';
+
+require('dotenv').config();
+const test = require('ava');
+const chai = require('chai');
+const sinon = require('sinon');
+const sinonChai = require('sinon-chai');
+const httpMocks = require('node-mocks-http');
+
+const stubs = require('../../helpers/stubs');
+
+chai.should();
+chai.use(sinonChai);
+
+// module to be tested
+const twilioHelper = require('../../../lib/helpers/twilio');
+
+// sinon sandbox object
+const sandbox = sinon.sandbox.create();
+
+const mockTwilioRequestBody = stubs.getMockInboundTwilioRequestBody();
+
+test.beforeEach((t) => {
+  t.context.req = httpMocks.createRequest();
+  t.context.req.body = mockTwilioRequestBody;
+});
+
+test.afterEach(() => {
+  sandbox.restore();
+});
+
+// parseBody
+test('parseBody should inject vars into req', (t) => {
+  sandbox.spy(twilioHelper, 'parseUserLocationFromReq');
+  twilioHelper.parseBody(t.context.req);
+  twilioHelper.parseUserLocationFromReq.should.have.been.called;
+  t.context.req.platformUserId.should.equal(mockTwilioRequestBody.From);
+  t.context.req.should.have.property('platformUserLocation');
+});
+
+// hasLocation
+test('parseUserLocationFromReq should return an object', (t) => {
+  const result = twilioHelper.parseUserLocationFromReq(t.context.req);
+  result.addr_city.should.equal(mockTwilioRequestBody.FromCity);
+  result.addr_state.should.equal(mockTwilioRequestBody.FromState);
+  result.addr_zip.should.equal(mockTwilioRequestBody.FromZip);
+  result.country.should.equal(mockTwilioRequestBody.FromCountry);
+});

--- a/test/lib/lib-helpers/twilio.test.js
+++ b/test/lib/lib-helpers/twilio.test.js
@@ -31,16 +31,16 @@ test.afterEach(() => {
 
 // parseBody
 test('parseBody should inject vars into req', (t) => {
-  sandbox.spy(twilioHelper, 'parseUserLocationFromReq');
+  sandbox.spy(twilioHelper, 'parseUserAddressFromReq');
   twilioHelper.parseBody(t.context.req);
-  twilioHelper.parseUserLocationFromReq.should.have.been.called;
+  twilioHelper.parseUserAddressFromReq.should.have.been.called;
   t.context.req.platformUserId.should.equal(mockTwilioRequestBody.From);
-  t.context.req.should.have.property('platformUserLocation');
+  t.context.req.should.have.property('platformUserAddress');
 });
 
 // hasLocation
-test('parseUserLocationFromReq should return an object', (t) => {
-  const result = twilioHelper.parseUserLocationFromReq(t.context.req);
+test('parseUserAddressFromReq should return an object', (t) => {
+  const result = twilioHelper.parseUserAddressFromReq(t.context.req);
   result.addr_city.should.equal(mockTwilioRequestBody.FromCity);
   result.addr_state.should.equal(mockTwilioRequestBody.FromState);
   result.addr_zip.should.equal(mockTwilioRequestBody.FromZip);

--- a/test/lib/lib-helpers/user.test.js
+++ b/test/lib/lib-helpers/user.test.js
@@ -20,13 +20,13 @@ test.afterEach(() => {
   sandbox.restore();
 });
 
-// hasLocation
-test('hasLocation should return true if user has location properties set', (t) => {
-  const user = userFactory.getValidUserWithLocation();
-  t.true(userHelper.hasLocation(user));
+// hasAddress
+test('hasAddress should return true if user has address properties set', (t) => {
+  const user = userFactory.getValidUserWithAddress();
+  t.true(userHelper.hasAddress(user));
 });
 
-test('hasLocation should return false if user does not have location properties set', (t) => {
+test('hasAddress should return false if user does not have address properties set', (t) => {
   const user = userFactory.getValidUser();
-  t.falsy(userHelper.hasLocation(user));
+  t.falsy(userHelper.hasAddress(user));
 });

--- a/test/lib/lib-helpers/user.test.js
+++ b/test/lib/lib-helpers/user.test.js
@@ -1,6 +1,5 @@
 'use strict';
 
-// libs
 require('dotenv').config();
 const test = require('ava');
 const chai = require('chai');
@@ -8,20 +7,16 @@ const sinon = require('sinon');
 const sinonChai = require('sinon-chai');
 const userFactory = require('../../helpers/factories/user');
 
-// setup "x.should.y" assertion style
 chai.should();
 chai.use(sinonChai);
-
-// const config = require('../../../config/lib/helpers/tags');
 
 // module to be tested
 const userHelper = require('../../../lib/helpers/user');
 
 // sinon sandbox object
 const sandbox = sinon.sandbox.create();
-// Cleanup
+
 test.afterEach(() => {
-  // reset stubs, spies, and mocks
   sandbox.restore();
 });
 

--- a/test/lib/lib-helpers/user.test.js
+++ b/test/lib/lib-helpers/user.test.js
@@ -1,0 +1,37 @@
+'use strict';
+
+// libs
+require('dotenv').config();
+const test = require('ava');
+const chai = require('chai');
+const sinon = require('sinon');
+const sinonChai = require('sinon-chai');
+const userFactory = require('../../helpers/factories/user');
+
+// setup "x.should.y" assertion style
+chai.should();
+chai.use(sinonChai);
+
+// const config = require('../../../config/lib/helpers/tags');
+
+// module to be tested
+const userHelper = require('../../../lib/helpers/user');
+
+// sinon sandbox object
+const sandbox = sinon.sandbox.create();
+// Cleanup
+test.afterEach(() => {
+  // reset stubs, spies, and mocks
+  sandbox.restore();
+});
+
+// hasLocation
+test('hasLocation should return true if user has location properties set', (t) => {
+  const user = userFactory.getValidUserWithLocation();
+  t.true(userHelper.hasLocation(user));
+});
+
+test('hasLocation should return false if user does not have location properties set', (t) => {
+  const user = userFactory.getValidUser();
+  t.falsy(userHelper.hasLocation(user));
+});


### PR DESCRIPTION
#### What's this PR do?
Parses sender location info from an inbound Twilio request to `POST /receive-message`, and updates the corresponding Northstar User's address fields if they don't exist.

#### How should this be reviewed?
* Deploy this branch to staging (or run it locally)
* Clear out your Northstar User's address fields from Aurora
* Post to the relevant Gambit Staging / Dev Twilio numbers from your mobile number 
* Refresh your Northstar User's address in Aurora to verify address info has been saved

#### Any background context you want to provide?

* This PR introduces a `lib/helpers/user` -- the function that determines whether to update a Northstar user's `sms_status` should be moved into it (along with tests)

* This is a little messy for new users: we could include the address data in our first User Create post (but instead pass it when we make a 2nd update request). Intentionally leaving this work out of the branch for now, as it's a cleanup task that may or may not be worth doing.

* A nice-to-have could be to modify the Consolebot to post the parameters of Twiilio request, to verify location info is saved without using Paw or mobile end-to-end testing.

#### Relevant tickets
Fixes #226 technically, but could warrant some cleanup to pass location data on User Create instead of Update for new users.

#### Checklist
- [x] Tests added for new features/bug fixes.
- [ ] Tested on staging.
