### PR TITLE
Validate sending Front messages

### DIFF
--- a/app/routes/messages/broadcast.js
+++ b/app/routes/messages/broadcast.js
@@ -5,14 +5,14 @@ const express = require('express');
 const router = express.Router();
 
 // Middleware configs
-const outboundMessageConfig = require('../../../config/lib/middleware/messages/message-outbound');
+const outboundMessageConfig = require('../../../config/lib/middleware/messages/broadcast/message-outbound');
 
 // Middleware
 const paramsMiddleware = require('../../../lib/middleware/messages/broadcast/params');
 const getBroadcastMiddleware = require('../../../lib/middleware/messages/broadcast/broadcast-get');
 const parseBroadcastMiddleware = require('../../../lib/middleware/messages/broadcast/parse-broadcast');
 const getUserMiddleware = require('../../../lib/middleware/messages/user-get');
-const validateUserMiddleware = require('../../../lib/middleware/messages/user-validate');
+const validateOutboundMessageMiddleware = require('../../../lib/middleware/messages/message-outbound-validate');
 const getConvoMiddleware = require('../../../lib/middleware/messages/conversation-get');
 const createConvoMiddleware = require('../../../lib/middleware/messages/conversation-create');
 const updateConvoMiddleware = require('../../../lib/middleware/messages/broadcast/conversation-update');
@@ -23,7 +23,7 @@ router.use(paramsMiddleware());
 router.use(getBroadcastMiddleware());
 router.use(parseBroadcastMiddleware());
 router.use(getUserMiddleware());
-router.use(validateUserMiddleware());
+router.use(validateOutboundMessageMiddleware(outboundMessageConfig));
 
 // Load or create conversation
 router.use(getConvoMiddleware());

--- a/app/routes/messages/front.js
+++ b/app/routes/messages/front.js
@@ -5,20 +5,23 @@ const express = require('express');
 const router = express.Router();
 
 // Middleware configs
-const outboundMessageConfig = require('../../../config/lib/middleware/messages/message-outbound');
+const outboundMessageConfig = require('../../../config/lib/middleware/messages/support/message-outbound');
 
 // Middleware
 const paramsMiddleware = require('../../../lib/middleware/messages/support/params');
 const getConversationMiddleware = require('../../../lib/middleware/messages/conversation-get');
+const getUserMiddleware = require('../../../lib/middleware/messages/user-get');
+const validateOutboundMessageMiddleware = require('../../../lib/middleware/messages/message-outbound-validate');
 const updateConversationMiddleware = require('../../../lib/middleware/messages/support/conversation-update');
-// Note: we're not adding the Load Outbound Message middleware, because Front messages are posted
-// directly to Gambit Conversations, which means we're not retrying any failed requests here.
+// Note: we're not adding Load Outbound Message middleware, because Front messages are posted
+// directly to Gambit Conversations -- no retryCount to check.
 const createOutboundMessageMiddleware = require('../../../lib/middleware/messages/message-outbound-create');
 
 router.use(paramsMiddleware());
 router.use(getConversationMiddleware());
 
-// TODO: Fetch the User for the Conversation, verify they are not unsubscribed.
+router.use(getUserMiddleware());
+router.use(validateOutboundMessageMiddleware(outboundMessageConfig));
 
 router.use(updateConversationMiddleware());
 router.use(createOutboundMessageMiddleware(outboundMessageConfig));

--- a/app/routes/messages/signup.js
+++ b/app/routes/messages/signup.js
@@ -5,12 +5,12 @@ const express = require('express');
 const router = express.Router();
 
 // Middleware configs
-const outboundMessageConfig = require('../../../config/lib/middleware/messages/message-outbound');
+const outboundMessageConfig = require('../../../config/lib/middleware/messages/signup/message-outbound');
 
 // Middleware
 const paramsMiddleware = require('../../../lib/middleware/messages/signup/params');
 const getUserMiddleware = require('../../../lib/middleware/messages/user-get');
-const validateUserMiddleware = require('../../../lib/middleware/messages/user-validate');
+const validateOutboundMessageMiddleware = require('../../../lib/middleware/messages/message-outbound-validate');
 const getConversationMiddleware = require('../../../lib/middleware/messages/conversation-get');
 const createConversationMiddleware = require('../../../lib/middleware/messages/conversation-create');
 const getCampaignMiddleware = require('../../../lib/middleware/messages/signup/campaign-get');
@@ -22,7 +22,7 @@ router.use(paramsMiddleware());
 
 // Fetch Northstar User.
 router.use(getUserMiddleware());
-router.use(validateUserMiddleware());
+router.use(validateOutboundMessageMiddleware(outboundMessageConfig));
 
 // Find or create Conversation.
 router.use(getConversationMiddleware());

--- a/config/lib/middleware/messages/broadcast/message-outbound.js
+++ b/config/lib/middleware/messages/broadcast/message-outbound.js
@@ -1,0 +1,7 @@
+'use strict';
+
+module.exports = {
+  messageDirection: 'outbound-api-send',
+  shouldPostToPlatform: true,
+  shouldSendWhilePaused: false,
+};

