### PR TITLE
Update User cleanup + tests

### DIFF
--- a/documentation/endpoints/receive-message.md
+++ b/documentation/endpoints/receive-message.md
@@ -9,18 +9,42 @@ Receives a message and sends a reply (or forwards it, when appropriate).
 
 ## Input
 
+### Twilio
+
+Inbound Twilio messages sent to our shortcode are posted to this endpoint, passing a Twilio message:
+
 Name | Type | Description
 --- | --- | ---
-`From` | `string` | Sender's phone number (included in Twilio message)
-`Body` | `string` | Incoming message (included in Twilio message)
-`MediaUrl0` | `string` | Incoming message attachment URL (included in Twilio message)
-`MediaContentType0` | `string` | Incoming message attachment type (included in Twilio message)
-`slackId` | `string` |
-`slackChannel` | `string` |
-`facebookId` | `string` |
-`mobile` | `string` | Mobile number for the User (passed for general API usage, e.g. Consolebot).
-`text` | `string` | Incoming message sent from User.
-`mediaUrl` | `string` | Media attachment URL (currently only supports 1 attachment).
+`From` | `string` | Sender's phone number
+`Body` | `string` | Incoming message
+`MediaUrl0` | `string` | Incoming message attachment URL
+`MediaContentType0` | `string` | Incoming message attachment type
+`FromCity` | `string` |
+`FromState` | `string` |
+`FromZip` | `string` |
+`FromCountry`| `string` |
+
+### Slack
+
+Direct messages sent to our DoSomething `@gambit-staging` Slack app are posted to this endpoint, passing parameters:
+
+Name | Type | Description
+--- | --- | ---
+`slackId` | `string` | Sender's Slack User ID
+`slackChannel` | `string` |  Direct message channel from Slack User to Gambit Slack app
+`text` | `string` | Incoming message
+`mediaUrl` | `string` | Media attachment URL (hardcoded to an image set in Gambit Slack).
+
+
+### Consolebot
+
+The Gambit shell script posts to this endpoint, passing parameters:
+
+Name | Type | Description
+--- | --- | ---
+`mobile` | `string` | Sender's mobile number (`DS_CONSOLEBOT_MOBILE`).
+`text` | `string` | Incoming message
+`mediaUrl` | `string` | Media attachment URL (`DS_CONSOLEBOT_PHOTO_URL`).
 
 <details>
 <summary><strong>Example Request</strong></summary>

--- a/documentation/endpoints/receive-message.md
+++ b/documentation/endpoints/receive-message.md
@@ -15,6 +15,7 @@ Inbound Twilio messages sent to our shortcode are posted to this endpoint, passi
 
 Name | Type | Description
 --- | --- | ---
+`MessageSid` | string | Twilio Message ID
 `From` | `string` | Sender's phone number
 `Body` | `string` | Incoming message
 `MediaUrl0` | `string` | Incoming message attachment URL

--- a/lib/helpers/macro.js
+++ b/lib/helpers/macro.js
@@ -24,39 +24,28 @@ module.exports = {
     subscriptionStatusStop: () => getMacroForKey('subscriptionStatusStop'),
     supportRequested: () => getMacroForKey('supportRequested'),
   },
-};
-
-/**
- * Helpers to check if given string is a specific macro.
- */
-module.exports.isConfirmedCampaign = function (text) {
-  return (text === config.macros.confirmedCampaign);
-};
-
-module.exports.isDeclinedCampaign = function (text) {
-  return (text === config.macros.declinedCampaign);
-};
-
-module.exports.isCampaignMenu = function (text) {
-  return (text === config.macros.campaignMenu);
-};
-
-module.exports.isSendCrisisMessage = function (text) {
-  return (text === config.macros.sendCrisisMessage);
-};
-
-module.exports.isSendInfoMessage = function (text) {
-  return (text === config.macros.sendInfoMessage);
-};
-
-module.exports.isSubscriptionStatusLess = function (text) {
-  return (text === config.macros.subscriptionStatusLess);
-};
-
-module.exports.isSubscriptionStatusStop = function (text) {
-  return (text === config.macros.subscriptionStatusStop);
-};
-
-module.exports.isSupportRequested = function (text) {
-  return (text === config.macros.supportRequested);
+  isConfirmedCampaign: function isConfirmedCampaign(text) {
+    return (text === this.macros.confirmedCampaign());
+  },
+  isDeclinedCampaign: function isDeclinedCampaign(text) {
+    return (text === this.macros.declinedCampaign());
+  },
+  isCampaignMenu: function isCampaignMenu(text) {
+    return (text === this.macros.campaignMenu());
+  },
+  isSendCrisisMessage: function isSendCrisisMessage(text) {
+    return (text === this.macros.sendCrisisMessage());
+  },
+  isSendInfoMessage: function isSendInfoMessage(text) {
+    return (text === this.macros.sendInfoMessage());
+  },
+  isSubscriptionStatusLess: function isSubscriptionStatusLess(text) {
+    return (text === this.macros.subscriptionStatusLess());
+  },
+  isSubscriptionStatusStop: function isSubscriptionStatusStop(text) {
+    return (text === this.macros.subscriptionStatusStop());
+  },
+  isSupportRequested: function isSupportRequested(text) {
+    return (text === this.macros.supportRequested());
+  },
 };

