### PR TITLE
Throw error in helpers.formatMobileNumber for invalid numbers

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -90,7 +90,13 @@ module.exports.addBlinkSuppressHeaders = function addBlinkSuppressHeaders(res) {
 };
 
 module.exports.formatMobileNumber = function formatMobileNumber(mobile, format = 'E164', countryCode = 'US') {
+  logger.debug('formatMobileNumber params', { mobile });
   const phoneUtil = PhoneNumberUtil.getInstance();
   const phoneNumberObject = phoneUtil.parse(mobile, countryCode);
-  return phoneUtil.format(phoneNumberObject, PhoneNumberFormat[format]);
+  if (!phoneUtil.isValidNumber(phoneNumberObject)) {
+    throw Error('Invalid mobile number.');
+  }
+  const result = phoneUtil.format(phoneNumberObject, PhoneNumberFormat[format]);
+  logger.debug('formatMobileNumber return', { result });
+  return result;
 };

--- a/test/lib/middleware/messages/message-outbound-validate.test.js
+++ b/test/lib/middleware/messages/message-outbound-validate.test.js
@@ -152,6 +152,7 @@ test('validateOutbound calls next if user is paused and config is shouldSendWhen
     .returns(true);
   sandbox.stub(helpers.user, 'isPaused')
     .returns(true);
+  t.context.req.platform = 'alexa';
 
   // test
   middleware(t.context.req, t.context.res, next);


### PR DESCRIPTION
#### What's this PR do?
Adds a [google-libphonenumber](https://www.npmjs.com/package/google-libphonenumber) `isValidNumber` call to throw an error if the given mobile number is not valid. 

Doesn't add tests yet for sake of deploying this 

#### How should this be reviewed?
* Post a signup message with your User (who has a valid mobile), verify it's delivered
* Post a signup message for a User with invalid number (5a8c886b10707d0bde51084b), verify a 422 is returned

#### Relevant tickets
Fixes #290 

#### Checklist
- [ ] Tests added for new features/bug fixes.
- [x] Tested on staging.