--- a/config/lib/middleware/messages/signup/message-outbound.js
+++ b/config/lib/middleware/messages/signup/message-outbound.js
@@ -1,0 +1,7 @@
+'use strict';
+
+module.exports = {
+  messageDirection: 'outbound-api-send',
+  shouldPostToPlatform: true,
+  shouldSendWhilePaused: false,
+};

--- a/config/lib/middleware/messages/support/message-outbound.js
+++ b/config/lib/middleware/messages/support/message-outbound.js
@@ -3,4 +3,5 @@
 module.exports = {
   messageDirection: 'outbound-api-send',
   shouldPostToPlatform: true,
+  shouldSendWhilePaused: true,
 };

--- a/lib/middleware/messages/message-outbound-validate.js
+++ b/lib/middleware/messages/message-outbound-validate.js
@@ -3,22 +3,14 @@
 const helpers = require('../../helpers');
 const UnprocessibleEntityError = require('../../../app/exceptions/UnprocessibleEntityError');
 
-module.exports = function validateUser() {
+module.exports = function validateOutbound(config) {
   return (req, res, next) => {
-    // This check is here because Front messages get routed through here.
-    // TODO: Remove this check once Send Message is split into v2 Front + Campaign Signup messages.
-    // It's safe to leave for Broadcast messages, because we have already checked for northstarId
-    // in our middleware/messages/broadcast/params.
-    if (!req.user) {
-      return next();
-    }
-
     if (!helpers.user.isSubscriber(req.user)) {
       const error = new UnprocessibleEntityError('Northstar User is unsubscribed.');
       return helpers.sendErrorResponseWithSuppressHeaders(res, error);
     }
 
-    if (helpers.user.isPaused(req.user)) {
+    if (config.shouldSendWhenPaused === false && helpers.user.isPaused(req.user)) {
       const error = new UnprocessibleEntityError('Northstar User conversation is paused.');
       return helpers.sendErrorResponseWithSuppressHeaders(res, error);
     }

--- a/lib/middleware/messages/signup/params.js
+++ b/lib/middleware/messages/signup/params.js
@@ -1,11 +1,13 @@
 'use strict';
 
 const helpers = require('../../../helpers');
+const logger = require('../../../logger');
 const UnprocessibleEntityError = require('../../../../app/exceptions/UnprocessibleEntityError');
 
 module.exports = function params() {
   return (req, res, next) => {
     const body = req.body;
+    logger.debug('origin=signup', { body }, req);
     let error;
 
     helpers.request.setCampaignId(req, body.campaignId);
@@ -14,19 +16,14 @@ module.exports = function params() {
       return helpers.sendErrorResponse(res, error);
     }
 
-    if (body.northstarId) {
-      helpers.request.setUserId(req, body.northstarId);
-      req.platform = 'sms';
-      return next();
+    helpers.request.setUserId(req, body.northstarId);
+    if (!req.userId) {
+      error = new UnprocessibleEntityError('Missing required campaignId.');
+      return helpers.sendErrorResponse(res, error);
     }
+    // Only SMS is supported until we're saving other platformUserId's in Northstar (e.g. slack_id)
+    req.platform = 'sms';
 
-    if (body.slackId) {
-      req.platform = 'slack';
-      req.platformUserId = body.slackId;
-      return next();
-    }
-
-    error = new UnprocessibleEntityError('Missing required northstarId or slackId.');
-    return helpers.sendErrorResponse(res, error);
+    return next();
   };
 };

--- a/lib/middleware/messages/user-get.js
+++ b/lib/middleware/messages/user-get.js
@@ -5,15 +5,14 @@ const NotFoundError = require('../../../app/exceptions/NotFoundError');
 
 module.exports = function getNorthstarUser() {
   return (req, res, next) => {
-    // This check is here because Front messages get routed through here.
-    // TODO: Remove this check once Send Message is split into v2 Front + Campaign Signup messages.
-    // It's safe to leave for Broadcast messages, because we have already checked for northstarId
-    // in our middleware/messages/broadcast/params.
-    if (!req.userId) {
-      return next();
+    let promise;
+    if (req.userId) {
+      promise = helpers.user.fetchById(req.userId);
+    } else {
+      promise = req.conversation.getNorthstarUser();
     }
 
-    return helpers.user.fetchById(req.userId)
+    return promise
       .then((user) => {
         req.user = user;
 

--- a/test/lib/middleware/messages/message-outbound-validate.test.js
+++ b/test/lib/middleware/messages/message-outbound-validate.test.js
@@ -28,6 +28,9 @@ const mockUser = userFactory.getValidUser();
 const defaultConfigStub = {
   shouldSendWhenPaused: false,
 };
+const supportConfigStub = {
+  shouldSendWhenPaused: true,
+};
 
 // Setup!
 test.beforeEach((t) => {
@@ -61,7 +64,7 @@ test('validateUser calls sendErrorResponseWithSuppressHeaders if user is not sub
   next.should.not.have.been.called;
 });
 
-test('validateUser calls sendErrorResponseWithSuppressHeaders if user is paused', (t) => {
+test('validateUser sends error if user is paused and config is not shouldSendWhenPaused', (t) => {
   // setup
   const next = sinon.stub();
   const middleware = validateOutbound(defaultConfigStub);
@@ -114,6 +117,21 @@ test('validateUser calls next if user validates', (t) => {
   helpers.user.isSubscriber.should.have.been.called;
   helpers.user.isPaused.should.have.been.called;
   helpers.formatMobileNumber.should.have.been.called;
+  helpers.sendErrorResponseWithSuppressHeaders.should.not.have.been.called;
+  next.should.have.been.called;
+});
+
+test('validateUser calls next if user is paused and config is shouldSendWhenPaused', (t) => {
+  // setup
+  const next = sinon.stub();
+  const middleware = validateOutbound(supportConfigStub);
+  sandbox.stub(helpers.user, 'isSubscriber')
+    .returns(true);
+  sandbox.stub(helpers.user, 'isPaused')
+    .returns(true);
+
+  // test
+  middleware(t.context.req, t.context.res, next);
   helpers.sendErrorResponseWithSuppressHeaders.should.not.have.been.called;
   next.should.have.been.called;
 });

--- a/test/lib/middleware/messages/message-outbound-validate.test.js
+++ b/test/lib/middleware/messages/message-outbound-validate.test.js
@@ -17,7 +17,7 @@ chai.should();
 chai.use(sinonChai);
 
 // module to be tested
-const validateUser = require('../../../../lib/middleware/messages/user-validate');
+const validateOutbound = require('../../../../lib/middleware/messages/message-outbound-validate');
 
 // sinon sandbox object
 const sandbox = sinon.sandbox.create();
@@ -25,6 +25,9 @@ const sandbox = sinon.sandbox.create();
 // stubs
 const sendErrorResponseStub = underscore.noop;
 const mockUser = userFactory.getValidUser();
+const defaultConfigStub = {
+  shouldSendWhenPaused: false,
+};
 
 // Setup!
 test.beforeEach((t) => {
@@ -47,7 +50,7 @@ test.afterEach((t) => {
 test('validateUser calls sendErrorResponseWithSuppressHeaders if user is not subscriber', (t) => {
   // setup
   const next = sinon.stub();
-  const middleware = validateUser();
+  const middleware = validateOutbound(defaultConfigStub);
   sandbox.stub(helpers.user, 'isSubscriber')
     .returns(false);
 
@@ -61,7 +64,7 @@ test('validateUser calls sendErrorResponseWithSuppressHeaders if user is not sub
 test('validateUser calls sendErrorResponseWithSuppressHeaders if user is paused', (t) => {
   // setup
   const next = sinon.stub();
-  const middleware = validateUser();
+  const middleware = validateOutbound(defaultConfigStub);
   sandbox.stub(helpers.user, 'isSubscriber')
     .returns(true);
   sandbox.stub(helpers.user, 'isPaused')
@@ -78,7 +81,7 @@ test('validateUser calls sendErrorResponseWithSuppressHeaders if user is paused'
 test('validateUser calls sendErrorResponseWithSuppressHeaders if formatMobileNumber throws', (t) => {
   // setup
   const next = sinon.stub();
-  const middleware = validateUser();
+  const middleware = validateOutbound(defaultConfigStub);
   sandbox.stub(helpers.user, 'isSubscriber')
     .returns(true);
   sandbox.stub(helpers.user, 'isPaused')
@@ -98,7 +101,7 @@ test('validateUser calls sendErrorResponseWithSuppressHeaders if formatMobileNum
 test('validateUser calls next if user validates', (t) => {
   // setup
   const next = sinon.stub();
-  const middleware = validateUser();
+  const middleware = validateOutbound(defaultConfigStub);
   sandbox.stub(helpers.user, 'isSubscriber')
     .returns(true);
   sandbox.stub(helpers.user, 'isPaused')


### PR DESCRIPTION
#### What's this PR do?

Refactors the `user-validate` middleware as `message-outbound-validate`, and uses it to verify a User's subscription status before sending them a Front message.

 * Adds Message Outbound config `shouldSendWhenPaused` boolean property

 * Tweaks `user-get` to call `helpers.users.fetchUserById` if there's a `req.userId` (like in Signup and Broacast messages), or `req.conversation.getNorthstarUser` (for Front messages)

#### How should this be reviewed?

* Verify Front messages work as expected for subscribers-- you can send a Front message to a paused User,.

* Verify Front receives an error when sending to an unsubcribed User:

   * Send a Q keyword to enter support. After receiving the `supportRequested` template, send a message that will be forwarded to Front.
    * While paused,  send a STOP keyword to unsubscribe status
    * Open your message in Front and try to respond -- Front should indicate that "the webhook has return an error."

#### Any background context you want to provide?
It'd take some effort on the Member message side if we wanted to automatically archive a Front Conversation that should no longer be open if a User has since unsubscribed.

We've been chatting about potentially building support into Gambit Admin to deprecate Front. If we did, we could disable the UI for directly messaging a User if they are unsubscribed. Either way, we'd still want the safety check in validating the request.

#### Relevant tickets
Closes #239 

#### Checklist
- [x] Tests added for new features/bug fixes.
- [x] Tested on staging.
