### PR TITLE
Custom URL Campaign parameter tweaks

### DIFF
--- a/config/lib/helpers/tags.js
+++ b/config/lib/helpers/tags.js
@@ -11,16 +11,16 @@ module.exports = {
    */
   customUrl: {
     url: process.env.DS_GAMBIT_CUSTOM_URL || 'https://dosomething.turbovote.org',
-    queryParamName: process.env.DS_GAMBIT_CUSTOM_URL_QUERY_PARAM || 'referral-code',
+    queryParamName: process.env.DS_GAMBIT_CUSTOM_URL_QUERY_PARAM || 'r',
     queryValue: {
       separator: ',',
       fieldSuffix: ':',
       fields: {
         userId: 'user',
-        campaignRunId: 'campaign',
+        campaignId: 'campaignID',
+        campaignRunId: 'campaignRunID',
         platform: 'source',
       },
     },
   },
-
 };

--- a/lib/helpers/tags.js
+++ b/lib/helpers/tags.js
@@ -33,9 +33,9 @@ module.exports = {
     if (userIdField) {
       data.push(userIdField);
     }
-    const campaignRunIdField = module.exports.getCampaignRunIdCustomUrlQueryValueField(req);
-    if (campaignRunIdField) {
-      data.push(campaignRunIdField);
+    const campaignField = module.exports.getCampaignCustomUrlQueryValueField(req);
+    if (campaignField) {
+      data.push(campaignField);
     }
 
     const platformField = module.exports.getPlatformCustomUrlQueryValueField(req);
@@ -54,13 +54,19 @@ module.exports = {
     }
     return '';
   },
-  getCampaignRunIdCustomUrlQueryValueField: function getCampaignRunIdCustomUrlQueryValueField(req) {
-    const fieldName = config.customUrl.queryValue.fields.campaignRunId;
-    if (req.campaign && req.campaign.currentCampaignRun) {
-      const campaignRunId = req.campaign.currentCampaignRun.id;
-      return module.exports.formatCustomUrlQueryValueField(fieldName, campaignRunId);
+  getCampaignCustomUrlQueryValueField: function getCampaignCustomUrlQueryValueField(req) {
+    const fields = config.customUrl.queryValue.fields;
+    const campaign = req.campaign;
+    if (!campaign) {
+      return '';
     }
-    return '';
+    const data = [];
+    data.push(module.exports.formatCustomUrlQueryValueField(fields.campaignId, campaign.id));
+    if (campaign.currentCampaignRun) {
+      const runId = campaign.currentCampaignRun.id;
+      data.push(module.exports.formatCustomUrlQueryValueField(fields.campaignRunId, runId));
+    }
+    return module.exports.joinCustomUrlQueryValueFields(data);
   },
   getPlatformCustomUrlQueryValueField: function getPlatformCustomUrlQueryValueField(req) {
     const fieldName = config.customUrl.queryValue.fields.platform;

--- a/test/lib/lib-helpers/tags.test.js
+++ b/test/lib/lib-helpers/tags.test.js
@@ -150,9 +150,11 @@ test('getUserIdCustomUrlQueryValueField returns empty string if req.user undefin
 
 test('getCampaignCustomUrlQueryValueField should return string for req.user', (t) => {
   t.context.req.campaign = mockCampaign;
-  const fieldName = config.customUrl.queryValue.fields.campaignRunId;
+  const fields = config.customUrl.queryValue.fields;
   const result = tagsHelper.getCampaignCustomUrlQueryValueField(t.context.req);
-  t.truthy(result.includes(fieldName));
+  t.truthy(result.includes(fields.campaignId));
+  t.truthy(result.includes(mockCampaign.id));
+  t.truthy(result.includes(fields.campaignRunId));
   t.truthy(result.includes(mockCampaign.currentCampaignRun.id));
 });
 

--- a/test/lib/lib-helpers/tags.test.js
+++ b/test/lib/lib-helpers/tags.test.js
@@ -103,13 +103,13 @@ test('getCustomUrlQueryParamValue should call joinCustomUrlQueryValueFields', (t
   const mockResult = 'success';
   sandbox.stub(tagsHelper, 'getUserIdCustomUrlQueryValueField')
     .returns('success1');
-  sandbox.stub(tagsHelper, 'getCampaignRunIdCustomUrlQueryValueField')
+  sandbox.stub(tagsHelper, 'getCampaignCustomUrlQueryValueField')
     .returns('success2');
   sandbox.stub(tagsHelper, 'joinCustomUrlQueryValueFields')
     .returns(mockResult);
   const result = tagsHelper.getCustomUrlQueryParamValue(t.context.req);
   tagsHelper.getUserIdCustomUrlQueryValueField.should.have.been.called;
-  tagsHelper.getCampaignRunIdCustomUrlQueryValueField.should.have.been.called;
+  tagsHelper.getCampaignCustomUrlQueryValueField.should.have.been.called;
   tagsHelper.joinCustomUrlQueryValueFields.should.have.been.called;
   result.should.equal(mockResult);
 });
@@ -148,16 +148,16 @@ test('getUserIdCustomUrlQueryValueField returns empty string if req.user undefin
   result.should.equal('');
 });
 
-test('getCampaignRunIdCustomUrlQueryValueField should return string for req.user', (t) => {
+test('getCampaignCustomUrlQueryValueField should return string for req.user', (t) => {
   t.context.req.campaign = mockCampaign;
   const fieldName = config.customUrl.queryValue.fields.campaignRunId;
-  const result = tagsHelper.getCampaignRunIdCustomUrlQueryValueField(t.context.req);
+  const result = tagsHelper.getCampaignCustomUrlQueryValueField(t.context.req);
   t.truthy(result.includes(fieldName));
   t.truthy(result.includes(mockCampaign.currentCampaignRun.id));
 });
 
-test('getCampaignRunIdCustomUrlQueryValueField returns empty string if req.campaign undefined', (t) => {
-  const result = tagsHelper.getCampaignRunIdCustomUrlQueryValueField(t.context.req);
+test('getCampaignCustomUrlQueryValueField returns empty string if req.campaign undefined', (t) => {
+  const result = tagsHelper.getCampaignCustomUrlQueryValueField(t.context.req);
   result.should.equal('');
 });
 


### PR DESCRIPTION
#### What's this PR do?
Renames  the tags `getCampaignRunIdCustomUrlQueryValueField` as `getCampaignCustomUrlQueryValueField` to pass both a Campaign ID and Run ID

#### How should this be reviewed?
Text [BOOKBOT](https://gambit-admin-staging.herokuapp.com/campaigns/2299#gambitSignupMenu) to Staging to verify `campaignID` and `campaignRunID`  parameter and values are present in the URL returned in the `gambitSignupMenu` or `completedMenu` messages.

#### Relevant tickets
Fixes #277 

#### Checklist
- [x] Documentation added for new features/changed endpoints -- https://github.com/DoSomething/gambit-admin/wiki/Tags#examples
- [x] Tests added for new features/bug fixes.
- [x] Tested on staging -- https://gambit-admin-staging.herokuapp.com/requests/0d77a0f6-0e7e-4fc3-aa71-f6b896058ffd