--- a/lib/helpers/macro.js
+++ b/lib/helpers/macro.js
@@ -1,16 +1,29 @@
 'use strict';
 
-const logger = require('../logger');
 const config = require('../../config/lib/helpers/macro');
 
-/**
- * Is given string a Rivescript macro?
- */
-module.exports.isMacro = function (text) {
-  const result = config.macros[text];
-  logger.debug('helpers.macro.isMacro', { result });
+function getMacroForKey(key) {
+  return config.macros[key];
+}
 
-  return result;
+module.exports = {
+  /**
+   * Is given string a Rivescript macro?
+   */
+  isMacro: function isMacro(text) {
+    return getMacroForKey(text);
+  },
+  macros: {
+    campaignMenu: () => getMacroForKey('campaignMenu'),
+    confirmedCampaign: () => getMacroForKey('confirmedCampaign'),
+    declinedCampaign: () => getMacroForKey('declinedCampaign'),
+    gambit: () => getMacroForKey('gambit'),
+    sendCrisisMessage: () => getMacroForKey('sendCrisisMessage'),
+    sendInfoMessage: () => getMacroForKey('sendInfoMessage'),
+    subscriptionStatusLess: () => getMacroForKey('subscriptionStatusLess'),
+    subscriptionStatusStop: () => getMacroForKey('subscriptionStatusStop'),
+    supportRequested: () => getMacroForKey('supportRequested'),
+  },
 };
 
 /**

--- a/lib/helpers/user.js
+++ b/lib/helpers/user.js
@@ -16,6 +16,17 @@ module.exports = {
   },
 
   /**
+   * @param {object} req
+   * @return {object}
+   */
+  getDefaultUpdatePayloadFromReq: function getDefaultUpdatePayloadFromReq(req) {
+    return {
+      last_messaged_at: req.inboundMessage.createdAt.toISOString(),
+      sms_paused: req.conversation.paused,
+    };
+  },
+
+  /**
    * @param {object} user
    * @param {string} rivescriptReplyText
    * @return {string}

--- a/lib/helpers/user.js
+++ b/lib/helpers/user.js
@@ -1,5 +1,8 @@
 'use strict';
 
+const macro = require('./macro');
+const statuses = require('./subscription').statuses;
+
 module.exports = {
   /**
    * @param {object} user
@@ -10,5 +13,33 @@ module.exports = {
       return true;
     }
     return false;
+  },
+
+  /**
+   * @param {object} user
+   * @param {string} rivescriptReplyText
+   * @return {string}
+   */
+  getSubscriptionStatusUpdate: function getSubscriptionStatusUpdate(user, rivescriptReplyText) {
+    const stopValue = statuses.stop();
+
+    if (macro.isSubscriptionStatusStop(rivescriptReplyText)) {
+      return stopValue;
+    }
+
+    if (macro.isSubscriptionStatusLess(rivescriptReplyText)) {
+      return statuses.less();
+    }
+
+    // Note: We're setting SMS status for Slack users -- if we ever integrate with another platform,
+    // we'll want to store separate platform subscription values on a Northstar User.
+    const currentStatus = user.sms_status;
+    const undeliverableValue = statuses.undeliverable();
+    if (currentStatus === stopValue || currentStatus === undeliverableValue || !currentStatus) {
+      return statuses.active();
+    }
+
+    // Nothing to update.
+    return null;
   },
 };

