### PR TITLE
Fixes last outbound message loading bug

### DIFF
--- a/config/lib/helpers/template.js
+++ b/config/lib/helpers/template.js
@@ -1,34 +1,47 @@
 'use strict';
 
+const underscore = require('underscore');
+
 const helpCenterUrl = 'http://doso.me/1jf4/291kep';
 // TODO: DRY menuCommand definition.
 // @see lib/helpers.js
 const menuCommand = 'menu';
 
+
+const templatesMap = {
+  campaignClosed: 'campaignClosed',
+  declinedSignup: 'declinedSignup',
+  declinedContinue: 'declinedContinue',
+  askContinueTemplates: {
+    askContinue: 'askContinue',
+    invalidAskContinueResponse: 'invalidAskContinueResponse',
+  },
+  askSignupTemplates: {
+    askSignup: 'askSignup',
+    invalidAskSignupResponse: 'invalidAskSignupResponse',
+  },
+  gambitCampaignsTemplates: {
+    askCaption: 'askCaption',
+    askPhoto: 'askPhoto',
+    askQuantity: 'askQuantity',
+    askWhyParticipated: 'askWhyParticipated',
+    completedMenu: 'completedMenu',
+    externalSignupMenu: 'externalSignupMenu',
+    gambitSignupMenu: 'gambitSignupMenu',
+    invalidCaption: 'invalidCaption',
+    invalidCompletedMenuCommand: 'invalidCompletedMenuCommand',
+    invalidPhoto: 'invalidPhoto',
+    invalidQuantity: 'invalidQuantity',
+    invalidSignupMenuCommand: 'invalidSignupMenuCommand',
+    invalidWhyParticipated: 'invalidWhyParticipated',
+  },
+};
+
 module.exports = {
-  askContinueTemplates: [
-    'askContinue',
-    'invalidAskContinueResponse',
-  ],
-  askSignupTemplates: [
-    'askSignup',
-    'invalidAskSignupResponse',
-  ],
-  gambitCampaignsTemplates: [
-    'askCaption',
-    'askPhoto',
-    'askQuantity',
-    'askWhyParticipated',
-    'completedMenu',
-    'externalSignupMenu',
-    'gambitSignupMenu',
-    'invalidCaption',
-    'invalidCompletedMenuCommand',
-    'invalidPhoto',
-    'invalidQuantity',
-    'invalidSignupMenuCommand',
-    'invalidWhyParticipated',
-  ],
+  templatesMap,
+  askContinueTemplates: underscore.values(templatesMap.askContinueTemplates),
+  askSignupTemplates: underscore.values(templatesMap.askSignupTemplates),
+  gambitCampaignsTemplates: underscore.values(templatesMap.gambitCampaignsTemplates),
   templateText: {
     badWords: 'Not cool. I\'m a real person & that offends me. I send out these texts to help young ppl take action. If you don\'t want my texts, text STOP or LESS to get less.',
     crisis: 'Thanks for being brave and sharing that. If you want to talk to someone, our friends at CTL are here for you 24/7. Just send a text to 741741. Theyll listen!',

--- a/config/lib/helpers/template.js
+++ b/config/lib/helpers/template.js
@@ -12,6 +12,8 @@ const templatesMap = {
   campaignClosed: 'campaignClosed',
   declinedSignup: 'declinedSignup',
   declinedContinue: 'declinedContinue',
+  rivescriptReply: 'rivescript',
+  memberSupport: 'memberSupport',
   askContinueTemplates: {
     askContinue: 'askContinue',
     invalidAskContinueResponse: 'invalidAskContinueResponse',
@@ -35,21 +37,53 @@ const templatesMap = {
     invalidSignupMenuCommand: 'invalidSignupMenuCommand',
     invalidWhyParticipated: 'invalidWhyParticipated',
   },
+  gambitConversationsTemplates: {
+    badWords: {
+      name: 'badWords',
+      text: 'Not cool. I\'m a real person & that offends me. I send out these texts to help young ppl take action. If you don\'t want my texts, text STOP or LESS to get less.',
+    },
+    crisis: {
+      name: 'crisis',
+      text: 'Thanks for being brave and sharing that. If you want to talk to someone, our friends at CTL are here for you 24/7. Just send a text to 741741. Theyll listen!',
+    },
+    info: {
+      name: 'info',
+      text: `These are Do Something Alerts - 4 messages/mo. Info help@dosomething.org or ${helpCenterUrl}. Txt STOP to quit. Msg&Data Rates May Apply.`,
+    },
+    noCampaign: {
+      name: 'noCampaign',
+      text: `Sorry, I'm not sure how to respond to that.\n\nSay ${menuCommand.toUpperCase()} to find a Campaign to join.`,
+    },
+    noReply: {
+      name: 'noReply',
+      text: '',
+    },
+    subscriptionStatusLess: {
+      name: 'subscriptionStatusLess',
+      text: 'OK, great! We\'ll start sending you updates monthly instead of weekly! -Freddie, DoSomething.org.',
+    },
+    subscriptionStatusStop: {
+      name: 'subscriptionStatusStop',
+      text: `Ok, you'll stop getting texts from me. If you just want monthly texts, text LESS. Questions? ${helpCenterUrl}. If you wish to unsubscribe, do not respond to this message.`,
+    },
+    supportRequested: {
+      name: 'supportRequested',
+      text: 'What\'s your question? I\'ll try my best to answer it.',
+    },
+  },
 };
 
 module.exports = {
   templatesMap,
+
+  /**
+   * Example structure of this property
+   * { badWords: 'Not cool... text STOP or LESS to get less.', }
+   */
+  conversationsTemplatesText: underscore.mapObject(
+    templatesMap.gambitConversationsTemplates, val => val.text),
   askContinueTemplates: underscore.values(templatesMap.askContinueTemplates),
   askSignupTemplates: underscore.values(templatesMap.askSignupTemplates),
   gambitCampaignsTemplates: underscore.values(templatesMap.gambitCampaignsTemplates),
-  templateText: {
-    badWords: 'Not cool. I\'m a real person & that offends me. I send out these texts to help young ppl take action. If you don\'t want my texts, text STOP or LESS to get less.',
-    crisis: 'Thanks for being brave and sharing that. If you want to talk to someone, our friends at CTL are here for you 24/7. Just send a text to 741741. Theyll listen!',
-    info: `These are Do Something Alerts - 4 messages/mo. Info help@dosomething.org or ${helpCenterUrl}. Txt STOP to quit. Msg&Data Rates May Apply.`,
-    noCampaign: `Sorry, I'm not sure how to respond to that.\n\nSay ${menuCommand.toUpperCase()} to find a Campaign to join.`,
-    noReply: '',
-    subscriptionStatusLess: 'OK, great! We\'ll start sending you updates monthly instead of weekly! -Freddie, DoSomething.org.',
-    subscriptionStatusStop: `Ok, you'll stop getting texts from me. If you just want monthly texts, text LESS. Questions? ${helpCenterUrl}. If you wish to unsubscribe, do not respond to this message.`,
-    supportRequested: 'What\'s your question? I\'ll try my best to answer it.',
-  },
+  gambitConversationsTemplates: underscore.pluck(underscore.values(templatesMap.gambitConversationsTemplates), 'name'),
 };

--- a/lib/helpers/replies.js
+++ b/lib/helpers/replies.js
@@ -13,7 +13,7 @@ const Message = require('../../app/models/Message');
  * @param {string} messageText
  * @param {string} messageTemplate
  */
-function sendReply(req, res, messageText, messageTemplate) {
+module.exports.sendReply = function (req, res, messageText, messageTemplate) {
   logger.debug('sendReply', { messageText, messageTemplate }, req);
   let promise = Promise.resolve();
 
@@ -39,7 +39,7 @@ function sendReply(req, res, messageText, messageTemplate) {
       return res.send({ data });
     })
     .catch(err => helpers.sendErrorResponse(res, err));
-}
+};
 
 /**
  * @param {string} string
@@ -81,7 +81,7 @@ module.exports.sendReplyWithCampaignTemplate = function (req, res, messageTempla
     messageText = replaceQuantity(messageText, req.signup);
   }
 
-  return sendReply(req, res, messageText, messageTemplate);
+  return exports.sendReply(req, res, messageText, messageTemplate);
 };
 
 /**
@@ -147,49 +147,49 @@ module.exports.invalidAskSignupResponse = function (req, res) {
 };
 
 module.exports.rivescriptReply = function (req, res, messageText) {
-  return sendReply(req, res, messageText, 'rivescript');
+  return exports.sendReply(req, res, messageText, 'rivescript');
 };
 
 /**
  * Send templates defined in Gambit Conversations.
  */
-function sendGambitConversationsTemplate(req, res, template) {
+module.exports.sendGambitConversationsTemplate = function (req, res, template) {
   logger.debug('sendGambitConversationsTemplate', { template });
   const text = helpers.template.getTextForTemplate(template);
-  return sendReply(req, res, text, template);
-}
+  return exports.sendReply(req, res, text, template);
+};
 
 module.exports.badWords = function (req, res) {
-  return sendGambitConversationsTemplate(req, res, 'badWords');
+  return exports.sendGambitConversationsTemplate(req, res, 'badWords');
 };
 
 module.exports.crisisMessage = function (req, res) {
-  return sendGambitConversationsTemplate(req, res, 'crisis');
+  return exports.sendGambitConversationsTemplate(req, res, 'crisis');
 };
 
 module.exports.infoMessage = function (req, res) {
-  return sendGambitConversationsTemplate(req, res, 'info');
+  return exports.sendGambitConversationsTemplate(req, res, 'info');
 };
 
 module.exports.noCampaign = function (req, res) {
-  return sendGambitConversationsTemplate(req, res, 'noCampaign');
+  return exports.sendGambitConversationsTemplate(req, res, 'noCampaign');
 };
 
 module.exports.noReply = function (req, res) {
-  return sendGambitConversationsTemplate(req, res, 'noReply');
+  return exports.sendGambitConversationsTemplate(req, res, 'noReply');
 };
 
 module.exports.subscriptionStatusLess = function (req, res) {
-  return sendGambitConversationsTemplate(req, res, 'subscriptionStatusLess');
+  return exports.sendGambitConversationsTemplate(req, res, 'subscriptionStatusLess');
 };
 
 module.exports.subscriptionStatusStop = function (req, res) {
-  return sendGambitConversationsTemplate(req, res, 'subscriptionStatusStop');
+  return exports.sendGambitConversationsTemplate(req, res, 'subscriptionStatusStop');
 };
 
 module.exports.supportRequested = function (req, res) {
   if (req.campaign) {
     return exports.sendReplyWithCampaignTemplate(req, res, 'memberSupport');
   }
-  return sendGambitConversationsTemplate(req, res, 'supportRequested');
+  return exports.sendGambitConversationsTemplate(req, res, 'supportRequested');
 };

--- a/lib/helpers/replies.js
+++ b/lib/helpers/replies.js
@@ -17,7 +17,8 @@ function sendReply(req, res, messageText, messageTemplate) {
   logger.debug('sendReply', { messageText, messageTemplate }, req);
   let promise = Promise.resolve();
 
-  if (req.isARetryRequest()) {
+  // If this is a retry request, we should load the last outbound message if it exists
+  if (req.isARetryRequest() && req.conversation.lastOutboundMessage) {
     promise = Message.updateMessageByRequestIdAndDirection(req.metadata.requestId,
       { metadata: req.metadata }, 'outbound-reply')
       .then(() => req.conversation.postLastOutboundMessageToPlatform());

--- a/lib/helpers/replies.js
+++ b/lib/helpers/replies.js
@@ -65,7 +65,7 @@ function replaceQuantity(string, signup) {
  * @param {object} res
  * @param {string} messageTemplate
  */
-function sendReplyWithCampaignTemplate(req, res, messageTemplate) {
+module.exports.sendReplyWithCampaignTemplate = function (req, res, messageTemplate) {
   const campaign = req.campaign;
   if (!campaign.id) {
     return helpers.sendErrorResponse(res, 'req.campaign undefined');
@@ -82,7 +82,7 @@ function sendReplyWithCampaignTemplate(req, res, messageTemplate) {
   }
 
   return sendReply(req, res, messageText, messageTemplate);
-}
+};
 
 /**
  * Sends reply message by posting inboundMessage to Gambit Campaigns for Conversation Campaign.
@@ -99,21 +99,21 @@ module.exports.continueCampaign = function (req, res) {
     .then((gambitCampaignsRes) => {
       req.signup = gambitCampaignsRes.signup;
       logger.debug('continueCampaign', { signupId: req.signup.id }, req);
-      return sendReplyWithCampaignTemplate(req, res, gambitCampaignsRes.replyTemplate);
+      return exports.sendReplyWithCampaignTemplate(req, res, gambitCampaignsRes.replyTemplate);
     })
     .catch(err => helpers.sendErrorResponse(res, err));
 };
 
 module.exports.askContinue = function (req, res) {
-  return sendReplyWithCampaignTemplate(req, res, 'askContinue');
+  return exports.sendReplyWithCampaignTemplate(req, res, 'askContinue');
 };
 
 module.exports.askSignup = function (req, res) {
-  return sendReplyWithCampaignTemplate(req, res, 'askSignup');
+  return exports.sendReplyWithCampaignTemplate(req, res, 'askSignup');
 };
 
 module.exports.campaignClosed = function (req, res) {
-  return sendReplyWithCampaignTemplate(req, res, 'campaignClosed');
+  return exports.sendReplyWithCampaignTemplate(req, res, 'campaignClosed');
 };
 
 module.exports.confirmedContinue = function (req, res) {
@@ -131,19 +131,19 @@ module.exports.confirmedSignup = function (req, res) {
 };
 
 module.exports.declinedContinue = function (req, res) {
-  return sendReplyWithCampaignTemplate(req, res, 'declinedContinue');
+  return exports.sendReplyWithCampaignTemplate(req, res, 'declinedContinue');
 };
 
 module.exports.declinedSignup = function (req, res) {
-  return sendReplyWithCampaignTemplate(req, res, 'declinedSignup');
+  return exports.sendReplyWithCampaignTemplate(req, res, 'declinedSignup');
 };
 
 module.exports.invalidAskContinueResponse = function (req, res) {
-  return sendReplyWithCampaignTemplate(req, res, 'invalidAskContinueResponse');
+  return exports.sendReplyWithCampaignTemplate(req, res, 'invalidAskContinueResponse');
 };
 
 module.exports.invalidAskSignupResponse = function (req, res) {
-  return sendReplyWithCampaignTemplate(req, res, 'invalidAskSignupResponse');
+  return exports.sendReplyWithCampaignTemplate(req, res, 'invalidAskSignupResponse');
 };
 
 module.exports.rivescriptReply = function (req, res, messageText) {
@@ -189,7 +189,7 @@ module.exports.subscriptionStatusStop = function (req, res) {
 
 module.exports.supportRequested = function (req, res) {
   if (req.campaign) {
-    return sendReplyWithCampaignTemplate(req, res, 'memberSupport');
+    return exports.sendReplyWithCampaignTemplate(req, res, 'memberSupport');
   }
   return sendGambitConversationsTemplate(req, res, 'supportRequested');
 };

--- a/lib/helpers/template.js
+++ b/lib/helpers/template.js
@@ -5,7 +5,7 @@ const config = require('../../config/lib/helpers/template');
 
 module.exports = {
   getTextForTemplate: function getTextForTemplate(templateName) {
-    return config.templateText[templateName];
+    return config.conversationsTemplatesText[templateName];
   },
   isAskContinueTemplate: function isAskContinueTemplate(templateName) {
     return config.askContinueTemplates.includes(templateName);

--- a/test/helpers/factories/message.js
+++ b/test/helpers/factories/message.js
@@ -4,7 +4,7 @@ const ObjectID = require('mongoose').Types.ObjectId;
 const Message = require('../../../app/models/Message');
 const stubs = require('../stubs');
 
-module.exports.getValidMessage = function getValidMessage() {
+module.exports.getValidMessage = function getValidMessage(direction) {
   const id = new ObjectID();
   const date = new Date();
   return new Message({
@@ -12,5 +12,10 @@ module.exports.getValidMessage = function getValidMessage() {
     createdAt: date,
     updatedAt: date,
     text: stubs.getRandomMessageText(),
+    direction: direction || 'inbound',
   });
+};
+
+module.exports.getValidOutboundReplyMessage = function getValidOutboundReplyMessage() {
+  return exports.getValidMessage('outbound-reply');
 };

--- a/test/helpers/stubs.js
+++ b/test/helpers/stubs.js
@@ -14,6 +14,28 @@ const totalInboundDeclinedCampaign = 10;
 const totalInboundNoMacro = 19;
 
 module.exports = {
+  gambitCampaigns: {
+    getSignupId: function getSignupId() {
+      return 8496477;
+    },
+    getReceiveMessageResponse: function getReceiveMessageResponse() {
+      return {
+        data: {
+          replyTemplate: module.exports.getTemplate(),
+          signup: {
+            id: this.getSignupId(),
+            campaign: {
+              id: module.exports.getCampaignId(),
+            },
+            user: {
+              id: module.exports.getUserId(),
+            },
+            totalQuantitySubmitted: null,
+          },
+        },
+      };
+    },
+  },
   stubLogger: function stubLogger(sandbox, logger) {
     sandbox.stub(logger, 'warn').returns(() => {});
     sandbox.stub(logger, 'error').returns(() => {});

--- a/test/lib/lib-helpers/replies.test.js
+++ b/test/lib/lib-helpers/replies.test.js
@@ -14,6 +14,9 @@ const logger = require('../../../lib/logger');
 const gambitCampaigns = require('../../../lib/gambit-campaigns');
 const helpers = require('../../../lib/helpers');
 const templatesConfig = require('../../../config/lib/helpers/template');
+const Message = require('../../../app/models/Message');
+const conversationFactory = require('../../helpers/factories/conversation');
+const messageFactory = require('../../helpers/factories/message');
 
 // setup "x.should.y" assertion style
 chai.should();
@@ -28,12 +31,14 @@ const sandbox = sinon.sandbox.create();
 // misc helper vars
 const gCampResponse = stubs.gambitCampaigns.getReceiveMessageResponse();
 const templates = templatesConfig.templatesMap;
+const resolvedPromise = Promise.resolve({});
 
 // Setup
 test.beforeEach((t) => {
   stubs.stubLogger(sandbox, logger);
   t.context.req = httpMocks.createRequest();
   t.context.res = httpMocks.createResponse();
+
   sandbox.stub(helpers, 'sendErrorResponse')
     .returns(() => {});
 
@@ -48,23 +53,76 @@ test.afterEach((t) => {
   t.context = {};
 });
 
-test('continueCampaign(): sendReplyWithCampaignTemplate should be called', async (t) => {
-  // Setup
+// Assert helper functions
+// TODO: Maybe move to own asserts module?
+async function assertSendingReplyWithCampaignTemplate(req, res, template, replyName) {
   sandbox.stub(repliesHelper, 'sendReplyWithCampaignTemplate')
-    .returns(() => {});
+    .returns(resolvedPromise);
+
+  await repliesHelper[replyName || template](req, res);
+  repliesHelper.sendReplyWithCampaignTemplate
+    .should.have.been.calledWith(req, res, template);
+}
+
+async function assertSendingGambitConversationsTemplate(req, res, template, replyName) {
+  sandbox.stub(repliesHelper, 'sendGambitConversationsTemplate')
+    .returns(resolvedPromise);
+
+  await repliesHelper[replyName || template](req, res);
+  repliesHelper.sendGambitConversationsTemplate
+    .should.have.been.calledWith(req, res, template);
+}
+
+
+/**
+ * Tests --------------------------------------------------
+ */
+
+test('sendReply()', async (t) => {
+  // setup
+  // TODO: DRY this somehow :/
+  const text = 'text line';
+  const template = templates.campaignClosed;
+  const inboundMsg = messageFactory.getValidMessage();
+  const outboundMsg = messageFactory.getValidOutboundReplyMessage();
+  t.context.req.metadata = {};
+  t.context.req.isARetryRequest = () => false;
+  t.context.req.inboundMessage = inboundMsg;
+  t.context.req.conversation = conversationFactory.getValidConversation();
+  t.context.req.conversation.lastOutboundMessage = outboundMsg;
+  sandbox.stub(t.context.req.conversation, 'postLastOutboundMessageToPlatform')
+    .returns(resolvedPromise);
+  sandbox.stub(t.context.req.conversation, 'createAndPostOutboundReplyMessage')
+    .returns(resolvedPromise);
+  sandbox.stub(Message, 'updateMessageByRequestIdAndDirection')
+    .returns(resolvedPromise);
+  sandbox.spy(t.context.res, 'send');
+
+  // test
+  await repliesHelper.sendReply(t.context.req, t.context.res, text, template);
+  const responseMessages = t.context.res.send.getCall(0).args[0].data.messages;
+
+  // asserts
+  t.context.res.send.should.have.been.called;
+  responseMessages.inbound[0].should.be.equal(inboundMsg);
+  responseMessages.outbound[0].should.be.equal(outboundMsg);
+});
+
+test('continueCampaign(): sendReplyWithCampaignTemplate should be called', async (t) => {
   sandbox.stub(gambitCampaigns, 'postReceiveMessage')
     .returns(Promise.resolve(gCampResponse.data));
+  sandbox.stub(repliesHelper, 'sendReplyWithCampaignTemplate')
+    .returns(resolvedPromise);
 
   await repliesHelper.continueCampaign(t.context.req, t.context.res);
   repliesHelper.sendReplyWithCampaignTemplate.should.have.been.called;
 });
 
 test('continueCampaign(): helpers.sendErrorResponse should be called if no campaign exists', async (t) => {
-  // Setup
-  sandbox.stub(repliesHelper, 'sendReplyWithCampaignTemplate')
-    .returns(() => {});
   sandbox.stub(gambitCampaigns, 'postReceiveMessage')
     .returns(Promise.reject(gCampResponse.data));
+  sandbox.stub(repliesHelper, 'sendReplyWithCampaignTemplate')
+    .returns(resolvedPromise);
 
   await repliesHelper.continueCampaign(t.context.req, t.context.res);
   repliesHelper.sendReplyWithCampaignTemplate.should.not.have.been.called;
@@ -72,37 +130,124 @@ test('continueCampaign(): helpers.sendErrorResponse should be called if no campa
 });
 
 test('continueCampaign(): helpers.sendErrorResponse should be called on Gambit Campaign error', async (t) => {
-  // Setup
   t.context.req.campaign = {};
   sandbox.stub(repliesHelper, 'sendReplyWithCampaignTemplate')
-    .returns(() => {});
+    .returns(resolvedPromise);
 
   await repliesHelper.continueCampaign(t.context.req, t.context.res);
   repliesHelper.sendReplyWithCampaignTemplate.should.not.have.been.called;
   helpers.sendErrorResponse.should.have.been.called;
 });
 
-test('askContinue(): sendReplyWithCampaignTemplate should be called', async (t) => {
-  // Setup
-  const replies = [
-    templates.askContinueTemplates.askContinue,
-    templates.askSignupTemplates.askSignup,
-    templates.campaignClosed,
-    templates.declinedContinue,
-    templates.declinedSignup,
-    templates.askContinueTemplates.invalidAskContinueResponse,
-    templates.askSignupTemplates.invalidAskSignupResponse,
-  ];
-  sandbox.stub(repliesHelper, 'sendReplyWithCampaignTemplate')
-    .returns(() => {});
+test('askContinue(): should call sendReplyWithCampaignTemplate', async (t) => {
+  const template = templates.askContinueTemplates.askContinue;
+  await assertSendingReplyWithCampaignTemplate(t.context.req, t.context.res, template);
+});
 
-  replies.forEach((template) => {
-    sandbox.spy(repliesHelper, template);
-    // async IIFE Needed to avoid using promises
-    (async () => {
-      await repliesHelper[template](t.context.req, t.context.res);
-    })();
-    repliesHelper.sendReplyWithCampaignTemplate
-      .should.have.been.calledWith(t.context.req, t.context.res, template);
-  });
+test('askSignup(): should call sendReplyWithCampaignTemplate', async (t) => {
+  const template = templates.askSignupTemplates.askSignup;
+  await assertSendingReplyWithCampaignTemplate(t.context.req, t.context.res, template);
+});
+
+test('campaignClosed(): should call sendReplyWithCampaignTemplate', async (t) => {
+  const template = templates.campaignClosed;
+  await assertSendingReplyWithCampaignTemplate(t.context.req, t.context.res, template);
+});
+
+test('confirmedContinue(): should call continueCampaign', async (t) => {
+  sandbox.stub(repliesHelper, 'continueCampaign')
+    .returns(resolvedPromise);
+
+  await repliesHelper.confirmedContinue(t.context.req, t.context.res);
+  repliesHelper.continueCampaign.should.have.been.called;
+  // TODO: Should not be testing hardcoded strings
+  repliesHelper.continueCampaign.getCall(0).args[0].keyword.should.equal('continue');
+});
+
+test('confirmedSignup(): should call continueCampaign', async (t) => {
+  sandbox.stub(repliesHelper, 'continueCampaign')
+    .returns(resolvedPromise);
+
+  await repliesHelper.confirmedSignup(t.context.req, t.context.res);
+  repliesHelper.continueCampaign.should.have.been.called;
+  // TODO: Should not be testing hardcoded strings
+  repliesHelper.continueCampaign.getCall(0).args[0].keyword.should.equal('confirmed');
+});
+
+test('declinedContinue(): should call sendReplyWithCampaignTemplate', async (t) => {
+  const template = templates.declinedContinue;
+  await assertSendingReplyWithCampaignTemplate(t.context.req, t.context.res, template);
+});
+
+test('declinedSignup(): should call sendReplyWithCampaignTemplate', async (t) => {
+  const template = templates.declinedSignup;
+  await assertSendingReplyWithCampaignTemplate(t.context.req, t.context.res, template);
+});
+
+test('invalidAskContinueResponse(): should call sendReplyWithCampaignTemplate', async (t) => {
+  const template = templates.askContinueTemplates.invalidAskContinueResponse;
+  await assertSendingReplyWithCampaignTemplate(t.context.req, t.context.res, template);
+});
+
+test('invalidAskSignupResponse(): should call sendReplyWithCampaignTemplate', async (t) => {
+  const template = templates.askSignupTemplates.invalidAskSignupResponse;
+  await assertSendingReplyWithCampaignTemplate(t.context.req, t.context.res, template);
+});
+
+test('badWords(): should call sendGambitConversationsTemplate', async (t) => {
+  const template = templates.gambitConversationsTemplates.badWords.name;
+  await assertSendingGambitConversationsTemplate(t.context.req, t.context.res, template);
+});
+
+test('crisis(): should call sendGambitConversationsTemplate', async (t) => {
+  const template = templates.gambitConversationsTemplates.crisis.name;
+  await assertSendingGambitConversationsTemplate(t.context.req, t.context.res, template, 'crisisMessage');
+});
+
+test('info(): should call sendGambitConversationsTemplate', async (t) => {
+  const template = templates.gambitConversationsTemplates.info.name;
+  await assertSendingGambitConversationsTemplate(t.context.req, t.context.res, template, 'infoMessage');
+});
+
+test('noCampaign(): should call sendGambitConversationsTemplate', async (t) => {
+  const template = templates.gambitConversationsTemplates.noCampaign.name;
+  await assertSendingGambitConversationsTemplate(t.context.req, t.context.res, template);
+});
+
+test('noReply(): should call sendGambitConversationsTemplate', async (t) => {
+  const template = templates.gambitConversationsTemplates.noReply.name;
+  await assertSendingGambitConversationsTemplate(t.context.req, t.context.res, template);
+});
+
+test('subscriptionStatusLess(): should call sendGambitConversationsTemplate', async (t) => {
+  const template = templates.gambitConversationsTemplates.subscriptionStatusLess.name;
+  await assertSendingGambitConversationsTemplate(t.context.req, t.context.res, template);
+});
+
+test('subscriptionStatusStop(): should call sendGambitConversationsTemplate', async (t) => {
+  const template = templates.gambitConversationsTemplates.subscriptionStatusStop.name;
+  await assertSendingGambitConversationsTemplate(t.context.req, t.context.res, template);
+});
+
+test('supportRequested(): should call sendGambitConversationsTemplate if no campaign is found', async (t) => {
+  // Campaign is being set beforeEach test, so we need to unset it here
+  t.context.req.campaign = undefined;
+  const template = templates.gambitConversationsTemplates.supportRequested.name;
+  await assertSendingGambitConversationsTemplate(t.context.req, t.context.res, template);
+});
+
+test('supportRequested(): should call sendReplyWithCampaignTemplate if campaign is found', async (t) => {
+  const template = templates.memberSupport;
+  await assertSendingReplyWithCampaignTemplate(t.context.req, t.context.res, template, 'supportRequested');
+});
+
+test('rivescriptReply(): should call sendReply', async (t) => {
+  const template = templates.rivescriptReply;
+  const text = 'some text';
+  sandbox.stub(repliesHelper, 'sendReply')
+    .returns(resolvedPromise);
+
+  await repliesHelper.rivescriptReply(t.context.req, t.context.res, text);
+  repliesHelper.sendReply
+    .should.have.been.calledWith(t.context.req, t.context.res, text, template);
 });

--- a/test/lib/lib-helpers/replies.test.js
+++ b/test/lib/lib-helpers/replies.test.js
@@ -1,0 +1,108 @@
+'use strict';
+
+// libs
+require('dotenv').config();
+const test = require('ava');
+const chai = require('chai');
+const sinon = require('sinon');
+const sinonChai = require('sinon-chai');
+const httpMocks = require('node-mocks-http');
+const Promise = require('bluebird');
+
+const stubs = require('../../helpers/stubs');
+const logger = require('../../../lib/logger');
+const gambitCampaigns = require('../../../lib/gambit-campaigns');
+const helpers = require('../../../lib/helpers');
+const templatesConfig = require('../../../config/lib/helpers/template');
+
+// setup "x.should.y" assertion style
+chai.should();
+chai.use(sinonChai);
+
+// module to be tested
+const repliesHelper = require('../../../lib/helpers/replies');
+
+// sinon sandbox object
+const sandbox = sinon.sandbox.create();
+
+// misc helper vars
+const gCampResponse = stubs.gambitCampaigns.getReceiveMessageResponse();
+const templates = templatesConfig.templatesMap;
+
+// Setup
+test.beforeEach((t) => {
+  stubs.stubLogger(sandbox, logger);
+  t.context.req = httpMocks.createRequest();
+  t.context.res = httpMocks.createResponse();
+  sandbox.stub(helpers, 'sendErrorResponse')
+    .returns(() => {});
+
+  // add a campaign object
+  t.context.req.campaign = { id: stubs.getCampaignId() };
+});
+
+// Cleanup
+test.afterEach((t) => {
+  // reset stubs, spies, and mocks
+  sandbox.restore();
+  t.context = {};
+});
+
+test('continueCampaign(): sendReplyWithCampaignTemplate should be called', async (t) => {
+  // Setup
+  sandbox.stub(repliesHelper, 'sendReplyWithCampaignTemplate')
+    .returns(() => {});
+  sandbox.stub(gambitCampaigns, 'postReceiveMessage')
+    .returns(Promise.resolve(gCampResponse.data));
+
+  await repliesHelper.continueCampaign(t.context.req, t.context.res);
+  repliesHelper.sendReplyWithCampaignTemplate.should.have.been.called;
+});
+
+test('continueCampaign(): helpers.sendErrorResponse should be called if no campaign exists', async (t) => {
+  // Setup
+  sandbox.stub(repliesHelper, 'sendReplyWithCampaignTemplate')
+    .returns(() => {});
+  sandbox.stub(gambitCampaigns, 'postReceiveMessage')
+    .returns(Promise.reject(gCampResponse.data));
+
+  await repliesHelper.continueCampaign(t.context.req, t.context.res);
+  repliesHelper.sendReplyWithCampaignTemplate.should.not.have.been.called;
+  helpers.sendErrorResponse.should.have.been.called;
+});
+
+test('continueCampaign(): helpers.sendErrorResponse should be called on Gambit Campaign error', async (t) => {
+  // Setup
+  t.context.req.campaign = {};
+  sandbox.stub(repliesHelper, 'sendReplyWithCampaignTemplate')
+    .returns(() => {});
+
+  await repliesHelper.continueCampaign(t.context.req, t.context.res);
+  repliesHelper.sendReplyWithCampaignTemplate.should.not.have.been.called;
+  helpers.sendErrorResponse.should.have.been.called;
+});
+
+test('askContinue(): sendReplyWithCampaignTemplate should be called', async (t) => {
+  // Setup
+  const replies = [
+    templates.askContinueTemplates.askContinue,
+    templates.askSignupTemplates.askSignup,
+    templates.campaignClosed,
+    templates.declinedContinue,
+    templates.declinedSignup,
+    templates.askContinueTemplates.invalidAskContinueResponse,
+    templates.askSignupTemplates.invalidAskSignupResponse,
+  ];
+  sandbox.stub(repliesHelper, 'sendReplyWithCampaignTemplate')
+    .returns(() => {});
+
+  replies.forEach((template) => {
+    sandbox.spy(repliesHelper, template);
+    // async IIFE Needed to avoid using promises
+    (async () => {
+      await repliesHelper[template](t.context.req, t.context.res);
+    })();
+    repliesHelper.sendReplyWithCampaignTemplate
+      .should.have.been.calledWith(t.context.req, t.context.res, template);
+  });
+});

--- a/test/lib/lib-helpers/template.test.js
+++ b/test/lib/lib-helpers/template.test.js
@@ -30,7 +30,7 @@ test.afterEach(() => {
 
 test('getTextForTemplate should return text for given template', () => {
   const template = 'badWords';
-  const templateText = config.templateText[template];
+  const templateText = config.conversationsTemplatesText[template];
   const result = templateHelper.getTextForTemplate(template);
   templateText.should.equal(result);
 });


### PR DESCRIPTION
#### What's this PR do?
G-Con now checks if there was an outbound message created instead of assuming there is one, for requests that are being retried.

#### How should this be reviewed?
- 👀 
- Delete all messages that match your user's conversation id:
    - Run `db.messages.remove({conversationId: ObjectId(<CONVERSATION-ID>)})` in your local mongo cli runtime.
- Send a request with text `MENU` to `/receive-message` using Postman
    - Include the `x-blink-retry-count: 1` 
    - Include the `x-request-id: test` 
- You should not see any errors in your console or your Postman app. Previously, this would have triggered a `code=500 response#message="Cannot read property 'text' of undefined" level=error message=sendResponseWithStatusCode` error.
- Confirm both the `inbound` and `outbound` messages were created.

#### Relevant tickets
Fixes #219

#### Checklist
- [ ] Tests added for new features/bug fixes.
- [ ] Tested on staging.