### PR TITLE
Additional unsubscribe triggers

### DIFF
--- a/brain/index.rive
+++ b/brain/index.rive
@@ -81,14 +81,15 @@
   ^ rape|raped|rapes|raping
   ^ is violent|gets violent
   ^ suicidal|suicidial|suicide
-! array messaging = text|txt|texting|txting|talking|talkign|messaging|contacting
+! array messaging = text|texts|txt|texting|txting|talking|talkign|messaging|contacting|sending
 ! array my        = my this
 ! array no        = n no nah nope nay
 ! array photo     = photo photos mms pic pics pix image image img
+! array please    = pls|plz|please|can you|will you
 ! array question  = is there|who|what|when|why|how
 ! array send      = send submit text
 ! array social    = social media|facebook|twitter|instagram|social
-! array unsubscribe = stop|quit|end|unsubscribe|cancel|do not
+! array unsubscribe = sotp|stop|stopp|quit|end|unsubscribe|cancel|do not|remove
 ! array want      = want|am going|am thinking about
 ! array why       = why y how
 ! array yes       = y ya yas yea yeah yep yes yup

--- a/brain/keywords.rive
+++ b/brain/keywords.rive
@@ -27,8 +27,5 @@
 + @unsubscribe
 @ stop
 
-+ @unsubscribe @messaging [to] [me]
-@ stop
-
-+ shut up
++ [*] @unsubscribe [*] @messaging [*]
 @ stop


### PR DESCRIPTION
#### What's this PR do?

Makes Rivescript changes to catch more unsubscribe requests.

* Changes ` @unsubscribe @messaging [to] [me]` to `[*] @unsubscribe [*] @messaging [*]` catch variations like "will you stop texting me" or "stop freaking texting me"

* Moves defining `+ shut up` trigger out of code and into a new ["Additional unsubscribe triggers" entry in Contentful](https://app.contentful.com/spaces/owik07lyerdj/entries/EwL2vgxGvYAS2Ya2CaAMy).

* Adds a `@please` array of substitutions, adds `'sending'` as a `@messaging` array item

#### How should this be reviewed?
Test messages like examples #259 via DM with `@gambit-staging` or Consolebot -- or any variations of examples per Rivescript we're using:

Hardcoded in `/brain/keywords.rive`:
```
+ stop
- subscriptionStatusStop

+ @unsubscribe
@ stop

+ [*] @unsubscribe [*] @messaging [*]
@ stop
```

Current revision of [EwL2vgxGvYAS2Ya2CaAMy](https://app.contentful.com/spaces/owik07lyerdj/entries/EwL2vgxGvYAS2Ya2CaAMy):
```
+ @please @unsubscribe [*]
@ stop

+ leave me alone
@ stop

+ lose [*] (number|phone) [*]
@ stop

+ remove *
@ stop

+ shut up
@ stop

+ suck [*]
@ stop

```

#### Any background context you want to provide?
We'll likely add any additional triggers into the Rivescript entry vs. hardcoding.

There's a possibility the more lenient triggers could be false alarms, e.g. an inbound text of "Will you stop the evil empire?" will result in an unsubscribe -- but I gather we get asked to stop sending messages a little bit more.

#### Relevant tickets
Fixes #259 , https://www.pivotaltracker.com/story/show/154227138

#### Checklist
- [x] Tested on staging.
