### PR TITLE
Template field for Campaign Broadcasts

### DIFF
--- a/config/lib/helpers/broadcast.js
+++ b/config/lib/helpers/broadcast.js
@@ -1,9 +1,11 @@
 'use strict';
 
 module.exports = {
-  defaults: {
-    platform: 'sms',
-    template: 'askSignup',
+  default: {
+    templates: {
+      campaign: 'askSignup',
+      topic: 'rivescript',
+    },
   },
   customerIo: {
     userIdField: '{{customer.id}}',

--- a/config/lib/helpers/broadcast.js
+++ b/config/lib/helpers/broadcast.js
@@ -1,7 +1,10 @@
 'use strict';
 
 module.exports = {
-  defaultPlatform: 'sms',
+  defaults: {
+    platform: 'sms',
+    template: 'askSignup',
+  },
   customerIo: {
     userIdField: '{{customer.id}}',
     userPhoneField: '{{customer.phone}}',

--- a/config/lib/helpers/template.js
+++ b/config/lib/helpers/template.js
@@ -36,6 +36,7 @@ const templatesMap = {
     invalidQuantity: 'invalidQuantity',
     invalidSignupMenuCommand: 'invalidSignupMenuCommand',
     invalidWhyParticipated: 'invalidWhyParticipated',
+    signupMenu: 'signupMenu',
   },
   gambitConversationsTemplates: {
     badWords: {

--- a/documentation/endpoints/broadcasts.md
+++ b/documentation/endpoints/broadcasts.md
@@ -3,29 +3,16 @@
 ```
 GET /api/v1/broadcasts/:broadcastId
 ```
-Returns the settings necessary to setup a Customer.io Triggered Campaign **after** the broadcast is created in Contentful.
+Retrieves a [Broadcast](https://github.com/DoSomething/gambit-admin/wiki/Broadcasts).
 
-## Authentication
-
-The endpoint expects you to use [Basic Auth](../authentication.md). Example url using the browser: `http://protectedName:protectedPass@localhost:5100/api/v1/broadcasts/4kBM6LBfCowMmKKuqwwSUE`
-
-
-## Inputs
-
-Param | Description
---- | ---
-`userPhoneField=<any valid US number>` | Overrides the `To` property with the passed `userPhoneField` in the `webhook.To` settings property.  
 
 ## Examples
-
 
 <details>
 <summary><strong>Example Request</strong></summary>
 
-Get Broadcast with Contentful entry ID: `4kBM6LBfCowMmKKuqwwSUE`.
-
 ```
-curl -X "GET" "http://localhost:5100/api/v1/broadcasts/4kBM6LBfCowMmKKuqwwSUE" \
+curl -X "GET" "http://localhost:5100/api/v1/broadcasts/1S4pnWcZ3qeK0IyU6u4gYE" \
      -H "Authorization: Basic cHVwcGV0OnRvdGFsbHlzZWNyZXQ="
 ```
 </details>
@@ -35,42 +22,35 @@ curl -X "GET" "http://localhost:5100/api/v1/broadcasts/4kBM6LBfCowMmKKuqwwSUE" \
 
 ```
 {
-  "data": {
-    "id": "4kBM6LBfCowMmKKuqwwSUE",
-    "name": "DefendDreamers_Nov9_GroupA",
-    "createdAt": "2017-11-02T16:55:26.123Z",
-    "updatedAt": "2017-11-02T16:55:26.123Z",
-    "campaignId": "7927",
-    "topic": "defenddreamers_nov9",
-    "message": "It's Freddie again! It's inspiring to see thousands of DoSomething members pushing Congress to pass the DREAM Act, before they break for the holidays in mid-December! \n\nWe saw that there's misconceptions about actions you can take. Did you know even if you're under 18 you CAN call your congressperson? \n\nLet's build this movement together, take 2 mins to share this myth busting guide and encourage others to join the movement to protect young people. Click here to share: http://bit.ly/2yor7e7\n\nWant to keep calling? Click here: +1 202-851-9273",
-    "stats": {
-      "inbound": {
-        "total": 320103
-      },
-      "outbound": {
-        "total": 299112
-      }
-    },
-    "webhook": {
-      "url": "http://<secret>:<secret>@blink-staging.dosomething.org/api/v1/webhooks/twilio-sms-broadcast",
-      "headers": {
-        "Content-Type": "application/json"
-      },
-      "body": {
-        "To": "{{customer.phone}}",
-        "Body": "It's Freddie again! It's inspiring to see thousands of DoSomething members pushing Congress to pass the DREAM Act, before they break for the holidays in mid-December! \n\nWe saw that there's misconceptions about actions you can take. Did you know even if you're under 18 you CAN call your congressperson? \n\nLet's build this movement together, take 2 mins to share this myth busting guide and encourage others to join the movement to protect young people. Click here to share: http://bit.ly/2yor7e7\n\nWant to keep calling? Click here: +1 202-851-9273",
-        "StatusCallback": "http://<secret>:<secret>@blink-staging.dosomething.org/api/v1/webhooks/twilio-sms-broadcast?broadcastId=4kBM6LBfCowMmKKuqwwSUE"
-      }
+    "data": {
+        "id": "1S4pnWcZ3qeK0IyU6u4gYE",
+        "name": "Sprint Demo Broadcast",
+        "createdAt": "2018-02-22T21:17:30.874Z",
+        "updatedAt": "2018-02-22T22:32:37.505Z",
+        "message": "Hi {{user.first_name}}!\n\nThis is the demo. Do you accept?",
+        "topic": "survey_response",
+        "campaignId": "2299",
+        "template": "rivescript",
+        "webhook": {
+            "headers": {
+                "Content-Type": "application/json"
+            },
+            "url": "http://<secret>:<secret>@localhost:5050/api/v1/webhooks/customerio-gambit-broadcast",
+            "body": {
+                "northstarId": "{{customer.id}}",
+                "broadcastId": "1S4pnWcZ3qeK0IyU6u4gYE"
+            }
+        },,
+        "stats": {
+            "outbound": {
+                "total": 2
+            },
+            "inbound": {
+                "total": 2,
+                "macros": {}
+            }
+        }
     }
-  }
 }
 ```
 </details>
-
-## Troubleshooting
-
-Error | Meaning
---- | ---
-Cannot GET `/api/v1/broadcasts` | Missing broadcastId in the URL
-Broadcast **X** not found. | broadcastId was not found in Contentful. Is it published?
-Broadcast misconfigured. Message is required! | Broadcast `message` field is empty in Contentful. Is this a pre-TGM/Conversations broadcast? Customer.io broadcasts expect the copy to exist in Contentful.

--- a/documentation/endpoints/messages.md
+++ b/documentation/endpoints/messages.md
@@ -25,6 +25,7 @@ Name | Type | Description
 --- | --- | ---
 `northstarId` | `string` | User Id to send Broadcast message to
 `broadcastId` | `string` | Broadcast Id to send
+`platform` | `string` | Optional, defaults to `'sms'`.
 
 <details>
 <summary><strong>Example Request</strong></summary>

--- a/documentation/endpoints/messages.md
+++ b/documentation/endpoints/messages.md
@@ -256,9 +256,9 @@ curl -X "POST" "http://localhost:5100/api/v2/messages?origin=twilio" \
      -u puppet:totallysecret \
      -d $'{
   "MessageSid": "MM09a8f657567f807443191c1e7exxxxxx",
-  "MediaUrl0": "http://bit.ly/2wkfrep",
+  "MediaUrl0": "http://www.fillmurray.com/g/200/300",
   "From":  "+5555555555",
-  "Body": "uhh",
+  "Body": "hi",
   "MediaContentType0": "image/png"
 }'
 

--- a/lib/contentful.js
+++ b/lib/contentful.js
@@ -166,3 +166,11 @@ module.exports.getTopicFromBroadcast = function (broadcastObject) {
 module.exports.getMessageTextFromBroadcast = function (broadcastObject) {
   return broadcastObject.fields.message;
 };
+
+/**
+ * @param {object} broadcastObject
+ * @return {string}
+ */
+module.exports.getMessageTemplateFromBroadcast = function (broadcastObject) {
+  return broadcastObject.fields.template;
+};

--- a/lib/contentful.js
+++ b/lib/contentful.js
@@ -137,18 +137,10 @@ module.exports.fetchRivescripts = function () {
  */
 module.exports.getCampaignIdFromBroadcast = function (broadcastObject) {
   const campaign = broadcastObject.fields.campaign;
-  if (!campaign.fields) {
-    return null;
+  if (campaign && campaign.fields) {
+    return campaign.fields.campaignId;
   }
-  return campaign.fields.campaignId;
-};
-
-/**
- * @param {object} broadcastObject
- * @return {string}
- */
-module.exports.getPlatformFromBroadcast = function (broadcastObject) {
-  return broadcastObject.fields.platform;
+  return null;
 };
 
 /**

--- a/lib/helpers/analytics.js
+++ b/lib/helpers/analytics.js
@@ -9,6 +9,6 @@ module.exports = {
    */
   addParameters: function addParameters(paramsObject) {
     logger.debug('analytics.addParameters', paramsObject);
-    newrelic.addCustomParameters(paramsObject);
+    newrelic.addCustomAttributes(paramsObject);
   },
 };

--- a/lib/helpers/broadcast.js
+++ b/lib/helpers/broadcast.js
@@ -6,6 +6,8 @@ const Message = require('../../app/models/Message');
 
 const config = require('../../config/lib/helpers/broadcast');
 
+const defaults = config.defaults;
+
 /**
  * getV1WebhookBody
  *
@@ -109,10 +111,15 @@ module.exports = {
       platform: contentful.getPlatformFromBroadcast(broadcastObject) || this.getDefaultPlatform(),
       createdAt: broadcastObject.sys.createdAt,
       updatedAt: broadcastObject.sys.updatedAt,
-      campaignId: contentful.getCampaignIdFromBroadcast(broadcastObject),
-      topic: contentful.getTopicFromBroadcast(broadcastObject),
       message: contentful.getMessageTextFromBroadcast(broadcastObject),
+      topic: contentful.getTopicFromBroadcast(broadcastObject),
+      campaignId: contentful.getCampaignIdFromBroadcast(broadcastObject),
+      template: contentful.getMessageTemplateFromBroadcast(broadcastObject) || defaults.template,
     };
+    if (result.topic) {
+      result.template = 'rivescript';
+    }
+
     return result;
   },
   /**
@@ -147,7 +154,7 @@ module.exports = {
     ]);
   },
   getDefaultPlatform: function getDefaultPlatform() {
-    return config.defaultPlatform;
+    return defaults.platform;
   },
   formatStats,
   parseMessageDirection,

--- a/lib/helpers/broadcast.js
+++ b/lib/helpers/broadcast.js
@@ -6,8 +6,6 @@ const Message = require('../../app/models/Message');
 
 const config = require('../../config/lib/helpers/broadcast');
 
-const defaults = config.defaults;
-
 /**
  * getV1WebhookBody
  *
@@ -105,19 +103,19 @@ module.exports = {
    * @return {object}
    */
   parseBroadcast: function parseBroadcast(broadcastObject) {
+    const templates = config.default.templates;
     const result = {
       id: broadcastObject.sys.id,
       name: broadcastObject.fields.name,
-      platform: contentful.getPlatformFromBroadcast(broadcastObject) || this.getDefaultPlatform(),
       createdAt: broadcastObject.sys.createdAt,
       updatedAt: broadcastObject.sys.updatedAt,
       message: contentful.getMessageTextFromBroadcast(broadcastObject),
       topic: contentful.getTopicFromBroadcast(broadcastObject),
       campaignId: contentful.getCampaignIdFromBroadcast(broadcastObject),
-      template: contentful.getMessageTemplateFromBroadcast(broadcastObject) || defaults.template,
+      template: contentful.getMessageTemplateFromBroadcast(broadcastObject) || templates.campaign,
     };
     if (result.topic) {
-      result.template = 'rivescript';
+      result.template = templates.topic;
     }
 
     return result;
@@ -133,7 +131,7 @@ module.exports = {
       },
     };
 
-    // TODO: Remove this when v2 goes live.
+    // TODO: Remove when we're ready to deprecate v1.
     if (!useApiVersion2) {
       data.url = config.blink.v1WebhookUrl;
       data.body = getV1WebhookBody(req);
@@ -152,9 +150,6 @@ module.exports = {
       { $match: { broadcastId } },
       { $group: { _id: { direction: '$direction', macro: '$macro' }, count: { $sum: 1 } } },
     ]);
-  },
-  getDefaultPlatform: function getDefaultPlatform() {
-    return defaults.platform;
   },
   formatStats,
   parseMessageDirection,

--- a/lib/helpers/request.js
+++ b/lib/helpers/request.js
@@ -39,6 +39,9 @@ module.exports = {
     req.platform = platform;
     analytics.addParameters({ platform });
   },
+  setPlatformToSms: function setPlatformToSms(req) {
+    module.exports.setPlatform(req, 'sms');
+  },
   setUserId: function setUserId(req, userId) {
     req.userId = userId;
     analytics.addParameters({ userId });

--- a/lib/helpers/twilio.js
+++ b/lib/helpers/twilio.js
@@ -4,9 +4,8 @@ const logger = require('heroku-logger');
 const Promise = require('bluebird');
 const request = require('request-promise');
 
-const attachments = require('./attachments');
-
-const platform = 'sms';
+const attachmentsHelper = require('./attachments');
+const requestHelper = require('./request');
 
 /**
  * Twilio helper
@@ -20,7 +19,7 @@ module.exports = {
    * @return {promise}
    */
   parseBody: function parseBody(req) {
-    req.platform = platform;
+    requestHelper.setPlatformToSms(req);
     req.inboundMessageText = req.body.Body;
     req.platformMessageId = req.body.MessageSid;
     req.platformUserId = req.body.From;
@@ -42,7 +41,7 @@ module.exports = {
           .then((url) => {
             req.mediaUrl = url;
             attachmentObject.url = url;
-            attachments.add(req, attachmentObject, 'inbound');
+            attachmentsHelper.add(req, attachmentObject, 'inbound');
             resolve(url);
           })
           .catch(error => reject(error));
@@ -106,7 +105,7 @@ module.exports = {
       addr_state: body.FromState,
       addr_zip: body.FromZip,
       country: body.FromCountry,
-      addr_source: platform,
+      addr_source: req.platform,
     };
 
     return data;

--- a/lib/middleware/broadcasts/index/index.js
+++ b/lib/middleware/broadcasts/index/index.js
@@ -6,5 +6,5 @@ const helpers = require('../../../helpers');
 module.exports = function getBroadcasts() {
   return (req, res) => contentful.fetchBroadcasts()
     .then(apiRes => res.send(apiRes.map(entry => helpers.broadcast.parseBroadcast(entry))))
-    .catch(err => helpers.sendResponseWithError(res, err));
+    .catch(err => helpers.sendErrorResponse(res, err));
 };

--- a/lib/middleware/messages/broadcast/conversation-update.js
+++ b/lib/middleware/messages/broadcast/conversation-update.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const logger = require('../../../logger');
 const helpers = require('../../../helpers');
 const gambitCampaigns = require('../../../gambit-campaigns');
 
@@ -8,21 +7,14 @@ module.exports = function updateConversation() {
   return (req, res, next) => {
     const topic = req.topic;
     if (topic) {
-      req.outboundTemplate = 'rivescript';
       return req.conversation.setTopic(topic).then(() => next());
     }
-    logger.debug('updateConversation()', {
-      topic: req.topic,
-      outboundTemplate: req.outboundTemplate,
-      campaignId: req.campaignId,
-    }, req);
 
+    // TODO: Why are we querying Campaigns here? Seems this isn't needed anymore, if it ever was.
+    // Could potentially return a 422 if the Campaign is closed.
     return gambitCampaigns.getCampaignById(req.campaignId)
       .then(campaign => req.conversation.promptSignupForCampaign(campaign))
-      .then(() => {
-        req.outboundTemplate = 'askSignup';
-        return next();
-      })
+      .then(() => next())
       .catch(err => helpers.sendErrorResponse(res, err));
   };
 };

--- a/lib/middleware/messages/broadcast/params.js
+++ b/lib/middleware/messages/broadcast/params.js
@@ -26,6 +26,8 @@ module.exports = function params() {
       // This is a hack until we start storing userId on a Conversation, same as we're doing in
       // Signup messages. The shared Get Conversation middleware checks for a req.platformUserId.
       req.platformUserId = req.userId;
+    } else {
+      helpers.request.setPlatformToSms(req);
     }
 
     return next();

--- a/lib/middleware/messages/broadcast/parse-broadcast.js
+++ b/lib/middleware/messages/broadcast/parse-broadcast.js
@@ -8,9 +8,6 @@ module.exports = function parseBroadcast() {
       const data = helpers.broadcast.parseBroadcast(req.broadcast);
       req.outboundMessageText = data.message;
       req.outboundTemplate = data.template;
-      if (!req.platform) {
-        helpers.request.setPlatform(req, data.platform);
-      }
 
       if (data.topic) {
         req.topic = data.topic;

--- a/lib/middleware/messages/broadcast/parse-broadcast.js
+++ b/lib/middleware/messages/broadcast/parse-broadcast.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const helpers = require('../../../helpers');
+const UnprocessibleEntityError = require('../../../../app/exceptions/UnprocessibleEntityError');
 
 module.exports = function parseBroadcast() {
   return (req, res, next) => {
@@ -13,6 +14,11 @@ module.exports = function parseBroadcast() {
         req.topic = data.topic;
       } else {
         req.campaignId = data.campaignId;
+      }
+
+      if (!req.campaignId && !req.topic) {
+        const error = new UnprocessibleEntityError('Missing required topic or campaignId.');
+        return helpers.sendErrorResponse(res, error);
       }
 
       return next();

--- a/lib/middleware/messages/broadcast/parse-broadcast.js
+++ b/lib/middleware/messages/broadcast/parse-broadcast.js
@@ -8,12 +8,14 @@ module.exports = function parseBroadcast() {
       const data = helpers.broadcast.parseBroadcast(req.broadcast);
       req.outboundMessageText = data.message;
       req.outboundTemplate = data.template;
-      req.campaignId = data.campaignId;
       if (!req.platform) {
         helpers.request.setPlatform(req, data.platform);
       }
+
       if (data.topic) {
         req.topic = data.topic;
+      } else {
+        req.campaignId = data.campaignId;
       }
 
       return next();

--- a/lib/middleware/messages/broadcast/parse-broadcast.js
+++ b/lib/middleware/messages/broadcast/parse-broadcast.js
@@ -13,7 +13,7 @@ module.exports = function parseBroadcast() {
       if (data.topic) {
         req.topic = data.topic;
       } else {
-        req.campaignId = data.campaignId;
+        helpers.request.setCampaignId(req, data.campaignId);
       }
 
       if (!req.campaignId && !req.topic) {

--- a/lib/middleware/messages/broadcast/parse-broadcast.js
+++ b/lib/middleware/messages/broadcast/parse-broadcast.js
@@ -4,19 +4,16 @@ const helpers = require('../../../helpers');
 
 module.exports = function parseBroadcast() {
   return (req, res, next) => {
-    const broadcast = req.broadcast;
-
     try {
-      const data = helpers.broadcast.parseBroadcast(broadcast);
-      req.topic = data.topic;
-      req.campaignId = data.campaignId;
+      const data = helpers.broadcast.parseBroadcast(req.broadcast);
       req.outboundMessageText = data.message;
-      helpers.analytics.addParameters({
-        broadcastTopic: req.topic,
-        broadcastCampaignId: req.campaignId,
-      });
+      req.outboundTemplate = data.template;
+      req.campaignId = data.campaignId;
       if (!req.platform) {
         helpers.request.setPlatform(req, data.platform);
+      }
+      if (data.topic) {
+        req.topic = data.topic;
       }
 
       return next();

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "heroku-logger": "^0.1.1",
     "mongoose": "^4.10.6",
     "mustache": "^2.3.0",
-    "newrelic": "^2.0.2",
+    "newrelic": "2.8.x",
     "request": "^2.81.0",
     "request-promise": "^4.2.1",
     "rivescript": "^1.17.2",

--- a/test/helpers/factories/broadcast.js
+++ b/test/helpers/factories/broadcast.js
@@ -29,5 +29,13 @@ module.exports.getValidCampaignBroadcast = function getValidCampaignBroadcast(da
 module.exports.getValidTopicBroadcast = function getValidTopicBroadcast(date = Date.now()) {
   const broadcast = module.exports.getValidCampaignBroadcast(date);
   broadcast.fields.topic = stubs.getTopic();
+  broadcast.fields.campaign = null;
   return broadcast;
 };
+
+module.exports.getInvalidBroadcast = function getInvalidBroadcast(date = Date.now()) {
+  const broadcast = module.exports.getValidCampaignBroadcast(date);
+  broadcast.fields.campaign = null;
+  return broadcast;
+};
+

--- a/test/helpers/factories/broadcast.js
+++ b/test/helpers/factories/broadcast.js
@@ -2,7 +2,7 @@
 
 const stubs = require('../stubs');
 
-module.exports.getValidBroadcast = function getValidBroadcast(date = Date.now()) {
+module.exports.getValidCampaignBroadcast = function getValidCampaignBroadcast(date = Date.now()) {
   return {
     sys: {
       id: stubs.getBroadcastId(),
@@ -12,7 +12,7 @@ module.exports.getValidBroadcast = function getValidBroadcast(date = Date.now())
     fields: {
       name: stubs.getBroadcastName(),
       platform: stubs.getPlatform(),
-      topic: stubs.getTopic(),
+      topic: null,
       message: stubs.getBroadcastMessageText(),
       campaign: {
         sys: {
@@ -24,4 +24,10 @@ module.exports.getValidBroadcast = function getValidBroadcast(date = Date.now())
       },
     },
   };
+};
+
+module.exports.getValidTopicBroadcast = function getValidTopicBroadcast(date = Date.now()) {
+  const broadcast = module.exports.getValidCampaignBroadcast(date);
+  broadcast.fields.topic = stubs.getTopic();
+  return broadcast;
 };

--- a/test/lib/lib-helpers/analytics.test.js
+++ b/test/lib/lib-helpers/analytics.test.js
@@ -30,7 +30,7 @@ const sandbox = sinon.sandbox.create();
 // Setup!
 test.beforeEach(() => {
   stubs.stubLogger(sandbox, logger);
-  sandbox.stub(newrelic, 'addCustomParameters')
+  sandbox.stub(newrelic, 'addCustomAttributes')
     .returns(underscore.noop);
 });
 
@@ -40,9 +40,9 @@ test.afterEach(() => {
   sandbox.restore();
 });
 
-test('addParameters should call newrelic.addCustomParameters', () => {
+test('addParameters should call newrelic.addCustomAttributes', () => {
   analyticsHelper.addParameters(mockPayload);
-  newrelic.addCustomParameters.should.have.been.called;
+  newrelic.addCustomAttributes.should.have.been.called;
 });
 
 test('addParameters should call logger.debug', () => {

--- a/test/lib/lib-helpers/broadcast.test.js
+++ b/test/lib/lib-helpers/broadcast.test.js
@@ -182,5 +182,5 @@ test('getWebhook v2 should return an object with body of a POST Broadcast Messag
 });
 
 test('getDefaultPlatform should return string', (t) => {
-  t.deepEqual(broadcastHelper.getDefaultPlatform(), config.defaultPlatform);
+  t.deepEqual(broadcastHelper.getDefaultPlatform(), config.defaults.platform);
 });

--- a/test/lib/lib-helpers/broadcast.test.js
+++ b/test/lib/lib-helpers/broadcast.test.js
@@ -25,7 +25,7 @@ const broadcastHelper = require('../../../lib/helpers/broadcast');
 // stubs
 const broadcastId = stubs.getBroadcastId();
 const date = Date.now();
-const broadcast = broadcastFactory.getValidBroadcast(date);
+const broadcast = broadcastFactory.getValidCampaignBroadcast(date);
 const campaignId = stubs.getCampaignId();
 const platform = stubs.getPlatform();
 const topic = stubs.getTopic();

--- a/test/lib/lib-helpers/broadcast.test.js
+++ b/test/lib/lib-helpers/broadcast.test.js
@@ -27,7 +27,6 @@ const broadcastId = stubs.getBroadcastId();
 const date = Date.now();
 const broadcast = broadcastFactory.getValidCampaignBroadcast(date);
 const campaignId = stubs.getCampaignId();
-const platform = stubs.getPlatform();
 const topic = stubs.getTopic();
 const message = stubs.getBroadcastMessageText();
 const name = stubs.getBroadcastName();
@@ -52,8 +51,6 @@ test.afterEach(() => {
 test('parseBroadcast should return an object', () => {
   sandbox.stub(contentful, 'getCampaignIdFromBroadcast')
     .returns(campaignId);
-  sandbox.stub(contentful, 'getPlatformFromBroadcast')
-    .returns(platform);
   sandbox.stub(broadcastHelper, 'getDefaultPlatform')
     .returns(null);
   sandbox.stub(contentful, 'getTopicFromBroadcast')
@@ -65,9 +62,6 @@ test('parseBroadcast should return an object', () => {
   result.id.should.equal(broadcastId);
   contentful.getCampaignIdFromBroadcast.should.have.been.called;
   result.campaignId.should.equal(campaignId);
-  contentful.getPlatformFromBroadcast.should.have.been.called;
-  broadcastHelper.getDefaultPlatform.should.not.have.been.called;
-  result.platform.should.equal(platform);
   contentful.getTopicFromBroadcast.should.have.been.called;
   result.topic.should.equal(topic);
   contentful.getMessageTextFromBroadcast.should.have.been.called;
@@ -76,35 +70,6 @@ test('parseBroadcast should return an object', () => {
   result.createdAt.should.equal(date);
   result.updatedAt.should.equal(date);
 });
-
-test('parseBroadcast platform should return defaultPlatform if broadcast.platform is not set', () => {
-  sandbox.stub(contentful, 'getCampaignIdFromBroadcast')
-    .returns(campaignId);
-  sandbox.stub(contentful, 'getPlatformFromBroadcast')
-    .returns(null);
-  sandbox.stub(broadcastHelper, 'getDefaultPlatform')
-    .returns(platform);
-  sandbox.stub(contentful, 'getTopicFromBroadcast')
-    .returns(topic);
-  sandbox.stub(contentful, 'getMessageTextFromBroadcast')
-    .returns(message);
-
-  const result = broadcastHelper.parseBroadcast(broadcast);
-  result.id.should.equal(broadcastId);
-  contentful.getCampaignIdFromBroadcast.should.have.been.called;
-  result.campaignId.should.equal(campaignId);
-  contentful.getPlatformFromBroadcast.should.have.been.called;
-  broadcastHelper.getDefaultPlatform.should.have.been.called;
-  result.platform.should.equal(platform);
-  contentful.getTopicFromBroadcast.should.have.been.called;
-  result.topic.should.equal(topic);
-  contentful.getMessageTextFromBroadcast.should.have.been.called;
-  result.message.should.equal(message);
-  result.name.should.equal(name);
-  result.createdAt.should.equal(date);
-  result.updatedAt.should.equal(date);
-});
-
 
 test('aggregateMessagesForBroadcastId should call Messages.aggregate and return array', async () => {
   sandbox.stub(Message, 'aggregate')
@@ -179,8 +144,4 @@ test('getWebhook v2 should return an object with body of a POST Broadcast Messag
   result.body.northstarId.should.equal(config.customerIo.userIdField);
   result.body.broadcastId.should.equal(broadcastId);
   result.should.have.property('url');
-});
-
-test('getDefaultPlatform should return string', (t) => {
-  t.deepEqual(broadcastHelper.getDefaultPlatform(), config.defaults.platform);
 });

--- a/test/lib/lib-helpers/cache.test.js
+++ b/test/lib/lib-helpers/cache.test.js
@@ -20,7 +20,7 @@ const cacheHelper = rewire('../../../lib/helpers/cache');
 
 // stubs
 const broadcastId = stubs.getBroadcastId();
-const broadcast = broadcastFactory.getValidBroadcast();
+const broadcast = broadcastFactory.getValidCampaignBroadcast();
 const broadcastStats = stubs.getBroadcastStats();
 const campaignId = stubs.getCampaignId();
 const campaign = { id: campaignId, title: 'Winter' };

--- a/test/lib/lib-helpers/request.test.js
+++ b/test/lib/lib-helpers/request.test.js
@@ -62,6 +62,12 @@ test('setPlatform should inject a platform property to req', (t) => {
   helpers.analytics.addParameters.should.have.been.calledWith({ platform });
 });
 
+test('setPlatformToSms should call setPlatform', (t) => {
+  sandbox.spy(requestHelper, 'setPlatform');
+  requestHelper.setPlatformToSms(t.context.req);
+  requestHelper.setPlatform.should.have.been.calledWith(t.context.req, 'sms');
+});
+
 test('setUserId should inject a userId property to req', (t) => {
   requestHelper.setUserId(t.context.req, userId);
   t.context.req.userId.should.equal(userId);

--- a/test/lib/lib-helpers/twilio.test.js
+++ b/test/lib/lib-helpers/twilio.test.js
@@ -7,6 +7,7 @@ const sinon = require('sinon');
 const sinonChai = require('sinon-chai');
 const httpMocks = require('node-mocks-http');
 
+const helpers = require('../../../lib/helpers');
 const stubs = require('../../helpers/stubs');
 
 chai.should();
@@ -31,8 +32,10 @@ test.afterEach(() => {
 
 // parseBody
 test('parseBody should inject vars into req', (t) => {
+  sandbox.spy(helpers.request, 'setPlatformToSms');
   sandbox.spy(twilioHelper, 'parseUserAddressFromReq');
   twilioHelper.parseBody(t.context.req);
+  helpers.request.setPlatformToSms.should.have.been.calledWith(t.context.req);
   twilioHelper.parseUserAddressFromReq.should.have.been.called;
   t.context.req.platformUserId.should.equal(mockTwilioRequestBody.From);
   t.context.req.should.have.property('platformUserAddress');

--- a/test/lib/middleware/messages/broadcast/broadcast-get.test.js
+++ b/test/lib/middleware/messages/broadcast/broadcast-get.test.js
@@ -21,7 +21,7 @@ const broadcastFactory = require('../../../../helpers/factories/broadcast');
 const broadcastId = stubs.getBroadcastId();
 const cache = cacheHelper.broadcasts;
 const sendErrorResponseStub = underscore.noop;
-const mockBroadcast = broadcastFactory.getValidBroadcast();
+const mockBroadcast = broadcastFactory.getValidCampaignBroadcast();
 const broadcastLookupStub = () => Promise.resolve(mockBroadcast);
 const broadcastLookupFailStub = () => Promise.reject({ message: 'Epic fail' });
 const broadcastLookupNotFoundStub = () => Promise.reject({ status: 404 });

--- a/test/lib/middleware/messages/broadcast/parse-broadcast.test.js
+++ b/test/lib/middleware/messages/broadcast/parse-broadcast.test.js
@@ -81,3 +81,14 @@ test('parseBroadcast should call sendErrorResponse on error', async (t) => {
   helpers.sendErrorResponse.should.have.been.called;
   next.should.not.have.been.called;
 });
+
+test('parseBroadcast should call sendErrorResponse if campaignId and topic undefined', async (t) => {
+  const next = sinon.stub();
+  const middleware = parseBroadcast();
+  t.context.req.broadcast = broadcastFactory.getInvalidBroadcast();
+
+  // test
+  await middleware(t.context.req, t.context.res, next);
+  helpers.sendErrorResponse.should.have.been.called;
+  next.should.not.have.been.called;
+});

--- a/test/lib/middleware/messages/broadcast/parse-broadcast.test.js
+++ b/test/lib/middleware/messages/broadcast/parse-broadcast.test.js
@@ -47,7 +47,6 @@ test('parseBroadcast should inject vars into the req object for Campaign Broadca
   await middleware(t.context.req, t.context.res, next);
 
   helpers.broadcast.parseBroadcast.should.have.been.called;
-  t.context.req.platform.should.equal(stubs.getPlatform());
   t.context.req.campaignId.should.equal(stubs.getCampaignId());
   t.context.req.should.not.have.property('topic');
   t.context.req.outboundMessageText.should.equal(stubs.getBroadcastMessageText());
@@ -64,7 +63,6 @@ test('parseBroadcast should inject vars into the req object for Topic Broadcasts
   await middleware(t.context.req, t.context.res, next);
 
   helpers.broadcast.parseBroadcast.should.have.been.called;
-  t.context.req.platform.should.equal(stubs.getPlatform());
   t.context.req.topic.should.equal(stubs.getTopic());
   t.context.req.should.not.have.property('campaignId');
   t.context.req.outboundMessageText.should.equal(stubs.getBroadcastMessageText());

--- a/test/lib/middleware/messages/broadcast/parse-broadcast.test.js
+++ b/test/lib/middleware/messages/broadcast/parse-broadcast.test.js
@@ -41,13 +41,15 @@ test('parseBroadcast should inject vars into the req object for Campaign Broadca
   const next = sinon.stub();
   const middleware = parseBroadcast();
   sandbox.spy(helpers.broadcast, 'parseBroadcast');
-  t.context.req.broadcast = broadcastFactory.getValidCampaignBroadcast();
+  sandbox.spy(helpers.request, 'setCampaignId');
+  const broadcast = broadcastFactory.getValidCampaignBroadcast();
+  t.context.req.broadcast = broadcast;
 
   // test
   await middleware(t.context.req, t.context.res, next);
 
-  helpers.broadcast.parseBroadcast.should.have.been.called;
-  t.context.req.campaignId.should.equal(stubs.getCampaignId());
+  helpers.broadcast.parseBroadcast.should.have.been.calledWith(t.context.req.broadcast);
+  helpers.request.setCampaignId.should.have.been.calledWith(t.context.req, stubs.getCampaignId());
   t.context.req.should.not.have.property('topic');
   t.context.req.outboundMessageText.should.equal(stubs.getBroadcastMessageText());
   next.should.have.been.called;

--- a/test/lib/middleware/messages/broadcast/parse-broadcast.test.js
+++ b/test/lib/middleware/messages/broadcast/parse-broadcast.test.js
@@ -10,8 +10,6 @@ const httpMocks = require('node-mocks-http');
 const underscore = require('underscore');
 
 const helpers = require('../../../../../lib/helpers');
-const analyticsHelper = require('../../../../../lib/helpers/analytics');
-const contentful = require('../../../../../lib/contentful');
 const stubs = require('../../../../helpers/stubs');
 const broadcastFactory = require('../../../../helpers/factories/broadcast');
 
@@ -25,54 +23,63 @@ const parseBroadcast = require('../../../../../lib/middleware/messages/broadcast
 // sinon sandbox object
 const sandbox = sinon.sandbox.create();
 
-// Setup!
+
 test.beforeEach((t) => {
-  sandbox.stub(analyticsHelper, 'addParameters')
-    .returns(underscore.noop);
   sandbox.stub(helpers, 'sendErrorResponse')
     .returns(underscore.noop);
-
-  // setup req, res mocks
   t.context.req = httpMocks.createRequest();
-  t.context.req.broadcast = broadcastFactory.getValidBroadcast();
   t.context.res = httpMocks.createResponse();
 });
 
-// Cleanup!
 test.afterEach((t) => {
-  // reset stubs, spies, and mocks
   sandbox.restore();
   t.context = {};
 });
 
-test('parseBroadcast should inject vars into the req object when they exist', async (t) => {
-  // setup
+
+test('parseBroadcast should inject vars into the req object for Campaign Broadcasts', async (t) => {
   const next = sinon.stub();
   const middleware = parseBroadcast();
   sandbox.spy(helpers.broadcast, 'parseBroadcast');
+  t.context.req.broadcast = broadcastFactory.getValidCampaignBroadcast();
 
   // test
   await middleware(t.context.req, t.context.res, next);
-  analyticsHelper.addParameters.should.have.been.called;
+
   helpers.broadcast.parseBroadcast.should.have.been.called;
   t.context.req.platform.should.equal(stubs.getPlatform());
   t.context.req.campaignId.should.equal(stubs.getCampaignId());
+  t.context.req.should.not.have.property('topic');
+  t.context.req.outboundMessageText.should.equal(stubs.getBroadcastMessageText());
+  next.should.have.been.called;
+});
+
+test('parseBroadcast should inject vars into the req object for Topic Broadcasts', async (t) => {
+  const next = sinon.stub();
+  const middleware = parseBroadcast();
+  sandbox.spy(helpers.broadcast, 'parseBroadcast');
+  t.context.req.broadcast = broadcastFactory.getValidTopicBroadcast();
+
+  // test
+  await middleware(t.context.req, t.context.res, next);
+
+  helpers.broadcast.parseBroadcast.should.have.been.called;
+  t.context.req.platform.should.equal(stubs.getPlatform());
   t.context.req.topic.should.equal(stubs.getTopic());
+  t.context.req.should.not.have.property('campaignId');
   t.context.req.outboundMessageText.should.equal(stubs.getBroadcastMessageText());
   next.should.have.been.called;
 });
 
 test('parseBroadcast should call sendErrorResponse on error', async (t) => {
-  // setup
   const next = sinon.stub();
   const middleware = parseBroadcast();
   t.context.req.broadcastId = 'notFound';
-  sandbox.stub(contentful, 'getCampaignIdFromBroadcast')
-    .callsFake(new Error());
+  sandbox.stub(helpers.broadcast, 'parseBroadcast')
+    .throws();
 
   // test
   await middleware(t.context.req, t.context.res, next);
   helpers.sendErrorResponse.should.have.been.called;
-  t.context.req.should.not.have.property('campaignId');
   next.should.not.have.been.called;
 });


### PR DESCRIPTION
#### What's this PR do?

Adds support for a newly added `template` field on the Contentful Broadcast content type.

* Adds a `signupMenu` template to list of Gambit Camaigns templates. The Broadcast template can be set to either `askSignup` or `signupMenu` via the Template field in Contentful.

* Removes setting the Broadcast message's outbound template from the Conversation Update middleware and into the Params middleware

* Removes inspecting the Broadcast `platform` field and hardcodes `sms` as default to keep things simple -- we can worry about multiple platform broadcasts if/when we need to.

#### How should this be reviewed?

Test broadcasts:
* `3OuosgslsAYQ4QGqiU2M4o` - Campaign Ask Signup
* `72mon4jUeQOaokEIkQMaoa` - Campaign Signup Menu
* `2RiEf5fSgUeIKowc0YCOu2` - Rivescript

#### Any background context you want to provide?
TODO's for a future PR:
* If the Broadcast Campaign is closed, return a 422.
* Remove the Broadcast Platform field in Contentful
* Tests for Broadcast Conversation Update 

#### Relevant tickets
Fixes https://www.pivotaltracker.com/story/show/152490063

#### Checklist
- [x] Documentation added for new features/changed endpoints: https://github.com/DoSomething/gambit-admin/wiki/Broadcasts#creating
- [x] Tests added for new features/bug fixes.
- [x] Tested on staging.