--- a/lib/middleware/receive-message/user-update.js
+++ b/lib/middleware/receive-message/user-update.js
@@ -10,7 +10,7 @@ const statuses = helpers.subscription.statuses;
 module.exports = function updateNorthstarUser() {
   return (req, res, next) => {
     // Initialize update data.
-    const data = helpers.user.getDefaultUpdatePayloadFromReq(req);
+    req.userUpdateData = helpers.user.getDefaultUpdatePayloadFromReq(req);
 
     /**
      * Check if User subscription status has changed.
@@ -18,20 +18,20 @@ module.exports = function updateNorthstarUser() {
     const replyText = req.rivescriptReplyText;
     const statusUpdate = helpers.user.getSubscriptionStatusUpdate(req.user, replyText);
     if (statusUpdate) {
-      data.sms_status = statusUpdate;
+      req.userUpdateData.sms_status = statusUpdate;
     }
 
     /**
      * Check if we need to update User address.
      */
     if (req.platformUserAddress && !helpers.user.hasAddress(req.user)) {
-      underscore.extend(data, req.platformUserAddress);
-      logger.debug('update userLocation', { data });
+      underscore.extend(req.userUpdateData, req.platformUserAddress);
+      logger.debug('update address', { data: req.userUpdateData });
     }
 
-    return northstar.updateUser(req.userId, data)
+    return northstar.updateUser(req.userId, req.userUpdateData)
       .then(() => {
-        logger.debug('northstar.updateUser success', { userId: req.userId, data }, req);
+        logger.debug('northstar.updateUser success', { userId: req.userId }, req);
 
         if (statusUpdate === statuses.less()) {
           return helpers.replies.subscriptionStatusLess(req, res);

--- a/lib/middleware/receive-message/user-update.js
+++ b/lib/middleware/receive-message/user-update.js
@@ -9,24 +9,33 @@ const statuses = helpers.subscription.statuses;
 
 module.exports = function updateNorthstarUser() {
   return (req, res, next) => {
+    let statusUpdate = null;
     // Initialize update data.
-    req.userUpdateData = helpers.user.getDefaultUpdatePayloadFromReq(req);
-
-    /**
-     * Check if User subscription status has changed.
-     */
-    const replyText = req.rivescriptReplyText;
-    const statusUpdate = helpers.user.getSubscriptionStatusUpdate(req.user, replyText);
-    if (statusUpdate) {
-      req.userUpdateData.sms_status = statusUpdate;
+    try {
+      req.userUpdateData = helpers.user.getDefaultUpdatePayloadFromReq(req);
+    } catch (error) {
+      return helpers.sendErrorResponse(res, error);
     }
 
-    /**
-     * Check if we need to update User address.
-     */
-    if (req.platformUserAddress && !helpers.user.hasAddress(req.user)) {
-      underscore.extend(req.userUpdateData, req.platformUserAddress);
-      logger.debug('update address', { data: req.userUpdateData });
+    // Check if User subscription status has changed.
+    try {
+      const replyText = req.rivescriptReplyText;
+      statusUpdate = helpers.user.getSubscriptionStatusUpdate(req.user, replyText);
+      if (statusUpdate) {
+        req.userUpdateData.sms_status = statusUpdate;
+      }
+    } catch (error) {
+      return helpers.sendErrorResponse(res, error);
+    }
+
+    try {
+      // Check if we need to update User address.
+      if (req.platformUserAddress && !helpers.user.hasAddress(req.user)) {
+        underscore.extend(req.userUpdateData, req.platformUserAddress);
+        logger.debug('update address', { data: req.userUpdateData });
+      }
+    } catch (error) {
+      return helpers.sendErrorResponse(res, error);
     }
 
     return northstar.updateUser(req.userId, req.userUpdateData)

--- a/lib/middleware/receive-message/user-update.js
+++ b/lib/middleware/receive-message/user-update.js
@@ -5,6 +5,8 @@ const logger = require('../../logger');
 const helpers = require('../../helpers');
 const northstar = require('../../northstar');
 
+const statuses = helpers.subscription.statuses;
+
 module.exports = function updateNorthstarUser() {
   return (req, res, next) => {
     // Initialize update data.
@@ -15,30 +17,9 @@ module.exports = function updateNorthstarUser() {
 
     /**
      * Check if User subscription status has changed.
-     * TODO: Extract this into user helper.
      */
     const replyText = req.rivescriptReplyText;
-    // Note: We're setting SMS status for Slack users. If we ever integrate with another platform,
-    // we'll want to store separate platform subscription values on a Northstar User.
-    const currentStatus = req.user.sms_status;
-    const lessValue = helpers.subscription.statuses.less();
-    const stopValue = helpers.subscription.statuses.stop();
-    const undeliverableValue = helpers.subscription.statuses.undeliverable();
-    let statusUpdate = null;
-
-    if (helpers.macro.isSubscriptionStatusStop(replyText)) {
-      statusUpdate = stopValue;
-    } else if (helpers.macro.isSubscriptionStatusLess(replyText)) {
-      statusUpdate = lessValue;
-    // If User is set to undeliverable but we've now received a message from them OR we don't
-    // have a status set at all:
-    } else if (currentStatus === stopValue ||
-      currentStatus === undeliverableValue || !currentStatus) {
-      // TODO: There's an edge case here, if a User sends STOP while they're paused.
-      // We'll want to update the Conversation.paused to true by default if we're bringing someone
-      // back to life.
-      statusUpdate = helpers.subscription.statuses.active();
-    }
+    const statusUpdate = helpers.user.getSubscriptionStatusUpdate(req.user, replyText);
     if (statusUpdate) {
       data.sms_status = statusUpdate;
     }
@@ -55,9 +36,9 @@ module.exports = function updateNorthstarUser() {
       .then(() => {
         logger.debug('northstar.updateUser success', { userId: req.userId, data }, req);
 
-        if (statusUpdate === lessValue) {
+        if (statusUpdate === statuses.less()) {
           return helpers.replies.subscriptionStatusLess(req, res);
-        } else if (statusUpdate === stopValue) {
+        } else if (statusUpdate === statuses.stop()) {
           return helpers.replies.subscriptionStatusStop(req, res);
         }
 

--- a/lib/middleware/receive-message/user-update.js
+++ b/lib/middleware/receive-message/user-update.js
@@ -10,10 +10,7 @@ const statuses = helpers.subscription.statuses;
 module.exports = function updateNorthstarUser() {
   return (req, res, next) => {
     // Initialize update data.
-    const data = {
-      last_messaged_at: req.inboundMessage.createdAt.toISOString(),
-      sms_paused: req.conversation.paused,
-    };
+    const data = helpers.user.getDefaultUpdatePayloadFromReq(req);
 
     /**
      * Check if User subscription status has changed.

--- a/lib/northstar.js
+++ b/lib/northstar.js
@@ -113,7 +113,7 @@ module.exports.fetchUserByMobile = function (mobile) {
  * @return {Promise}
  */
 module.exports.updateUser = function (userId, data) {
-  logger.debug('updateUser', { userId, data });
+  logger.debug('northstar.updateUser post', { userId, data });
 
   return exports.getClient().Users.update(userId, data);
 };

--- a/test/helpers/factories/message.js
+++ b/test/helpers/factories/message.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const ObjectID = require('mongoose').Types.ObjectId;
+const Message = require('../../../app/models/Message');
+const stubs = require('../stubs');
+
+module.exports.getValidMessage = function getValidMessage() {
+  const id = new ObjectID();
+  const date = new Date();
+  return new Message({
+    _id: id,
+    createdAt: date,
+    updatedAt: date,
+    text: stubs.getRandomMessageText(),
+  });
+};

--- a/test/lib/lib-helpers/macro.test.js
+++ b/test/lib/lib-helpers/macro.test.js
@@ -44,6 +44,12 @@ test('isCampaignMenu should return boolean', (t) => {
   t.falsy(macroHelper.isCampaignMenu(undefinedMacroName));
 });
 
+test('macro.macros.x() should be equal to macro.macroNameValues.x', () => {
+  Object.keys(config.macros).forEach((macroName) => {
+    macroHelper.macros[macroName]().should.be.equal(macroName);
+  });
+});
+
 test('isConfirmedCampaign should return boolean', (t) => {
   t.true(macroHelper.isConfirmedCampaign(macros.confirmedCampaign));
   t.falsy(macroHelper.isConfirmedCampaign(undefinedMacroName));

--- a/test/lib/lib-helpers/user.test.js
+++ b/test/lib/lib-helpers/user.test.js
@@ -5,6 +5,9 @@ const test = require('ava');
 const chai = require('chai');
 const sinon = require('sinon');
 const sinonChai = require('sinon-chai');
+const macroHelper = require('../../../lib/helpers/macro');
+const subscriptionHelper = require('../../../lib/helpers/subscription');
+const stubs = require('../../helpers/stubs');
 const userFactory = require('../../helpers/factories/user');
 
 chai.should();
@@ -29,4 +32,46 @@ test('hasAddress should return true if user has address properties set', (t) => 
 test('hasAddress should return false if user does not have address properties set', (t) => {
   const user = userFactory.getValidUser();
   t.falsy(userHelper.hasAddress(user));
+});
+
+// updateSubscriptionStatus
+test('getSubscriptionStatusUpdate should return stop value if stop macro is passed', () => {
+  const user = userFactory.getValidUser();
+  const stopMacro = macroHelper.macros.subscriptionStatusStop();
+  const result = userHelper.getSubscriptionStatusUpdate(user, stopMacro);
+  result.should.equal(subscriptionHelper.statuses.stop());
+});
+
+test('getSubscriptionStatusUpdate should return less value if less macro is passed', () => {
+  const user = userFactory.getValidUser();
+  const lessMacro = macroHelper.macros.subscriptionStatusLess();
+  const result = userHelper.getSubscriptionStatusUpdate(user, lessMacro);
+  result.should.equal(subscriptionHelper.statuses.less());
+});
+
+test('getSubscriptionStatusUpdate should return active value if current status is stop', () => {
+  const user = userFactory.getValidUser();
+  user.sms_status = subscriptionHelper.statuses.stop();
+  const result = userHelper.getSubscriptionStatusUpdate(user, stubs.getRandomMessageText());
+  result.should.equal(subscriptionHelper.statuses.active());
+});
+
+test('getSubscriptionStatusUpdate should return active value if current status is undeliverable', () => {
+  const user = userFactory.getValidUser();
+  user.sms_status = subscriptionHelper.statuses.undeliverable();
+  const result = userHelper.getSubscriptionStatusUpdate(user, stubs.getRandomMessageText());
+  result.should.equal(subscriptionHelper.statuses.active());
+});
+
+test('getSubscriptionStatusUpdate should return active value if current status is null', () => {
+  const user = userFactory.getValidUser();
+  user.sms_status = null;
+  const result = userHelper.getSubscriptionStatusUpdate(user, stubs.getRandomMessageText());
+  result.should.equal(subscriptionHelper.statuses.active());
+});
+
+test('getSubscriptionStatusUpdate should return falsy if current status is active', (t) => {
+  const user = userFactory.getValidUser();
+  const result = userHelper.getSubscriptionStatusUpdate(user, stubs.getRandomMessageText());
+  t.falsy(result);
 });

--- a/test/lib/lib-helpers/user.test.js
+++ b/test/lib/lib-helpers/user.test.js
@@ -7,8 +7,6 @@ const sinon = require('sinon');
 const sinonChai = require('sinon-chai');
 const macroHelper = require('../../../lib/helpers/macro');
 const subscriptionHelper = require('../../../lib/helpers/subscription');
-const stubs = require('../../helpers/stubs');
-const userFactory = require('../../helpers/factories/user');
 
 chai.should();
 chai.use(sinonChai);
@@ -19,8 +17,26 @@ const userHelper = require('../../../lib/helpers/user');
 // sinon sandbox object
 const sandbox = sinon.sandbox.create();
 
+// stubs
+const stubs = require('../../helpers/stubs');
+const conversationFactory = require('../../helpers/factories/conversation');
+const messageFactory = require('../../helpers/factories/message');
+const userFactory = require('../../helpers/factories/user');
+
 test.afterEach(() => {
   sandbox.restore();
+});
+
+// hasAddress
+test('getDefaultUpdatePayloadFromReq should return object', () => {
+  const inboundMessage = messageFactory.getValidMessage();
+  const conversation = conversationFactory.getValidConversation();
+  const result = userHelper.getDefaultUpdatePayloadFromReq({
+    inboundMessage,
+    conversation,
+  });
+  result.last_messaged_at.should.equal(inboundMessage.createdAt.toISOString());
+  result.sms_paused.should.equal(conversation.paused);
 });
 
 // hasAddress

--- a/test/lib/middleware/receive-message/user-update.test.js
+++ b/test/lib/middleware/receive-message/user-update.test.js
@@ -12,8 +12,11 @@ const underscore = require('underscore');
 
 const northstar = require('../../../../lib/northstar');
 const helpers = require('../../../../lib/helpers');
+const stubs = require('../../../helpers/stubs');
 const userFactory = require('../../../helpers/factories/user');
 
+const repliesHelper = helpers.replies;
+const subscriptionHelper = helpers.subscription;
 const userHelper = helpers.user;
 
 // setup "x.should.y" assertion style
@@ -34,8 +37,13 @@ const userUpdateFailStub = () => Promise.reject({ message: 'Epic fail' });
 test.beforeEach((t) => {
   sandbox.stub(helpers, 'sendErrorResponse')
     .returns(underscore.noop);
+  sandbox.stub(repliesHelper, 'subscriptionStatusLess')
+    .returns(underscore.noop);
+  sandbox.stub(repliesHelper, 'subscriptionStatusStop')
+    .returns(underscore.noop);
   t.context.req = httpMocks.createRequest();
   t.context.req.user = mockUser;
+  t.context.req.rivescriptReplyText = stubs.getRandomMessageText();
   t.context.res = httpMocks.createResponse();
 });
 
@@ -50,14 +58,20 @@ test('updateUser should call next if Northstar.updateUser success', async (t) =>
   const middleware = updateUser();
   sandbox.stub(userHelper, 'getDefaultUpdatePayloadFromReq')
     .returns({ });
+  sandbox.stub(userHelper, 'getSubscriptionStatusUpdate')
+    .returns(null);
   sandbox.stub(northstar, 'updateUser')
     .callsFake(userUpdateStub);
 
   // test
   await middleware(t.context.req, t.context.res, next);
   userHelper.getDefaultUpdatePayloadFromReq.should.have.been.called;
+  userHelper.getSubscriptionStatusUpdate.should.have.been.called;
   northstar.updateUser.should.have.been.called;
+  repliesHelper.subscriptionStatusLess.should.not.have.been.called;
+  repliesHelper.subscriptionStatusStop.should.not.have.been.called;
   next.should.have.been.called;
+  helpers.sendErrorResponse.should.not.have.been.called;
 });
 
 test('updateUser should call sendErrorResponse if Northstar.updateUser fails', async (t) => {
@@ -66,13 +80,63 @@ test('updateUser should call sendErrorResponse if Northstar.updateUser fails', a
   const middleware = updateUser();
   sandbox.stub(userHelper, 'getDefaultUpdatePayloadFromReq')
     .returns({ });
+  sandbox.stub(userHelper, 'getSubscriptionStatusUpdate')
+    .returns(null);
   sandbox.stub(northstar, 'updateUser')
     .callsFake(userUpdateFailStub);
 
   // test
   await middleware(t.context.req, t.context.res, next);
   userHelper.getDefaultUpdatePayloadFromReq.should.have.been.called;
+  userHelper.getSubscriptionStatusUpdate.should.have.been.called;
   northstar.updateUser.should.have.been.called;
+  repliesHelper.subscriptionStatusLess.should.not.have.been.called;
+  repliesHelper.subscriptionStatusStop.should.not.have.been.called;
   next.should.not.have.been.called;
   helpers.sendErrorResponse.should.have.been.called;
 });
+
+test('updateUser should call replies.subscriptionStatusLess if statusUpdate is less', async (t) => {
+  // setup
+  const next = sinon.stub();
+  const middleware = updateUser();
+  sandbox.stub(userHelper, 'getDefaultUpdatePayloadFromReq')
+    .returns({ });
+  sandbox.stub(userHelper, 'getSubscriptionStatusUpdate')
+    .returns(subscriptionHelper.statuses.less());
+  sandbox.stub(northstar, 'updateUser')
+    .callsFake(userUpdateStub);
+
+  // test
+  await middleware(t.context.req, t.context.res, next);
+  userHelper.getDefaultUpdatePayloadFromReq.should.have.been.called;
+  userHelper.getSubscriptionStatusUpdate.should.have.been.called;
+  northstar.updateUser.should.have.been.called;
+  repliesHelper.subscriptionStatusLess.should.have.been.called;
+  repliesHelper.subscriptionStatusStop.should.not.have.been.called;
+  next.should.not.have.been.called;
+  helpers.sendErrorResponse.should.not.have.been.called;
+});
+
+test('updateUser should call replies.subscriptionStatusStop if statusUpdate is stop', async (t) => {
+  // setup
+  const next = sinon.stub();
+  const middleware = updateUser();
+  sandbox.stub(userHelper, 'getDefaultUpdatePayloadFromReq')
+    .returns({ });
+  sandbox.stub(userHelper, 'getSubscriptionStatusUpdate')
+    .returns(subscriptionHelper.statuses.stop());
+  sandbox.stub(northstar, 'updateUser')
+    .callsFake(userUpdateStub);
+
+  // test
+  await middleware(t.context.req, t.context.res, next);
+  userHelper.getDefaultUpdatePayloadFromReq.should.have.been.called;
+  userHelper.getSubscriptionStatusUpdate.should.have.been.called;
+  northstar.updateUser.should.have.been.called;
+  repliesHelper.subscriptionStatusLess.should.not.have.been.called;
+  repliesHelper.subscriptionStatusStop.should.have.been.called;
+  next.should.not.have.been.called;
+  helpers.sendErrorResponse.should.not.have.been.called;
+});
+

--- a/test/lib/middleware/receive-message/user-update.test.js
+++ b/test/lib/middleware/receive-message/user-update.test.js
@@ -31,6 +31,10 @@ const sandbox = sinon.sandbox.create();
 
 // stubs
 const mockUser = userFactory.getValidUser();
+const mockDefaultUserUpdateData = {
+  last_messaged_at: Date.now(),
+  sms_paused: false,
+};
 const userUpdateStub = () => Promise.resolve(mockUser);
 const userUpdateFailStub = () => Promise.reject({ message: 'Epic fail' });
 
@@ -57,7 +61,7 @@ test('updateUser should call next if Northstar.updateUser success', async (t) =>
   const next = sinon.stub();
   const middleware = updateUser();
   sandbox.stub(userHelper, 'getDefaultUpdatePayloadFromReq')
-    .returns({ });
+    .returns(mockDefaultUserUpdateData);
   sandbox.stub(userHelper, 'getSubscriptionStatusUpdate')
     .returns(null);
   sandbox.stub(northstar, 'updateUser')
@@ -67,6 +71,7 @@ test('updateUser should call next if Northstar.updateUser success', async (t) =>
   await middleware(t.context.req, t.context.res, next);
   userHelper.getDefaultUpdatePayloadFromReq.should.have.been.called;
   userHelper.getSubscriptionStatusUpdate.should.have.been.called;
+  t.context.req.userUpdateData.should.deep.equal(mockDefaultUserUpdateData);
   northstar.updateUser.should.have.been.called;
   repliesHelper.subscriptionStatusLess.should.not.have.been.called;
   repliesHelper.subscriptionStatusStop.should.not.have.been.called;
@@ -79,7 +84,7 @@ test('updateUser should call sendErrorResponse if Northstar.updateUser fails', a
   const next = sinon.stub();
   const middleware = updateUser();
   sandbox.stub(userHelper, 'getDefaultUpdatePayloadFromReq')
-    .returns({ });
+    .returns(mockDefaultUserUpdateData);
   sandbox.stub(userHelper, 'getSubscriptionStatusUpdate')
     .returns(null);
   sandbox.stub(northstar, 'updateUser')
@@ -140,3 +145,57 @@ test('updateUser should call replies.subscriptionStatusStop if statusUpdate is s
   helpers.sendErrorResponse.should.not.have.been.called;
 });
 
+test('updateUser should not set address if req.user.platformUserAddress undefined', async (t) => {
+  // setup
+  const next = sinon.stub();
+  const middleware = updateUser();
+  sandbox.stub(userHelper, 'getDefaultUpdatePayloadFromReq')
+    .returns(mockDefaultUserUpdateData);
+  sandbox.stub(userHelper, 'getSubscriptionStatusUpdate')
+    .returns(null);
+  sandbox.stub(userHelper, 'hasAddress')
+    .returns(false);
+  sandbox.stub(northstar, 'updateUser')
+    .callsFake(userUpdateStub);
+
+  // test
+  await middleware(t.context.req, t.context.res, next);
+  userHelper.getDefaultUpdatePayloadFromReq.should.have.been.called;
+  userHelper.getSubscriptionStatusUpdate.should.have.been.called;
+  userHelper.hasAddress.should.not.have.been.called;
+  t.context.req.userUpdateData.should.not.have.property('country');
+  northstar.updateUser.should.have.been.called;
+  repliesHelper.subscriptionStatusLess.should.not.have.been.called;
+  repliesHelper.subscriptionStatusStop.should.not.have.been.called;
+  next.should.have.been.called;
+  helpers.sendErrorResponse.should.not.have.been.called;
+});
+
+test('updateUser should set address when req.user does not have address', async (t) => {
+  // setup
+  const next = sinon.stub();
+  const middleware = updateUser();
+  sandbox.stub(userHelper, 'getDefaultUpdatePayloadFromReq')
+    .returns(mockDefaultUserUpdateData);
+  sandbox.stub(userHelper, 'getSubscriptionStatusUpdate')
+    .returns(null);
+  sandbox.stub(userHelper, 'hasAddress')
+    .returns(false);
+  sandbox.stub(northstar, 'updateUser')
+    .callsFake(userUpdateStub);
+  t.context.req.userId = mockUser.id;
+  t.context.req.platformUserAddress = { country: 'US' };
+
+  // test
+  await middleware(t.context.req, t.context.res, next);
+  userHelper.getDefaultUpdatePayloadFromReq.should.have.been.called;
+  userHelper.getSubscriptionStatusUpdate.should.have.been.called;
+  userHelper.hasAddress.should.have.been.called;
+  t.context.req.userUpdateData.should.have.property('country');
+  northstar.updateUser
+    .should.have.been.calledWith(t.context.req.userId, t.context.req.userUpdateData);
+  repliesHelper.subscriptionStatusLess.should.not.have.been.called;
+  repliesHelper.subscriptionStatusStop.should.not.have.been.called;
+  next.should.have.been.called;
+  helpers.sendErrorResponse.should.not.have.been.called;
+});

--- a/test/lib/middleware/receive-message/user-update.test.js
+++ b/test/lib/middleware/receive-message/user-update.test.js
@@ -1,0 +1,78 @@
+'use strict';
+
+require('dotenv').config();
+
+const test = require('ava');
+const chai = require('chai');
+const sinon = require('sinon');
+const sinonChai = require('sinon-chai');
+const httpMocks = require('node-mocks-http');
+const Promise = require('bluebird');
+const underscore = require('underscore');
+
+const northstar = require('../../../../lib/northstar');
+const helpers = require('../../../../lib/helpers');
+const userFactory = require('../../../helpers/factories/user');
+
+const userHelper = helpers.user;
+
+// setup "x.should.y" assertion style
+chai.should();
+chai.use(sinonChai);
+
+// module to be tested
+const updateUser = require('../../../../lib/middleware/receive-message/user-update');
+
+// sinon sandbox object
+const sandbox = sinon.sandbox.create();
+
+// stubs
+const mockUser = userFactory.getValidUser();
+const userUpdateStub = () => Promise.resolve(mockUser);
+const userUpdateFailStub = () => Promise.reject({ message: 'Epic fail' });
+
+test.beforeEach((t) => {
+  sandbox.stub(helpers, 'sendErrorResponse')
+    .returns(underscore.noop);
+  t.context.req = httpMocks.createRequest();
+  t.context.req.user = mockUser;
+  t.context.res = httpMocks.createResponse();
+});
+
+test.afterEach((t) => {
+  sandbox.restore();
+  t.context = {};
+});
+
+test('updateUser should call next if Northstar.updateUser success', async (t) => {
+  // setup
+  const next = sinon.stub();
+  const middleware = updateUser();
+  sandbox.stub(userHelper, 'getDefaultUpdatePayloadFromReq')
+    .returns({ });
+  sandbox.stub(northstar, 'updateUser')
+    .callsFake(userUpdateStub);
+
+  // test
+  await middleware(t.context.req, t.context.res, next);
+  userHelper.getDefaultUpdatePayloadFromReq.should.have.been.called;
+  northstar.updateUser.should.have.been.called;
+  next.should.have.been.called;
+});
+
+test('updateUser should call sendErrorResponse if Northstar.updateUser fails', async (t) => {
+  // setup
+  const next = sinon.stub();
+  const middleware = updateUser();
+  sandbox.stub(userHelper, 'getDefaultUpdatePayloadFromReq')
+    .returns({ });
+  sandbox.stub(northstar, 'updateUser')
+    .callsFake(userUpdateFailStub);
+
+  // test
+  await middleware(t.context.req, t.context.res, next);
+  userHelper.getDefaultUpdatePayloadFromReq.should.have.been.called;
+  northstar.updateUser.should.have.been.called;
+  next.should.not.have.been.called;
+  helpers.sendErrorResponse.should.have.been.called;
+});

--- a/test/lib/middleware/receive-message/user-update.test.js
+++ b/test/lib/middleware/receive-message/user-update.test.js
@@ -101,6 +101,56 @@ test('updateUser should call sendErrorResponse if Northstar.updateUser fails', a
   helpers.sendErrorResponse.should.have.been.called;
 });
 
+test('updateUser should call sendErrorResponse if getDefaultUpdatePayloadFromReq throws', async (t) => {
+  // setup
+  const next = sinon.stub();
+  const middleware = updateUser();
+  sandbox.stub(userHelper, 'getDefaultUpdatePayloadFromReq')
+    .throws();
+  sandbox.stub(userHelper, 'getSubscriptionStatusUpdate')
+    .returns(null);
+  sandbox.stub(userHelper, 'hasAddress')
+    .returns(false);
+  sandbox.stub(northstar, 'updateUser')
+    .callsFake(userUpdateStub);
+
+  // test
+  await middleware(t.context.req, t.context.res, next);
+  userHelper.getDefaultUpdatePayloadFromReq.should.have.been.called;
+  userHelper.getSubscriptionStatusUpdate.should.not.have.been.called;
+  userHelper.hasAddress.should.not.have.been.called;
+  northstar.updateUser.should.not.have.been.called;
+  repliesHelper.subscriptionStatusLess.should.not.have.been.called;
+  repliesHelper.subscriptionStatusStop.should.not.have.been.called;
+  next.should.not.have.been.called;
+  helpers.sendErrorResponse.should.have.been.called;
+});
+
+test('updateUser should call getSubscriptionStatusUpdate if hasAddress throws', async (t) => {
+  // setup
+  const next = sinon.stub();
+  const middleware = updateUser();
+  sandbox.stub(userHelper, 'getDefaultUpdatePayloadFromReq')
+    .returns(mockDefaultUserUpdateData);
+  sandbox.stub(userHelper, 'getSubscriptionStatusUpdate')
+    .throws();
+  sandbox.stub(userHelper, 'hasAddress')
+    .returns(false);
+  sandbox.stub(northstar, 'updateUser')
+    .callsFake(userUpdateStub);
+
+  // test
+  await middleware(t.context.req, t.context.res, next);
+  userHelper.getDefaultUpdatePayloadFromReq.should.have.been.called;
+  userHelper.getSubscriptionStatusUpdate.should.have.been.called;
+  userHelper.hasAddress.should.not.have.been.called;
+  northstar.updateUser.should.not.have.been.called;
+  repliesHelper.subscriptionStatusLess.should.not.have.been.called;
+  repliesHelper.subscriptionStatusStop.should.not.have.been.called;
+  next.should.not.have.been.called;
+  helpers.sendErrorResponse.should.have.been.called;
+});
+
 test('updateUser should call replies.subscriptionStatusLess if statusUpdate is less', async (t) => {
   // setup
   const next = sinon.stub();


### PR DESCRIPTION
#### What's this PR do?
Completes the TODO in #263 for extracting `sms_status` updates into a helper function, and adds tests.

#### How should this be reviewed?
* Verify Northstar updates work as expected for:
    * Adding address if it doesn't exist via posting Twilio properties
     * Changing `sms_status` value via subscription keywords (e.g. `'stop'`, `'less'`)

#### Any background context you want to provide?

Last TODO would be to add coverage and slightly refactor creating a User. Currently we create a User in the Create User middleware, posting to Northstar -- but we're also making a second post to Northstar to update the User's `sms_status`, `last_messaged_at`, etc. It's not the end of the world, but feels worth cleaning up? 

#### Relevant tickets 
#263 

#### Checklist
- [x] Documentation added for new features/changed endpoints.
- [x] Tests added for new features/bug fixes.
- [x] Tested on staging.
