### PR TITLE
Add fail injection capability to Conversations. 

### DIFF
--- a/lib/middleware/metadata-parse.js
+++ b/lib/middleware/metadata-parse.js
@@ -1,7 +1,10 @@
 'use strict';
 
-const logger = require('../logger');
 const uuidV4 = require('uuid/v4');
+const Promise = require('bluebird');
+
+const logger = require('../logger');
+const helpers = require('../helpers');
 
 function parseRetryCount(req) {
   const retryCountFromHeader = Number(req.get('x-blink-retry-count')) || 0;
@@ -30,11 +33,43 @@ function registerIsARetryRequestFunction(req) {
 }
 
 /**
+ * parseFailInjection - Used for testing purposes ONLY.
+ *
+ * @param  {object} req
+ * @param  {object} res
+ */
+function parseFailInjection(req) {
+  const failHeader = req.get('x-request-fail');
+  const failMaxCountHeader = parseInt(req.get('x-request-fail-count'), 10);
+  const isRetryRequest = req.isARetryRequest();
+  const shouldFail = (failHeader && failMaxCountHeader);
+  const failMsg = 'Fail injection detected. Failing request.';
+
+  return new Promise((resolve, reject) => {
+    // If a fail injection is detected
+    if (shouldFail) {
+      // If this request is a retry
+      if (isRetryRequest) {
+        // Let's make sure we are under the max fail count set
+        // If it's over, the request will go through
+        if (req.metadata.retryCount <= failMaxCountHeader) {
+          return reject(new Error(failMsg));
+        }
+      // If it's not a retry, just fail the request
+      } else {
+        return reject(new Error(failMsg));
+      }
+    }
+
+    // Don't fail the request
+    return resolve();
+  });
+}
+
+/**
  * parseMetadata - Here we parse global properties. All requests to Conversations API will run
  * through this middleware. Most parsing should be done at the specific route's middleware.
  * You should have a good reason to parse it here.
- *
- * @return {type}  description
  */
 module.exports = function parseMetadata() {
   return (req, res, next) => {
@@ -48,6 +83,8 @@ module.exports = function parseMetadata() {
     parseRequestId(req, res);
     parseRetryCount(req);
     registerIsARetryRequestFunction(req);
-    return next();
+    parseFailInjection(req)
+      .then(next)
+      .catch(error => helpers.sendErrorResponse(res, error));
   };
 };


### PR DESCRIPTION
#### What's this PR do?
Adds the capability to control (fail) requests based on headers.

#### How should this be reviewed?
- Using Postman/Paw: send an /import-message request with the following headers:
    - `x-request-fail: true`
    - `x-request-fail-count: 1`
- It should fail the request as expected.

#### Any background context you want to provide?
- I need this feature to hand pick requests to fail while load testing. This will help stress the new Blink retries mechanism.

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Tested on staging.
