### PR TITLE
User tag

### DIFF
--- a/config/lib/helpers/tags.js
+++ b/config/lib/helpers/tags.js
@@ -4,6 +4,7 @@ module.exports = {
   // Tags used in message templates.
   tags: {
     customUrl: 'custom_url',
+    user: 'user',
   },
   /**
    * The customUrl tag should return a custom link with Conversation variables set in query string:

--- a/lib/helpers/tags.js
+++ b/lib/helpers/tags.js
@@ -11,6 +11,7 @@ module.exports = {
   getVarsForTags: function getVarsForTags(req) {
     const vars = {};
     vars[config.tags.customUrl] = module.exports.getCustomUrl(req);
+    vars[config.tags.user] = req.user || {};
     return vars;
   },
   render: function render(string, req) {

--- a/test/helpers/factories/user.js
+++ b/test/helpers/factories/user.js
@@ -8,7 +8,7 @@ const chance = new Chance();
 
 module.exports.getValidUser = function getValidUser(phoneNumber) {
   return {
-    id: new ObjectID(),
+    id: new ObjectID().toString(),
     mobile: phoneNumber || stubs.getMobileNumber(),
     sms_status: 'active',
     sms_paused: false,

--- a/test/lib/lib-helpers/tags.test.js
+++ b/test/lib/lib-helpers/tags.test.js
@@ -69,18 +69,24 @@ test('render should throw if getVarsForTags fails', () => {
   tagsHelper.render(mockText, mockVars).should.throw;
 });
 
-test('getVarsForTags should return an object', () => {
+test('render should replace user vars', (t) => {
+  t.context.req.user = mockUser;
+  const result = tagsHelper.render('{{user.id}}', t.context.req);
+  result.should.equal(mockUser.id);
+});
+
+test('getVarsForTags should return an object', (t) => {
   sandbox.stub(tagsHelper, 'getCustomUrl')
     .returns(mockText);
-  const result = tagsHelper.getVarsForTags();
+  const result = tagsHelper.getVarsForTags(t.context.req);
   result.should.be.a('object');
   result[config.tags.customUrl].should.equal(mockText);
 });
 
-test('getVarsForTags should throw if getCustomUrl fails', () => {
+test('getVarsForTags should throw if getCustomUrl fails', (t) => {
   sandbox.stub(tagsHelper, 'getCustomUrl')
     .returns(new Error());
-  tagsHelper.getVarsForTags().should.throw;
+  tagsHelper.getVarsForTags(t.context.req).should.throw;
 });
 
 test('getCustomUrl should return a string', () => {


### PR DESCRIPTION
#### What's this PR do?
Supports embedding properties of the `req.user` object in a Gambit message,  via a `user` Mustache tag.

#### How should this be reviewed?
Upon staging deploy, send `PUPPETSLOTH` to Gambit Staging and verify your User ID is included in the reply message. I've added the `{{user.id}}`  tag into the Rivescript reply via [Contentful](https://app.contentful.com/spaces/owik07lyerdj/entries/5or7RXWYQoMUM0yIoiWAUq).

#### Any background context you want to provide?
Rivescript:
```
+ puppetsloth
- Greetings User {{user.id}}, here's your custom URL {{{custom_url}}}.
```

Consolebot response to PUPPETSLOTH:
> Greetings User 5a78a8a610707d22021fcc7b, here's your custom URL https://dosomething.turbovote.org?r=user:5a78a8a610707d22021fcc7b,source:api.


#### Relevant tickets
Fixes # 279

#### Checklist
- [x] Documentation added for new features/changed endpoints. https://github.com/DoSomething/gambit-admin/wiki/Tags#user-id
- [x] Tests added for new features/bug fixes.
- [x] Tested on staging.

