### PR TITLE
Conversation.userId [pr]

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,8 +11,11 @@ DS_BLINK_GAMBIT_BROADCAST_WEBHOOK_URL=http://blink:wink@localhost:5050/api/v1/we
 DS_NORTHSTAR_API_KEY=totallysecret
 DS_NORTHSTAR_API_BASEURI=https://northstar-slothbot4eva.dosomething.org/v1
 
-# Only used for development / testing locally
+# Consolebot -- Only used for local development.
+# Posts to local /messages?origin=twilio from this number.
 DS_CONSOLEBOT_USER_MOBILE=12125555555
+# Comment to false to send to Consolebot Mobile from your Twilio From Number
+DS_CONSOLEBOT_SUPPRESS_REPLY=true
 
 TWILIO_ACCOUNT_SID=totallysecret
 TWILIO_AUTH_TOKEN=totallysecret

--- a/.env.example
+++ b/.env.example
@@ -14,7 +14,7 @@ DS_NORTHSTAR_API_BASEURI=https://northstar-slothbot4eva.dosomething.org/v1
 # Consolebot -- Only used for local development.
 # Posts to local /messages?origin=twilio from this number.
 DS_CONSOLEBOT_USER_MOBILE=12125555555
-# Comment to false to send to Consolebot Mobile from your Twilio From Number
+# Set as false to send to Consolebot Mobile from your Twilio From Number
 DS_CONSOLEBOT_SUPPRESS_REPLY=true
 
 TWILIO_ACCOUNT_SID=totallysecret

--- a/app/models/Conversation.js
+++ b/app/models/Conversation.js
@@ -4,7 +4,6 @@ const mongoose = require('mongoose');
 const logger = require('../../lib/logger');
 const Message = require('./Message');
 const helpers = require('../../lib/helpers');
-const twilio = require('../../lib/twilio');
 
 const campaignTopic = 'campaign';
 const defaultTopic = 'random';
@@ -306,14 +305,14 @@ conversationSchema.methods.createAndPostOutboundReplyMessage = function (text, t
     .then(() => {
       if (suppressReply) return Promise.resolve();
 
-      return this.postLastOutboundMessageToPlatform();
+      return this.postLastOutboundMessageToPlatform(req);
     });
 };
 
 /**
  * Posts the Last Outbound Message to Twilio for SMS conversations.
  */
-conversationSchema.methods.postLastOutboundMessageToPlatform = function () {
+conversationSchema.methods.postLastOutboundMessageToPlatform = function (req) {
   const messageText = this.lastOutboundMessage.text;
 
   // This could be blank for noReply templates.
@@ -321,7 +320,7 @@ conversationSchema.methods.postLastOutboundMessageToPlatform = function () {
     return Promise.resolve();
   }
 
-  return twilio.postMessage(this.platformUserId, messageText);
+  return helpers.user.sendTwilioMessage(req.user, messageText);
 };
 
 /**

--- a/app/models/Conversation.js
+++ b/app/models/Conversation.js
@@ -57,16 +57,19 @@ conversationSchema.statics.createForUserIdAndPlatform = function (userId, platfo
  * @return {Promise}
  */
 conversationSchema.statics.getFromReq = function (req) {
-  let query = { userId: req.userId, platform: req.platform };
+  const queryByUserId = { userId: req.userId, platform: req.platform };
 
-  return this.findOneAndPopulateLastOutboundMessage(query, req)
+  return this.findOneAndPopulateLastOutboundMessage(queryByUserId, req)
     .then((conversation) => {
       if (conversation) {
         return Promise.resolve(conversation);
       }
+      if (!helpers.request.isTwilio(req)) {
+        return Promise.resolve(null);
+      }
       // Have we already saved a Conversation for this User by their mobile?
-      query = { platformUserId: req.userMobile };
-      return this.findOneAndPopulateLastOutboundMessage(query, req);
+      const queryByUserMobile = { platformUserId: req.userMobile };
+      return this.findOneAndPopulateLastOutboundMessage(queryByUserMobile, req);
     });
 };
 

--- a/app/models/Conversation.js
+++ b/app/models/Conversation.js
@@ -41,10 +41,11 @@ conversationSchema.index({ userId: 1, platform: 1 });
  * @param {Object} req - Express request
  * @return {Promise}
  */
-conversationSchema.statics.createForUserIdAndPlatform = function (userId, platform) {
+conversationSchema.statics.createFromReq = function (req) {
   const data = {
-    userId,
-    platform,
+    userId: req.userId,
+    platform: req.platform,
+    platformUserId: req.platformUserId,
     paused: false,
     topic: defaultTopic,
   };

--- a/app/models/Conversation.js
+++ b/app/models/Conversation.js
@@ -315,7 +315,7 @@ conversationSchema.methods.createAndSetLastOutboundMessage = function (direction
 conversationSchema.methods.postLastOutboundMessageToPlatform = function (req) {
   const messageText = this.lastOutboundMessage.text;
 
-  if (!(messageText && this.isSms())) {
+  if (!messageText || !this.isSms()) {
     return Promise.resolve();
   }
 

--- a/app/models/Conversation.js
+++ b/app/models/Conversation.js
@@ -325,17 +325,6 @@ conversationSchema.methods.postLastOutboundMessageToPlatform = function () {
 };
 
 /**
- * @return {Promise}
- */
-conversationSchema.methods.getNorthstarUser = function () {
-  if (this.isSms()) {
-    return helpers.user.fetchByMobile(this.platformUserId);
-  }
-
-  return helpers.user.fetchById(this.platformUserId);
-};
-
-/**
  * @return {boolean}
  */
 conversationSchema.methods.isSms = function () {

--- a/app/models/Conversation.js
+++ b/app/models/Conversation.js
@@ -4,7 +4,7 @@ const mongoose = require('mongoose');
 const logger = require('../../lib/logger');
 const Message = require('./Message');
 const helpers = require('../../lib/helpers');
-const twilioClient = require('../../lib/twilio');
+const twilio = require('../../lib/twilio');
 
 const campaignTopic = 'campaign';
 const defaultTopic = 'random';
@@ -313,9 +313,8 @@ conversationSchema.methods.createAndSetLastOutboundMessage = function (direction
  */
 conversationSchema.methods.postLastOutboundMessageToPlatform = function (req) {
   const messageText = this.lastOutboundMessage.text;
-  const shouldPost = messageText && !helpers.request.shouldSuppressOutbound(req);
-  if (shouldPost && this.isSms()) {
-    return twilioClient.postMessage(req.userMobile, messageText);
+  if (messageText && this.isSms()) {
+    return twilio.postMessage(req.userMobile, messageText);
   }
   return Promise.resolve();
 };

--- a/app/models/Conversation.js
+++ b/app/models/Conversation.js
@@ -190,7 +190,6 @@ conversationSchema.methods.getDefaultMessagePayload = function (text, template) 
     campaignId: this.campaignId,
     topic: this.topic,
     userId: this.userId,
-    platformUserId: this.platformUserId,
   };
   if (text) {
     data.text = text;

--- a/app/models/Conversation.js
+++ b/app/models/Conversation.js
@@ -77,7 +77,7 @@ conversationSchema.statics.getFromReq = function (req) {
  * @return {Promise}
  */
 conversationSchema.statics.findOneAndPopulateLastOutboundMessage = function (query, req) {
-  logger.debug('Conversation.findOneAndPopulateLastOutboundMessage', query, req);
+  logger.debug('Conversation.findOne', query, req);
   return this.findOne(query).populate('lastOutboundMessage');
 };
 

--- a/app/models/Conversation.js
+++ b/app/models/Conversation.js
@@ -4,6 +4,7 @@ const mongoose = require('mongoose');
 const logger = require('../../lib/logger');
 const Message = require('./Message');
 const helpers = require('../../lib/helpers');
+const twilio = require('../../lib/twilio');
 
 const campaignTopic = 'campaign';
 const defaultTopic = 'random';
@@ -323,7 +324,7 @@ conversationSchema.methods.postLastOutboundMessageToPlatform = function (req) {
     return Promise.resolve();
   }
 
-  return helpers.user.sendTwilioMessage(req.user, messageText);
+  return twilio.postMessage(req.userMobile, messageText);
 };
 
 /**

--- a/app/models/Message.js
+++ b/app/models/Message.js
@@ -18,7 +18,7 @@ const messageSchema = new mongoose.Schema({
     enum: ['inbound', 'outbound-reply', 'outbound-api-send', 'outbound-api-import'],
     required: true,
   },
-  platformMessageId: { type: String, index: true },
+  userId: { type: String, index: true },
   campaignId: Number,
   template: String,
   text: String,

--- a/app/models/Message.js
+++ b/app/models/Message.js
@@ -19,6 +19,7 @@ const messageSchema = new mongoose.Schema({
     required: true,
   },
   userId: { type: String, index: true },
+  platformUserId: { type: String, index: true },
   campaignId: Number,
   template: String,
   text: String,

--- a/app/models/Message.js
+++ b/app/models/Message.js
@@ -19,7 +19,7 @@ const messageSchema = new mongoose.Schema({
     required: true,
   },
   userId: { type: String, index: true },
-  platformUserId: { type: String, index: true },
+  platformMessageId: { type: String, index: true },
   campaignId: Number,
   template: String,
   text: String,

--- a/app/routes/messages/member.js
+++ b/app/routes/messages/member.js
@@ -29,6 +29,12 @@ const continueCampaignMiddleware = require('../../../lib/middleware/messages/mem
 
 router.use(paramsMiddleware());
 
+// Fetch User for Conversation.
+router.use(getUserMiddleware());
+
+// Creates User if doesn't exist.
+router.use(createUserIfNotFoundMiddleware());
+
 // Load/create conversation.
 router.use(getConversationMiddleware());
 router.use(createConversationMiddleware());
@@ -40,13 +46,8 @@ router.use(getRivescriptReplyMiddleware());
 router.use(loadInboundMessageMiddleware());
 router.use(createInboundMessageMiddleware());
 
-// Fetch User for Conversation.
-router.use(getUserMiddleware());
 // Updates Last Messaged At, Subscription Status, Paused.
 router.use(updateUserMiddleware());
-
-// Creates User if doesn't exist.
-router.use(createUserIfNotFoundMiddleware());
 
 // Sends macro reply if exists.
 router.use(macroReplyMiddleware());

--- a/app/routes/messages/signup.js
+++ b/app/routes/messages/signup.js
@@ -21,6 +21,9 @@ const sendOutboundMessageMiddleware = require('../../../lib/middleware/messages/
 
 router.use(paramsMiddleware());
 
+// Validate Campaign Signup should send a Signup Menu message.
+router.use(getCampaignMiddleware());
+
 // Fetch Northstar User.
 router.use(getUserMiddleware());
 router.use(validateOutboundMessageMiddleware(outboundMessageConfig));
@@ -29,7 +32,6 @@ router.use(validateOutboundMessageMiddleware(outboundMessageConfig));
 router.use(getConversationMiddleware());
 router.use(createConversationMiddleware());
 
-router.use(getCampaignMiddleware());
 router.use(updateConversationMiddleware());
 
 router.use(loadOutboundMessageMiddleware(outboundMessageConfig));

--- a/config/lib/consolebot/index.js
+++ b/config/lib/consolebot/index.js
@@ -24,6 +24,9 @@ const configVars = {
       FromZip: process.env.DS_CONSOLEBOT_USER_ZIP || '07302',
       FromCountry: process.env.DS_CONSOLEBOT_USER_COUNTRY || 'US',
     },
+    headers: {
+      suppressOutbound: process.env.DS_CONSOLEBOT_SUPPRESS_OUTBOUND || 'true',
+    },
   },
 };
 

--- a/config/lib/consolebot/index.js
+++ b/config/lib/consolebot/index.js
@@ -25,7 +25,7 @@ const configVars = {
       FromCountry: process.env.DS_CONSOLEBOT_USER_COUNTRY || 'US',
     },
     headers: {
-      suppressOutbound: process.env.DS_CONSOLEBOT_SUPPRESS_OUTBOUND || 'true',
+      suppressReply: process.env.DS_CONSOLEBOT_SUPPRESS_REPLY || 'true',
     },
   },
 };

--- a/lib/consolebot.js
+++ b/lib/consolebot.js
@@ -11,7 +11,7 @@ const defaultConfig = require('../config/lib/consolebot');
 
 const retryHeader = 'x-blink-retry-count';
 const requestIdHeader = 'x-request-id';
-const suppressSendHeader = 'x-gambit-outbound-reply-suppress';
+const suppressOutboundHeader = 'x-gambit-outbound-suppress';
 
 class Consolebot {
   constructor(config = {}) {
@@ -61,7 +61,7 @@ class Consolebot {
       .post(this.options.request.url)
       .set(retryHeader, payload.headers[retryHeader])
       .set(requestIdHeader, payload.headers[requestIdHeader])
-      .set(suppressSendHeader, 'true')
+      .set(suppressOutboundHeader, this.options.request.headers.suppressOutbound)
       .send(payload)
       .then(res => this.handleSuccess(res))
       .catch(err => this.reply(err.message));

--- a/lib/consolebot.js
+++ b/lib/consolebot.js
@@ -11,7 +11,7 @@ const defaultConfig = require('../config/lib/consolebot');
 
 const retryHeader = 'x-blink-retry-count';
 const requestIdHeader = 'x-request-id';
-const suppressOutboundHeader = 'x-gambit-outbound-suppress';
+const suppressSendHeader = 'x-gambit-outbound-reply-suppress';
 
 class Consolebot {
   constructor(config = {}) {
@@ -61,7 +61,7 @@ class Consolebot {
       .post(this.options.request.url)
       .set(retryHeader, payload.headers[retryHeader])
       .set(requestIdHeader, payload.headers[requestIdHeader])
-      .set(suppressOutboundHeader, this.options.request.headers.suppressOutbound)
+      .set(suppressSendHeader, this.options.request.headers.suppressReply)
       .send(payload)
       .then(res => this.handleSuccess(res))
       .catch(err => this.reply(err.message));

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -95,7 +95,7 @@ module.exports.formatMobileNumber = function formatMobileNumber(mobile, format =
   const phoneUtil = PhoneNumberUtil.getInstance();
   const phoneNumberObject = phoneUtil.parse(mobile, countryCode);
   if (!phoneUtil.isValidNumber(phoneNumberObject)) {
-    const error = new UnprocessibleEntityError('Invalid mobile number');
+    const error = new UnprocessibleEntityError('Cannot format mobile number.');
     throw error;
   }
   const result = phoneUtil.format(phoneNumberObject, PhoneNumberFormat[format]);

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -6,6 +6,7 @@ const { PhoneNumberFormat, PhoneNumberUtil } = require('google-libphonenumber');
 const config = require('../config/lib/helpers');
 const helpers = require('./helpers/index');
 const InternalServerError = require('../app/exceptions/InternalServerError');
+const UnprocessibleEntityError = require('../app/exceptions/UnprocessibleEntityError');
 
 // TODO: Move contents of this helper.js file into lib/helpers/index.js or to modular helpers
 
@@ -94,7 +95,8 @@ module.exports.formatMobileNumber = function formatMobileNumber(mobile, format =
   const phoneUtil = PhoneNumberUtil.getInstance();
   const phoneNumberObject = phoneUtil.parse(mobile, countryCode);
   if (!phoneUtil.isValidNumber(phoneNumberObject)) {
-    throw Error('Invalid mobile number.');
+    const error = new UnprocessibleEntityError('Invalid mobile number');
+    throw error;
   }
   const result = phoneUtil.format(phoneNumberObject, PhoneNumberFormat[format]);
   logger.debug('formatMobileNumber return', { result });

--- a/lib/helpers/replies.js
+++ b/lib/helpers/replies.js
@@ -29,7 +29,13 @@ module.exports.sendReply = function (req, res, messageText, messageTemplate) {
   }
 
   return promise
-    .then(() => req.conversation.postLastOutboundMessageToPlatform(req))
+    .then(() => {
+      if (helpers.request.shouldSuppressOutboundReply(req)) {
+        logger.debug('suppressing reply', {}, req);
+        return Promise.resolve(true);
+      }
+      return req.conversation.postLastOutboundMessageToPlatform(req);
+    })
     .then(() => {
       const data = {
         messages: {

--- a/lib/helpers/replies.js
+++ b/lib/helpers/replies.js
@@ -15,21 +15,23 @@ const Message = require('../../app/models/Message');
  */
 module.exports.sendReply = function (req, res, messageText, messageTemplate) {
   logger.debug('sendReply', { messageTemplate }, req);
+  const direction = 'outbound-reply';
+
   let promise = Promise.resolve();
 
-  // If this is a retry request, we should load the last outbound message if it exists
+  // If this is a retry request, update the last outbound message if it exists.
   if (req.isARetryRequest() && req.conversation.lastOutboundMessage) {
     promise = Message.updateMessageByRequestIdAndDirection(req.metadata.requestId,
-      { metadata: req.metadata }, 'outbound-reply')
-      .then(() => req.conversation.postLastOutboundMessageToPlatform());
+      { metadata: req.metadata }, direction);
   } else {
-    promise = req.conversation.createAndPostOutboundReplyMessage(messageText, messageTemplate, req);
+    promise = req.conversation
+      .createAndSetLastOutboundMessage(direction, messageText, messageTemplate, req);
   }
 
   return promise
+    .then(() => req.conversation.postLastOutboundMessageToPlatform(req))
     .then(() => {
       const data = {
-        // TODO: Include User, Signup, Conversation properties.
         messages: {
           inbound: [req.inboundMessage],
           outbound: [req.conversation.lastOutboundMessage],

--- a/lib/helpers/replies.js
+++ b/lib/helpers/replies.js
@@ -14,7 +14,7 @@ const Message = require('../../app/models/Message');
  * @param {string} messageTemplate
  */
 module.exports.sendReply = function (req, res, messageText, messageTemplate) {
-  logger.debug('sendReply', { messageText, messageTemplate }, req);
+  logger.debug('sendReply', { messageTemplate }, req);
   let promise = Promise.resolve();
 
   // If this is a retry request, we should load the last outbound message if it exists

--- a/lib/helpers/request.js
+++ b/lib/helpers/request.js
@@ -50,7 +50,7 @@ module.exports = {
     req.userId = userId;
     analytics.addCustomAttributes({ userId });
   },
-  shouldSuppressOutbound: function shouldSuppressOutbound(req) {
-    return req.headers['x-gambit-outbound-suppress'] === 'true';
+  shouldSuppressOutboundReply: function shouldSuppressOutboundReply(req) {
+    return req.headers['x-gambit-outbound-reply-suppress'] === 'true';
   },
 };

--- a/lib/helpers/request.js
+++ b/lib/helpers/request.js
@@ -38,7 +38,7 @@ module.exports = {
     analyticsHelper.addCustomAttributes({ platform });
   },
   setPlatformToSms: function setPlatformToSms(req) {
-    module.exports.setPlatform(req, 'sms');
+    this.setPlatform(req, 'sms');
   },
   setUser: function setUser(req, user) {
     req.user = user;
@@ -50,7 +50,7 @@ module.exports = {
     req.userId = userId;
     analyticsHelper.addCustomAttributes({ userId });
   },
-  shouldSuppressOutboundReply: function shouldSuppressOutboundReply(req) {
-    return req.headers['x-gambit-outbound-reply-suppress'] === 'true';
+  shouldSuppressOutbound: function shouldSuppressOutbound(req) {
+    return req.headers['x-gambit-outbound-suppress'] === 'true';
   },
 };

--- a/lib/helpers/request.js
+++ b/lib/helpers/request.js
@@ -29,9 +29,16 @@ module.exports = {
     analytics.addCustomAttributes({ conversationId: conversation.id });
     const lastOutboundMessage = conversation.lastOutboundMessage;
     if (lastOutboundMessage) {
-      req.lastOutboundTemplate = lastOutboundMessage.template;
-      req.lastOutboundBroadcastId = lastOutboundMessage.broadcastId;
+      this.setLastOutboundMessage(req, lastOutboundMessage);
     }
+  },
+  setLastOutboundMessage: function setLastOutboundMessage(req, message) {
+    req.lastOutboundTemplate = message.template;
+    req.lastOutboundBroadcastId = message.broadcastId;
+    analytics.addCustomAttributes({
+      lastOutboundTemplate: req.lastOutboundTemplate,
+      lastOutboundBroadcastId: req.lastOutboundBroadcastId,
+    });
   },
   setPlatform: function setPlatform(req, platform) {
     req.platform = platform;

--- a/lib/helpers/request.js
+++ b/lib/helpers/request.js
@@ -40,12 +40,13 @@ module.exports = {
       lastOutboundBroadcastId: req.lastOutboundBroadcastId,
     });
   },
-  setPlatform: function setPlatform(req, platform) {
+  setPlatform: function setPlatform(req, platformString) {
+    let platform = platformString;
+    if (!platform) {
+      platform = 'sms';
+    }
     req.platform = platform;
     analytics.addCustomAttributes({ platform });
-  },
-  setPlatformToSms: function setPlatformToSms(req) {
-    this.setPlatform(req, 'sms');
   },
   setUser: function setUser(req, user) {
     req.user = user;

--- a/lib/helpers/request.js
+++ b/lib/helpers/request.js
@@ -24,6 +24,15 @@ module.exports = {
     req.campaignId = campaignId;
     analyticsHelper.addCustomAttributes({ campaignId });
   },
+  setConversation: function setConversation(req, conversation) {
+    req.conversation = conversation;
+    analyticsHelper.addCustomAttributes({ conversationId: conversation.id });
+    const lastOutboundMessage = conversation.lastOutboundMessage;
+    if (lastOutboundMessage) {
+      req.lastOutboundTemplate = lastOutboundMessage.template;
+      req.lastOutboundBroadcastId = lastOutboundMessage.broadcastId;
+    }
+  },
   setPlatform: function setPlatform(req, platform) {
     req.platform = platform;
     analyticsHelper.addCustomAttributes({ platform });

--- a/lib/helpers/request.js
+++ b/lib/helpers/request.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const analyticsHelper = require('./analytics');
+const analytics = require('./analytics');
 
 /**
  * Request helper
@@ -18,15 +18,15 @@ module.exports = {
   },
   setBroadcastId: function setBroadcastId(req, broadcastId) {
     req.broadcastId = broadcastId;
-    analyticsHelper.addCustomAttributes({ broadcastId });
+    analytics.addCustomAttributes({ broadcastId });
   },
   setCampaignId: function setCampaignId(req, campaignId) {
     req.campaignId = campaignId;
-    analyticsHelper.addCustomAttributes({ campaignId });
+    analytics.addCustomAttributes({ campaignId });
   },
   setConversation: function setConversation(req, conversation) {
     req.conversation = conversation;
-    analyticsHelper.addCustomAttributes({ conversationId: conversation.id });
+    analytics.addCustomAttributes({ conversationId: conversation.id });
     const lastOutboundMessage = conversation.lastOutboundMessage;
     if (lastOutboundMessage) {
       req.lastOutboundTemplate = lastOutboundMessage.template;
@@ -35,7 +35,7 @@ module.exports = {
   },
   setPlatform: function setPlatform(req, platform) {
     req.platform = platform;
-    analyticsHelper.addCustomAttributes({ platform });
+    analytics.addCustomAttributes({ platform });
   },
   setPlatformToSms: function setPlatformToSms(req) {
     this.setPlatform(req, 'sms');
@@ -48,7 +48,7 @@ module.exports = {
   },
   setUserId: function setUserId(req, userId) {
     req.userId = userId;
-    analyticsHelper.addCustomAttributes({ userId });
+    analytics.addCustomAttributes({ userId });
   },
   shouldSuppressOutbound: function shouldSuppressOutbound(req) {
     return req.headers['x-gambit-outbound-suppress'] === 'true';

--- a/lib/helpers/request.js
+++ b/lib/helpers/request.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const analytics = require('./analytics');
+const analyticsHelper = require('./analytics');
 
 /**
  * Request helper
@@ -18,22 +18,28 @@ module.exports = {
   },
   setBroadcastId: function setBroadcastId(req, broadcastId) {
     req.broadcastId = broadcastId;
-    analytics.addCustomAttributes({ broadcastId });
+    analyticsHelper.addCustomAttributes({ broadcastId });
   },
   setCampaignId: function setCampaignId(req, campaignId) {
     req.campaignId = campaignId;
-    analytics.addCustomAttributes({ campaignId });
+    analyticsHelper.addCustomAttributes({ campaignId });
   },
   setPlatform: function setPlatform(req, platform) {
     req.platform = platform;
-    analytics.addCustomAttributes({ platform });
+    analyticsHelper.addCustomAttributes({ platform });
   },
   setPlatformToSms: function setPlatformToSms(req) {
     module.exports.setPlatform(req, 'sms');
   },
+  setUser: function setUser(req, user) {
+    req.user = user;
+    if (!req.userId) {
+      this.setUserId(req, user.id);
+    }
+  },
   setUserId: function setUserId(req, userId) {
     req.userId = userId;
-    analytics.addCustomAttributes({ userId });
+    analyticsHelper.addCustomAttributes({ userId });
   },
   shouldSuppressOutboundReply: function shouldSuppressOutboundReply(req) {
     return req.headers['x-gambit-outbound-reply-suppress'] === 'true';

--- a/lib/helpers/twilio.js
+++ b/lib/helpers/twilio.js
@@ -19,7 +19,7 @@ module.exports = {
    * @return {promise}
    */
   parseBody: function parseBody(req) {
-    requestHelper.setPlatformToSms(req);
+    requestHelper.setPlatform(req);
     req.inboundMessageText = req.body.Body;
     req.platformMessageId = req.body.MessageSid;
     req.platformUserId = req.body.From;

--- a/lib/helpers/twilio.js
+++ b/lib/helpers/twilio.js
@@ -22,7 +22,7 @@ module.exports = {
     requestHelper.setPlatformToSms(req);
     req.inboundMessageText = req.body.Body;
     req.platformMessageId = req.body.MessageSid;
-    req.userMobile = req.body.From;
+    req.platformUserId = req.body.From;
     req.platformUserAddress = this.parseUserAddressFromReq(req);
     const attachmentObject = this.parseAttachmentFromReq(req);
 

--- a/lib/helpers/twilio.js
+++ b/lib/helpers/twilio.js
@@ -22,7 +22,7 @@ module.exports = {
     requestHelper.setPlatformToSms(req);
     req.inboundMessageText = req.body.Body;
     req.platformMessageId = req.body.MessageSid;
-    req.platformUserId = req.body.From;
+    req.userMobile = req.body.From;
     req.platformUserAddress = this.parseUserAddressFromReq(req);
 
     /**

--- a/lib/helpers/twilio.js
+++ b/lib/helpers/twilio.js
@@ -37,7 +37,7 @@ module.exports = {
           })
           .catch(error => reject(error));
       } else {
-        resolve('attachmentObject does\'t contain a redirectUrl');
+        resolve('attachmentObject doesn\'t contain a redirectUrl');
       }
     });
   },

--- a/lib/helpers/twilio.js
+++ b/lib/helpers/twilio.js
@@ -24,15 +24,6 @@ module.exports = {
     req.platformMessageId = req.body.MessageSid;
     req.userMobile = req.body.From;
     req.platformUserAddress = this.parseUserAddressFromReq(req);
-
-    /**
-     * Inspect baseUrl to check if it's an import request
-     * @see http://expressjs.com/en/api.html#req.baseUrl
-     */
-    if (req.baseUrl.indexOf('import-message') >= 0) {
-      req.platformUserId = req.body.To;
-    }
-
     const attachmentObject = this.parseAttachmentFromReq(req);
 
     return new Promise((resolve, reject) => {

--- a/lib/helpers/user.js
+++ b/lib/helpers/user.js
@@ -50,6 +50,7 @@ module.exports = {
    * @return {object}
    */
   getCreatePayloadFromReq: function getCreatePayloadFromReq(req) {
+    // Currently only support creating new Users via SMS.
     const mobile = req.userMobile;
     const data = {
       source: req.platform,

--- a/lib/helpers/user.js
+++ b/lib/helpers/user.js
@@ -3,9 +3,7 @@
 const crypto = require('crypto');
 const underscore = require('underscore');
 
-const helpers = require('../helpers');
 const northstar = require('../northstar');
-const twilio = require('../twilio');
 const macro = require('./macro');
 const statuses = require('./subscription').statuses;
 const config = require('../../config/lib/helpers/user');
@@ -129,20 +127,5 @@ module.exports = {
 
     // TODO: Confirm if status is undefined, should we consider the User a subscriber? Assuming yes.
     return true;
-  },
-
-  /**
-   * @param {object} user
-   * @param {string} messageText
-   * @return {Promise}
-   */
-  sendTwilioMessage(user, messageText) {
-    let mobileNumber;
-    try {
-      mobileNumber = helpers.formatMobileNumber(user.mobile);
-    } catch (err) {
-      return Promise.reject(err);
-    }
-    return twilio.postMessage(mobileNumber, messageText);
   },
 };

--- a/lib/helpers/user.js
+++ b/lib/helpers/user.js
@@ -48,15 +48,16 @@ module.exports = {
    * @param {object} req
    * @return {object}
    */
-  getDefaultCreatePayloadFromReq: function getDefaultCreatePayloadFromReq(req) {
-    const data = this.getDefaultUpdatePayloadFromReq(req);
+  getCreatePayloadFromReq: function getCreatePayloadFromReq(req) {
+    const mobile = req.userMobile;
+    const data = {
+      source: req.platform,
+      mobile,
+      password: this.generatePassword(mobile),
+      sms_status: statuses.active(),
+      sms_paused: false,
+    };
     underscore.extend(data, req.platformUserAddress);
-    data.source = req.platform;
-    data.mobile = req.userMobile;
-    data.password = this.generatePassword(data.mobile);
-    // TODO: Edge-case where a new user is created from subscriptionStatus macro.
-    data.sms_status = statuses.active();
-
     return data;
   },
 

--- a/lib/helpers/user.js
+++ b/lib/helpers/user.js
@@ -14,6 +14,12 @@ module.exports = {
   fetchByMobile: function fetchByMobile(mobileNumber) {
     return northstar.fetchUserByMobile(mobileNumber);
   },
+  fetchFromReq: function fetchFromReq(req) {
+    if (req.userMobile) {
+      return this.fetchByMobile(req.userMobile);
+    }
+    return this.fetchById(req.userId);
+  },
   /**
    * @param {string} stringToEncrypt
    * @return {string}
@@ -46,7 +52,7 @@ module.exports = {
     const data = this.getDefaultUpdatePayloadFromReq(req);
     underscore.extend(data, req.platformUserAddress);
     data.source = req.platform;
-    data.mobile = req.platformUserId;
+    data.mobile = req.userMobile;
     data.password = this.generatePassword(data.mobile);
     // TODO: Edge-case where a new user is created from subscriptionStatus macro.
     data.sms_status = statuses.active();

--- a/lib/helpers/user.js
+++ b/lib/helpers/user.js
@@ -2,6 +2,8 @@
 
 const crypto = require('crypto');
 const underscore = require('underscore');
+
+const helpers = require('../helpers');
 const northstar = require('../northstar');
 const twilio = require('../twilio');
 const macro = require('./macro');
@@ -135,6 +137,12 @@ module.exports = {
    * @return {Promise}
    */
   sendTwilioMessage(user, messageText) {
-    return twilio.postMessage(user.mobile, messageText);
+    let mobileNumber;
+    try {
+      mobileNumber = helpers.formatMobileNumber(user.mobile);
+    } catch (err) {
+      return Promise.reject(err);
+    }
+    return twilio.postMessage(mobileNumber, messageText);
   },
 };

--- a/lib/helpers/user.js
+++ b/lib/helpers/user.js
@@ -3,6 +3,7 @@
 const crypto = require('crypto');
 const underscore = require('underscore');
 const northstar = require('../northstar');
+const twilio = require('../twilio');
 const macro = require('./macro');
 const statuses = require('./subscription').statuses;
 const config = require('../../config/lib/helpers/user');
@@ -126,5 +127,14 @@ module.exports = {
 
     // TODO: Confirm if status is undefined, should we consider the User a subscriber? Assuming yes.
     return true;
+  },
+
+  /**
+   * @param {object} user
+   * @param {string} messageText
+   * @return {Promise}
+   */
+  sendTwilioMessage(user, messageText) {
+    return twilio.postMessage(user.mobile, messageText);
   },
 };

--- a/lib/helpers/user.js
+++ b/lib/helpers/user.js
@@ -16,8 +16,8 @@ module.exports = {
     return northstar.fetchUserByMobile(mobileNumber);
   },
   fetchFromReq: function fetchFromReq(req) {
-    if (req.userMobile) {
-      return this.fetchByMobile(req.userMobile);
+    if (req.platformUserId) {
+      return this.fetchByMobile(req.platformUserId);
     }
     return this.fetchById(req.userId);
   },
@@ -51,7 +51,7 @@ module.exports = {
    */
   getCreatePayloadFromReq: function getCreatePayloadFromReq(req) {
     // Currently only support creating new Users via SMS.
-    const mobile = req.userMobile;
+    const mobile = req.platformUserId;
     const data = {
       source: req.platform,
       mobile,

--- a/lib/middleware/messages/broadcast/params.js
+++ b/lib/middleware/messages/broadcast/params.js
@@ -23,9 +23,6 @@ module.exports = function params() {
 
     if (body.platform) {
       helpers.request.setPlatform(req, body.platform);
-      // This is a hack until we start storing userId on a Conversation, same as we're doing in
-      // Signup messages. The shared Get Conversation middleware checks for a req.platformUserId.
-      req.platformUserId = req.userId;
     } else {
       helpers.request.setPlatformToSms(req);
     }

--- a/lib/middleware/messages/broadcast/params.js
+++ b/lib/middleware/messages/broadcast/params.js
@@ -21,11 +21,7 @@ module.exports = function params() {
       return helpers.sendErrorResponse(res, error);
     }
 
-    if (body.platform) {
-      helpers.request.setPlatform(req, body.platform);
-    } else {
-      helpers.request.setPlatformToSms(req);
-    }
+    helpers.request.setPlatform(req, body.platform);
 
     return next();
   };

--- a/lib/middleware/messages/conversation-create.js
+++ b/lib/middleware/messages/conversation-create.js
@@ -8,7 +8,7 @@ module.exports = function createConversation() {
     if (req.conversation && req.conversation._id) {
       return next();
     }
-    return Conversation.createForUserIdAndPlatform(req.userId, req.platform)
+    return Conversation.createFromReq(req)
       .then((conversation) => {
         helpers.request.setConversation(req, conversation);
         return next();

--- a/lib/middleware/messages/conversation-create.js
+++ b/lib/middleware/messages/conversation-create.js
@@ -10,15 +10,7 @@ module.exports = function createConversation() {
     }
     return Conversation.createForUserIdAndPlatform(req.userId, req.platform)
       .then((conversation) => {
-        req.conversation = conversation;
-        // TODO: Remove this? Conversations don't have a lastOutboundTemplate property.
-        // This looks like old code.
-        req.lastOutboundTemplate = req.conversation.lastOutboundTemplate;
-
-        helpers.analytics.addCustomAttributes({
-          conversationId: conversation.id,
-        });
-
+        helpers.request.setConversation(req, conversation);
         return next();
       })
       .catch(err => helpers.sendErrorResponse(res, err));

--- a/lib/middleware/messages/conversation-create.js
+++ b/lib/middleware/messages/conversation-create.js
@@ -8,9 +8,11 @@ module.exports = function createConversation() {
     if (req.conversation && req.conversation._id) {
       return next();
     }
-    return Conversation.createFromReq(req)
+    return Conversation.createForUserIdAndPlatform(req.userId, req.platform)
       .then((conversation) => {
         req.conversation = conversation;
+        // TODO: Remove this? Conversations don't have a lastOutboundTemplate property.
+        // This looks like old code.
         req.lastOutboundTemplate = req.conversation.lastOutboundTemplate;
 
         helpers.analytics.addCustomAttributes({

--- a/lib/middleware/messages/conversation-get.js
+++ b/lib/middleware/messages/conversation-get.js
@@ -8,29 +8,10 @@ module.exports = function getConversation() {
   return (req, res, next) => Conversation.getFromReq(req)
     .then((conversation) => {
       if (!conversation) {
-        logger.debug('Conversation not found');
+        logger.debug('Conversation not found.');
         return next();
       }
-
-      req.conversation = conversation;
-
-      const lastOutboundMessage = req.conversation.lastOutboundMessage;
-      if (lastOutboundMessage) {
-        req.lastOutboundTemplate = lastOutboundMessage.template;
-        req.lastOutboundBroadcastId = lastOutboundMessage.broadcastId;
-      }
-
-      const logProperties = {
-        conversationId: conversation.id,
-        lastOutboundBroadcastId: req.lastOutboundBroadcastId ? req.lastOutboundBroadcastId : null,
-        lastOutboundCampaignId: conversation.campaignId ? conversation.campaignId : null,
-        lastOutboundTemplate: req.lastOutboundTemplate ? req.lastOutboundTemplate : null,
-        lastOutboundTopic: conversation.topic,
-      };
-
-      logger.debug('getConversation', logProperties, req);
-      helpers.analytics.addCustomAttributes(logProperties);
-
+      helpers.request.setConversation(req, conversation);
       return next();
     })
     .catch(err => helpers.sendErrorResponse(res, err));

--- a/lib/middleware/messages/conversation-get.js
+++ b/lib/middleware/messages/conversation-get.js
@@ -8,7 +8,7 @@ module.exports = function getConversation() {
   return (req, res, next) => Conversation.getFromReq(req)
     .then((conversation) => {
       if (!conversation) {
-        logger.debug('Conversation not found.');
+        logger.debug('Conversation not found', {}, req);
         return next();
       }
       helpers.request.setConversation(req, conversation);

--- a/lib/middleware/messages/member/params.js
+++ b/lib/middleware/messages/member/params.js
@@ -22,8 +22,8 @@ module.exports = function params() {
 
     helpers.request.setPlatform(req, origin);
     const body = req.body;
-    req.platformUserId = body.northstarId;
-    if (!req.platformUserId) {
+    req.userId = body.northstarId;
+    if (!req.userId) {
       const error = new UnprocessibleEntityError('Missing required northstarId.');
       return helpers.sendErrorResponseWithSuppressHeaders(res, error);
     }

--- a/lib/middleware/messages/member/rivescript-reply-get.js
+++ b/lib/middleware/messages/member/rivescript-reply-get.js
@@ -7,11 +7,11 @@ const rivescript = require('../../../rivescript');
 module.exports = function getRivescriptReply() {
   return (req, res, next) => rivescript.getReply(req.conversation, req.inboundMessageText)
     .then((rivescriptRes) => {
-      logger.debug('rivescript.getReply', rivescriptRes, req);
       const replyText = rivescriptRes.text;
       req.rivescriptReplyText = replyText;
       req.rivescriptMatch = rivescriptRes.match;
       req.rivescriptReplyTopic = rivescriptRes.topic;
+      logger.debug('rivescript.getReply', { match: req.rivescriptMatch }, req);
 
       let isMacro;
       try {

--- a/lib/middleware/messages/member/support-message.js
+++ b/lib/middleware/messages/member/support-message.js
@@ -10,15 +10,12 @@ module.exports = function postMessageToFront() {
       return next();
     }
 
-    // Support messages are only sent to Front for SMS Conversations.
-    // If we ever support multiple platforms, we should create Front conversations by our Gambit
-    // Conversation ID. For now, keeping backwards compatible by storing as mobile.
     if (!req.conversation.isSms()) {
       logger.debug('Support is not available for platform.', { platform: req.platform }, req);
       return helpers.replies.noReply(req, res);
     }
 
-    return front.postMessage(req.userMobile, req.inboundMessage.text)
+    return front.postMessage(req.platformUserId, req.inboundMessage.text)
       .then((frontRes) => {
         logger.trace('front.postMessage response', { body: frontRes.body }, req);
         return helpers.replies.noReply(req, res);

--- a/lib/middleware/messages/member/support-message.js
+++ b/lib/middleware/messages/member/support-message.js
@@ -10,11 +10,23 @@ module.exports = function postMessageToFront() {
       return next();
     }
 
-    return front.postMessage(req.platformUserId, req.inboundMessage.text)
+    // Support messages are only sent to Front for SMS Conversations.
+    // If we ever support multiple platforms, we should create Front conversations by our Gambit
+    // Conversation ID. For now, keeping backwards compatible by storing as mobile.
+    if (!req.conversation.isSms()) {
+      logger.debug('Support is not available for platform.', { platform: req.platform }, req);
+      return helpers.replies.noReply(req, res);
+    }
+
+    return front.postMessage(req.userMobile, req.inboundMessage.text)
       .then((frontRes) => {
-        logger.debug('front.postMessage response', { body: frontRes.body }, req);
+        logger.trace('front.postMessage response', { body: frontRes.body }, req);
         return helpers.replies.noReply(req, res);
       })
-      .catch(err => helpers.sendErrorResponse(res, err));
+      .catch((err) => {
+        logger.error('front.postMessage error', { err }, req);
+
+        return helpers.sendErrorResponse(res, err);
+      });
   };
 };

--- a/lib/middleware/messages/member/user-create.js
+++ b/lib/middleware/messages/member/user-create.js
@@ -22,12 +22,8 @@ module.exports = function createNorthstarUserIfNotFound() {
 
     return northstar.createUser(req.userCreateData)
       .then((user) => {
-        req.user = user;
-        req.userId = user.id;
-        logger.debug('createNorthstarUser', { userId: req.userId }, req);
-        helpers.analytics.addCustomAttributes({
-          userId: req.userId,
-        });
+        logger.debug('createUser', { userId: req.userId }, req);
+        helpers.request.setUser(req, user);
 
         return next();
       })

--- a/lib/middleware/messages/member/user-create.js
+++ b/lib/middleware/messages/member/user-create.js
@@ -10,12 +10,14 @@ module.exports = function createNorthstarUserIfNotFound() {
       return next();
     }
     // SMS is the only platform where we'd potentially be creating a new user if not found.
+    // TODO: Move this check into user-get. If SMS, Ok for 404 because we create new User. If not,
+    // throw error, because we're expecting to have been passed a userId parameter.
     if (!helpers.request.isTwilio(req)) {
       return next();
     }
 
     try {
-      req.userCreateData = helpers.user.getDefaultCreatePayloadFromReq(req);
+      req.userCreateData = helpers.user.getCreatePayloadFromReq(req);
     } catch (error) {
       return helpers.sendErrorResponse(res, error);
     }

--- a/lib/middleware/messages/member/user-get.js
+++ b/lib/middleware/messages/member/user-get.js
@@ -4,14 +4,9 @@ const logger = require('../../../logger');
 const helpers = require('../../../helpers');
 
 module.exports = function getNorthstarUser() {
-  return (req, res, next) => req.conversation.getNorthstarUser()
+  return (req, res, next) => helpers.user.fetchFromReq(req)
     .then((user) => {
-      req.user = user;
-      req.userId = user.id;
-      logger.debug('getNorthstarUser', { userId: req.userId }, req);
-      helpers.analytics.addCustomAttributes({
-        userId: req.userId,
-      });
+      helpers.request.setUser(req, user);
 
       return next();
     })

--- a/lib/middleware/messages/message-outbound-create.js
+++ b/lib/middleware/messages/message-outbound-create.js
@@ -10,7 +10,7 @@ module.exports = function createOutboundMessage(config) {
     }
 
     return req.conversation
-      .createLastOutboundMessage(config.messageDirection, req.outboundMessageText,
+      .createAndSetLastOutboundMessage(config.messageDirection, req.outboundMessageText,
         req.outboundTemplate, req)
       .then(() => {
         req.outboundMessage = req.conversation.lastOutboundMessage;

--- a/lib/middleware/messages/message-outbound-send.js
+++ b/lib/middleware/messages/message-outbound-send.js
@@ -16,15 +16,7 @@ module.exports = function sendOutboundMessage() {
     }
 
     return req.conversation.postLastOutboundMessageToPlatform(req)
-      .then((platformRes) => {
-        if (platformRes) {
-          // TODO: Save sid to the outboundMessage.platformMessageId.
-          const sid = platformRes.sid;
-          const status = platformRes.status;
-          logger.debug('sendOutboundMessage', { sid, status }, req);
-        }
-        return helpers.sendResponseWithMessage(res, req.outboundMessage);
-      })
+      .then(() => helpers.sendResponseWithMessage(res, req.outboundMessage))
       .catch((err) => {
         if (helpers.twilio.isBadRequestError(err)) {
           helpers.analytics.addTwilioError(err);

--- a/lib/middleware/messages/message-outbound-send.js
+++ b/lib/middleware/messages/message-outbound-send.js
@@ -10,7 +10,7 @@ module.exports = function sendOutboundMessage() {
     }
 
     try {
-      req.userMobile = helpers.formatMobileNumber(req.user.mobile);
+      req.platformUserId = helpers.formatMobileNumber(req.user.mobile);
     } catch (err) {
       return helpers.sendErrorResponseWithSuppressHeaders(res, err);
     }

--- a/lib/middleware/messages/message-outbound-send.js
+++ b/lib/middleware/messages/message-outbound-send.js
@@ -2,6 +2,7 @@
 
 const helpers = require('../../helpers');
 const logger = require('../../logger');
+const UnprocessibleEntityError = require('../../../app/exceptions/UnprocessibleEntityError');
 
 module.exports = function sendOutboundMessage() {
   return (req, res) => {
@@ -18,6 +19,10 @@ module.exports = function sendOutboundMessage() {
         return helpers.sendResponseWithMessage(res, req.outboundMessage);
       })
       .catch((err) => {
+        if (err instanceof UnprocessibleEntityError) {
+          logger.debug('UnprocessibleEntityError');
+          return helpers.sendErrorResponseWithSuppressHeaders(res, err);
+        }
         if (helpers.twilio.isBadRequestError(err)) {
           helpers.analytics.addTwilioError(err);
           logger.error('sendOutboundMessage', { err }, req);

--- a/lib/middleware/messages/message-outbound-send.js
+++ b/lib/middleware/messages/message-outbound-send.js
@@ -2,7 +2,7 @@
 
 const helpers = require('../../helpers');
 const logger = require('../../logger');
-const UnprocessibleEntityError = require('../../../app/exceptions/UnprocessibleEntityError');
+const twilio = require('../../twilio');
 
 module.exports = function sendOutboundMessage() {
   return (req, res) => {
@@ -10,7 +10,14 @@ module.exports = function sendOutboundMessage() {
       return helpers.sendResponseWithMessage(res, req.outboundMessage);
     }
 
-    return helpers.user.sendTwilioMessage(req.user, req.outboundMessage.text)
+    let userMobile;
+    try {
+      userMobile = helpers.formatMobileNumber(req.user.mobile);
+    } catch (err) {
+      return helpers.sendErrorResponseWithSuppressHeaders(res, err);
+    }
+
+    return twilio.postMessage(userMobile, req.outboundMessage.text)
       .then((twilioRes) => {
         // TODO: Save sid to the outboundMessage.platformMessageId.
         const sid = twilioRes.sid;
@@ -19,10 +26,6 @@ module.exports = function sendOutboundMessage() {
         return helpers.sendResponseWithMessage(res, req.outboundMessage);
       })
       .catch((err) => {
-        if (err instanceof UnprocessibleEntityError) {
-          logger.debug('UnprocessibleEntityError');
-          return helpers.sendErrorResponseWithSuppressHeaders(res, err);
-        }
         if (helpers.twilio.isBadRequestError(err)) {
           helpers.analytics.addTwilioError(err);
           logger.error('sendOutboundMessage', { err }, req);

--- a/lib/middleware/messages/message-outbound-send.js
+++ b/lib/middleware/messages/message-outbound-send.js
@@ -4,26 +4,14 @@ const helpers = require('../../helpers');
 const logger = require('../../logger');
 
 module.exports = function sendOutboundMessage() {
-  return (req, res) => {
-    if (!req.conversation.isSms()) {
-      return helpers.sendResponseWithMessage(res, req.outboundMessage);
-    }
-
-    try {
-      req.platformUserId = helpers.formatMobileNumber(req.user.mobile);
-    } catch (err) {
-      return helpers.sendErrorResponseWithSuppressHeaders(res, err);
-    }
-
-    return req.conversation.postLastOutboundMessageToPlatform(req)
-      .then(() => helpers.sendResponseWithMessage(res, req.outboundMessage))
-      .catch((err) => {
-        if (helpers.twilio.isBadRequestError(err)) {
-          helpers.analytics.addTwilioError(err);
-          logger.error('sendOutboundMessage', { err }, req);
-          return helpers.sendErrorResponseWithSuppressHeaders(res, err);
-        }
-        return helpers.sendErrorResponse(res, err);
-      });
-  };
+  return (req, res) => req.conversation.postLastOutboundMessageToPlatform(req)
+    .then(() => helpers.sendResponseWithMessage(res, req.outboundMessage))
+    .catch((err) => {
+      if (helpers.twilio.isBadRequestError(err)) {
+        helpers.analytics.addTwilioError(err);
+        logger.error('sendOutboundMessage', { err }, req);
+        return helpers.sendErrorResponseWithSuppressHeaders(res, err);
+      }
+      return helpers.sendErrorResponse(res, err);
+    });
 };

--- a/lib/middleware/messages/message-outbound-send.js
+++ b/lib/middleware/messages/message-outbound-send.js
@@ -2,7 +2,6 @@
 
 const helpers = require('../../helpers');
 const logger = require('../../logger');
-const twilio = require('../../twilio');
 
 module.exports = function sendOutboundMessage() {
   return (req, res) => {
@@ -10,19 +9,20 @@ module.exports = function sendOutboundMessage() {
       return helpers.sendResponseWithMessage(res, req.outboundMessage);
     }
 
-    let userMobile;
     try {
-      userMobile = helpers.formatMobileNumber(req.user.mobile);
+      req.userMobile = helpers.formatMobileNumber(req.user.mobile);
     } catch (err) {
       return helpers.sendErrorResponseWithSuppressHeaders(res, err);
     }
 
-    return twilio.postMessage(userMobile, req.outboundMessage.text)
-      .then((twilioRes) => {
-        // TODO: Save sid to the outboundMessage.platformMessageId.
-        const sid = twilioRes.sid;
-        const status = twilioRes.status;
-        logger.debug('sendOutboundMessage', { sid, status }, req);
+    return req.conversation.postLastOutboundMessageToPlatform(req)
+      .then((platformRes) => {
+        if (platformRes) {
+          // TODO: Save sid to the outboundMessage.platformMessageId.
+          const sid = platformRes.sid;
+          const status = platformRes.status;
+          logger.debug('sendOutboundMessage', { sid, status }, req);
+        }
         return helpers.sendResponseWithMessage(res, req.outboundMessage);
       })
       .catch((err) => {

--- a/lib/middleware/messages/message-outbound-send.js
+++ b/lib/middleware/messages/message-outbound-send.js
@@ -9,7 +9,7 @@ module.exports = function sendOutboundMessage() {
       return helpers.sendResponseWithMessage(res, req.outboundMessage);
     }
 
-    return req.conversation.postLastOutboundMessageToPlatform()
+    return helpers.user.sendTwilioMessage(req.user, req.outboundMessage.text)
       .then((twilioRes) => {
         // TODO: Save sid to the outboundMessage.platformMessageId.
         const sid = twilioRes.sid;

--- a/lib/middleware/messages/message-outbound-validate.js
+++ b/lib/middleware/messages/message-outbound-validate.js
@@ -15,20 +15,6 @@ module.exports = function validateOutbound(config) {
       return helpers.sendErrorResponseWithSuppressHeaders(res, error);
     }
 
-    if (req.platform !== 'sms') {
-      return next();
-    }
-
-    try {
-      /**
-       * Sanity check E.164 format.
-       */
-      req.platformUserId = helpers.formatMobileNumber(req.user.mobile);
-    } catch (err) {
-      const error = new UnprocessibleEntityError('Cannot format Northstar User mobile.');
-      return helpers.sendErrorResponseWithSuppressHeaders(res, error);
-    }
-
     return next();
   };
 };

--- a/lib/middleware/messages/message-outbound-validate.js
+++ b/lib/middleware/messages/message-outbound-validate.js
@@ -15,6 +15,19 @@ module.exports = function validateOutbound(config) {
       return helpers.sendErrorResponseWithSuppressHeaders(res, error);
     }
 
+    if (req.platform !== 'sms') {
+      return next();
+    }
+
+    try {
+      /**
+       * Sanity check E.164 format.
+       */
+      req.platformUserId = helpers.formatMobileNumber(req.user.mobile);
+    } catch (err) {
+      return helpers.sendErrorResponseWithSuppressHeaders(res, err);
+    }
+
     return next();
   };
 };

--- a/lib/middleware/messages/signup/params.js
+++ b/lib/middleware/messages/signup/params.js
@@ -22,10 +22,9 @@ module.exports = function params() {
       return helpers.sendErrorResponse(res, error);
     }
 
+    // TODO: DRY with Broadcast Message params
     if (body.platform) {
       helpers.request.setPlatform(req, body.platform);
-      // This is a hack until we end up just using a userId instead of a platformUserId.
-      req.platformUserId = req.userId;
     } else {
       helpers.request.setPlatform(req, 'sms');
     }

--- a/lib/middleware/messages/signup/params.js
+++ b/lib/middleware/messages/signup/params.js
@@ -22,12 +22,7 @@ module.exports = function params() {
       return helpers.sendErrorResponse(res, error);
     }
 
-    // TODO: DRY with Broadcast Message params
-    if (body.platform) {
-      helpers.request.setPlatform(req, body.platform);
-    } else {
-      helpers.request.setPlatform(req, 'sms');
-    }
+    helpers.request.setPlatform(req, body.platform);
 
     return next();
   };

--- a/lib/middleware/messages/support/params.js
+++ b/lib/middleware/messages/support/params.js
@@ -22,7 +22,7 @@ module.exports = function supportParams() {
     const toRecipient = recipients.find(recipient => recipient.role === 'to');
     // Support messages are only sent into Front via SMS.
     // @see lib/middleware/messages/member/support-message
-    req.userMobile = toRecipient.handle;
+    req.platformUserId = toRecipient.handle;
     req.platformMessageId = body.id;
     req.outboundTemplate = 'support';
     req.frontConversationUrl = body._links.related.conversation;

--- a/lib/middleware/messages/support/params.js
+++ b/lib/middleware/messages/support/params.js
@@ -20,8 +20,6 @@ module.exports = function supportParams() {
     const fromRecipient = recipients.find(recipient => recipient.role === 'from');
     req.agentId = fromRecipient.handle;
     const toRecipient = recipients.find(recipient => recipient.role === 'to');
-    // Support messages are only sent into Front via SMS.
-    // @see lib/middleware/messages/member/support-message
     req.platformUserId = toRecipient.handle;
     req.platformMessageId = body.id;
     req.outboundTemplate = 'support';

--- a/lib/middleware/messages/support/params.js
+++ b/lib/middleware/messages/support/params.js
@@ -20,7 +20,9 @@ module.exports = function supportParams() {
     const fromRecipient = recipients.find(recipient => recipient.role === 'from');
     req.agentId = fromRecipient.handle;
     const toRecipient = recipients.find(recipient => recipient.role === 'to');
-    req.platformUserId = toRecipient.handle;
+    // Support messages are only sent into Front via SMS.
+    // @see lib/middleware/messages/member/support-message
+    req.userMobile = toRecipient.handle;
     req.platformMessageId = body.id;
     req.outboundTemplate = 'support';
     req.frontConversationUrl = body._links.related.conversation;

--- a/lib/rivescript.js
+++ b/lib/rivescript.js
@@ -70,7 +70,6 @@ module.exports.getReply = function (conversation, inboundMessageText) {
       const updatedUservars = bot.getUservars(conversationId);
       res.topic = updatedUservars.topic;
       res.match = updatedUservars.__initialmatch__; // eslint-disable-line no-underscore-dangle
-      logger.trace('rivescript.getReply response', res);
 
       return res;
     })

--- a/lib/twilio.js
+++ b/lib/twilio.js
@@ -65,6 +65,7 @@ module.exports.getMessagePayload = function (phone, messageText) {
  * @return {Promise}
  */
 module.exports.postMessage = function (phone, messageText) {
+  logger.debug('twilio.postMessage', { phone });
   const data = exports.getMessagePayload(phone, messageText);
 
   return exports.getClient().messages.create(data);

--- a/lib/twilio.js
+++ b/lib/twilio.js
@@ -65,7 +65,6 @@ module.exports.getMessagePayload = function (phone, messageText) {
  * @return {Promise}
  */
 module.exports.postMessage = function (phone, messageText) {
-  logger.debug('twilio.postMessage', { phone });
   const data = exports.getMessagePayload(phone, messageText);
 
   return exports.getClient().messages.create(data);

--- a/test/app/models/conversation.test.js
+++ b/test/app/models/conversation.test.js
@@ -11,7 +11,7 @@ const underscore = require('underscore');
 
 const Message = require('../../../app/models/Message');
 const helpers = require('../../../lib/helpers');
-const twilioClient = require('../../../lib/twilio');
+const twilio = require('../../../lib/twilio');
 const stubs = require('../../helpers/stubs');
 const conversationFactory = require('../../helpers/factories/conversation');
 const userFactory = require('../../helpers/factories/user');
@@ -70,15 +70,34 @@ test('createMessage should not call helpers.tag.render if direction is inbound',
   Message.create.should.have.been.called;
 });
 
+// postLastOutboundMessageToPlatform
 test('postLastOutboundMessageToPlatform returns resolved Promise if outbound text undefined', async (t) => {
-  sandbox.stub(twilioClient, 'postMessage')
+  sandbox.stub(twilio, 'postMessage')
     .returns(resolvedPromise);
   const supportConversation = conversationFactory.getValidConversation();
   supportConversation.lastOutboundMessage.text = '';
   t.context.req.conversation = supportConversation;
 
   await supportConversation.postLastOutboundMessageToPlatform(t.context.req);
-  twilioClient.postMessage.should.not.have.been.called;
+  twilio.postMessage.should.not.have.been.called;
+});
+
+test('postLastOutboundMessageToPlatform returns resolved Promise if conversation is not SMS', async (t) => {
+  sandbox.stub(twilio, 'postMessage')
+    .returns(resolvedPromise);
+  t.context.req.conversation = alexaConversation;
+
+  await alexaConversation.postLastOutboundMessageToPlatform(t.context.req);
+  twilio.postMessage.should.not.have.been.called;
+});
+
+test('postLastOutboundMessageToPlatform returns twilio.postMessage if conversation is SMS', async (t) => {
+  sandbox.stub(twilio, 'postMessage')
+    .returns(resolvedPromise);
+  t.context.req.conversation = conversation;
+
+  await conversation.postLastOutboundMessageToPlatform(t.context.req);
+  twilio.postMessage.should.have.been.called;
 });
 
 // isSms

--- a/test/app/models/conversation.test.js
+++ b/test/app/models/conversation.test.js
@@ -71,7 +71,7 @@ test('createMessage should not call helpers.tag.render if direction is inbound',
 });
 
 // postLastOutboundMessageToPlatform
-test('postLastOutboundMessageToPlatform returns resolved Promise if outbound text undefined', async (t) => {
+test('postLastOutboundMessageToPlatform does not call twilio.postMessage if text undefined', async (t) => {
   sandbox.stub(twilio, 'postMessage')
     .returns(resolvedPromise);
   const supportConversation = conversationFactory.getValidConversation();
@@ -82,7 +82,7 @@ test('postLastOutboundMessageToPlatform returns resolved Promise if outbound tex
   twilio.postMessage.should.not.have.been.called;
 });
 
-test('postLastOutboundMessageToPlatform returns resolved Promise if conversation is not SMS', async (t) => {
+test('postLastOutboundMessageToPlatform does not call twilio.postMessage if conversation is not SMS', async (t) => {
   sandbox.stub(twilio, 'postMessage')
     .returns(resolvedPromise);
   t.context.req.conversation = alexaConversation;
@@ -91,7 +91,7 @@ test('postLastOutboundMessageToPlatform returns resolved Promise if conversation
   twilio.postMessage.should.not.have.been.called;
 });
 
-test('postLastOutboundMessageToPlatform returns twilio.postMessage if conversation is SMS', async (t) => {
+test('postLastOutboundMessageToPlatform calls twilio.postMessage if conversation is SMS', async (t) => {
   sandbox.stub(twilio, 'postMessage')
     .returns(resolvedPromise);
   t.context.req.conversation = conversation;

--- a/test/app/models/conversation.test.js
+++ b/test/app/models/conversation.test.js
@@ -11,6 +11,7 @@ const underscore = require('underscore');
 
 const Message = require('../../../app/models/Message');
 const helpers = require('../../../lib/helpers');
+const twilioClient = require('../../../lib/twilio');
 const stubs = require('../../helpers/stubs');
 const conversationFactory = require('../../helpers/factories/conversation');
 const userFactory = require('../../helpers/factories/user');
@@ -20,6 +21,7 @@ const conversation = conversationFactory.getValidConversation();
 const alexaConversation = conversationFactory.getValidConversation('alexa');
 const mockMessageText = stubs.getRandomMessageText();
 const mockUser = userFactory.getValidUser();
+const resolvedPromise = Promise.resolve({});
 
 // setup "x.should.y" assertion style
 chai.should();
@@ -66,6 +68,17 @@ test('createMessage should not call helpers.tag.render if direction is inbound',
   await conversation.createMessage('inbound', mockMessageText, 'temp', t.context.req);
   tagsHelper.render.should.not.have.been.called;
   Message.create.should.have.been.called;
+});
+
+test('postLastOutboundMessageToPlatform returns resolved Promise if outbound text undefined', async (t) => {
+  sandbox.stub(twilioClient, 'postMessage')
+    .returns(resolvedPromise);
+  const supportConversation = conversationFactory.getValidConversation();
+  supportConversation.lastOutboundMessage.text = '';
+  t.context.req.conversation = supportConversation;
+
+  await supportConversation.postLastOutboundMessageToPlatform(t.context.req);
+  twilioClient.postMessage.should.not.have.been.called;
 });
 
 // isSms

--- a/test/app/models/conversation.test.js
+++ b/test/app/models/conversation.test.js
@@ -68,19 +68,6 @@ test('createMessage should not call helpers.tag.render if direction is inbound',
   Message.create.should.have.been.called;
 });
 
-// getNorthstarUser
-test('getNorthstarUser should return northstar.fetchUserByMobile for SMS', async () => {
-  const result = await conversation.getNorthstarUser();
-  helpers.user.fetchByMobile.should.have.been.called;
-  result.should.equal(mockUser);
-});
-
-test('getNorthstarUser should return northstar.fetchById for non SMS', async () => {
-  const result = await alexaConversation.getNorthstarUser();
-  helpers.user.fetchById.should.have.been.called;
-  result.should.equal(mockUser);
-});
-
 // isSms
 test('isSms should return boolean', (t) => {
   let result = conversation.isSms();

--- a/test/helpers/factories/conversation.js
+++ b/test/helpers/factories/conversation.js
@@ -15,6 +15,7 @@ module.exports.getValidConversation = function getValidConversation(platformStri
     id,
     _id: id,
     platform,
+    userId: stubs.getUserId(),
     platformUserId: stubs.getMobileNumber(),
     topic: stubs.getTopic(),
     paused: false,

--- a/test/helpers/factories/conversation.js
+++ b/test/helpers/factories/conversation.js
@@ -2,6 +2,7 @@
 
 const ObjectID = require('mongoose').Types.ObjectId;
 const Conversation = require('../../../app/models/Conversation');
+const messageFactory = require('./message');
 const stubs = require('../stubs');
 
 module.exports.getValidConversation = function getValidConversation(platformString) {
@@ -21,5 +22,6 @@ module.exports.getValidConversation = function getValidConversation(platformStri
     paused: false,
     createdAt: date,
     updatedAt: date,
+    lastOutboundMessage: messageFactory.getValidMessage(),
   });
 };

--- a/test/helpers/factories/message.js
+++ b/test/helpers/factories/message.js
@@ -13,6 +13,7 @@ module.exports.getValidMessage = function getValidMessage(direction) {
     updatedAt: date,
     text: stubs.getRandomMessageText(),
     direction: direction || 'inbound',
+    template: stubs.getTemplate(),
   });
 };
 

--- a/test/helpers/factories/message.js
+++ b/test/helpers/factories/message.js
@@ -14,6 +14,7 @@ module.exports.getValidMessage = function getValidMessage(direction) {
     text: stubs.getRandomMessageText(),
     direction: direction || 'inbound',
     template: stubs.getTemplate(),
+    broadcastId: stubs.getBroadcastId(),
   });
 };
 

--- a/test/lib/lib-helpers/replies.test.js
+++ b/test/lib/lib-helpers/replies.test.js
@@ -97,7 +97,9 @@ test('sendReply(): responds with the inbound and outbound messages', async (t) =
     inboundMessage,
     outboundMessage,
   });
-  sandbox.stub(req.conversation, 'createAndPostOutboundReplyMessage')
+  sandbox.stub(req.conversation, 'createAndSetLastOutboundMessage')
+    .returns(resolvedPromise);
+  sandbox.stub(req.conversation, 'postLastOutboundMessageToPlatform')
     .returns(resolvedPromise);
   sandbox.spy(t.context.res, 'send');
 
@@ -107,7 +109,8 @@ test('sendReply(): responds with the inbound and outbound messages', async (t) =
 
   // asserts
   t.context.res.send.should.have.been.called;
-  req.conversation.createAndPostOutboundReplyMessage.should.have.been.called;
+  req.conversation.createAndSetLastOutboundMessage.should.have.been.called;
+  req.conversation.postLastOutboundMessageToPlatform.should.have.been.called;
   responseMessages.inbound[0].should.be.equal(inboundMessage);
   responseMessages.outbound[0].should.be.equal(outboundMessage);
 });
@@ -142,7 +145,7 @@ test('sendReply(): should create and post the outbound message if there is no la
     .returns(resolvedPromise);
   sandbox.stub(Message, 'updateMessageByRequestIdAndDirection')
     .returns(resolvedPromise);
-  sandbox.stub(req.conversation, 'createAndPostOutboundReplyMessage')
+  sandbox.stub(req.conversation, 'createAndSetLastOutboundMessage')
     .returns(resolvedPromise);
 
   // test
@@ -150,14 +153,14 @@ test('sendReply(): should create and post the outbound message if there is no la
 
   // asserts
   Message.updateMessageByRequestIdAndDirection.should.not.have.been.called;
-  req.conversation.postLastOutboundMessageToPlatform.should.not.have.been.called;
-  req.conversation.createAndPostOutboundReplyMessage.should.have.been.called;
+  req.conversation.createAndSetLastOutboundMessage.should.have.been.called;
+  req.conversation.postLastOutboundMessageToPlatform.should.have.been.called;
 });
 
 test('sendReply(): should call sendErrorResponse on failure', async (t) => {
   // setup
   const req = getReqWithProps();
-  sandbox.stub(req.conversation, 'createAndPostOutboundReplyMessage')
+  sandbox.stub(req.conversation, 'createAndSetLastOutboundMessage')
     .returns(rejectedPromise);
 
   // test

--- a/test/lib/lib-helpers/request.test.js
+++ b/test/lib/lib-helpers/request.test.js
@@ -22,7 +22,6 @@ const sandbox = sinon.sandbox.create();
 
 const campaignId = stubs.getCampaignId();
 const userId = stubs.getUserId();
-const platform = stubs.getPlatform();
 const conversation = conversationFactory.getValidConversation();
 const message = conversation.lastOutboundMessage;
 
@@ -79,23 +78,26 @@ test('setConversation should not call setLastOutboundMessage does not exist', (t
   requestHelper.setLastOutboundMessage.should.not.have.been.called;
 });
 
-test('setPlatform should inject lastOutbound properties to req', (t) => {
+test('setLastOutboundMessage should inject lastOutbound properties to req', (t) => {
   requestHelper.setLastOutboundMessage(t.context.req, message);
   t.context.req.lastOutboundTemplate.should.equal(message.template);
   t.context.req.lastOutboundBroadcastId.should.equal(message.broadcastId);
   helpers.analytics.addCustomAttributes.should.have.been.called;
 });
 
-test('setPlatform should inject a platform property to req', (t) => {
-  requestHelper.setPlatform(t.context.req, platform);
-  t.context.req.platform.should.equal(platform);
-  helpers.analytics.addCustomAttributes.should.have.been.calledWith({ platform });
+test('setPlatform should set req.platform to platform parameter', (t) => {
+  const alexaPlatform = 'alexa';
+  requestHelper.setPlatform(t.context.req, alexaPlatform);
+  t.context.req.platform.should.equal(alexaPlatform);
+  helpers.analytics.addCustomAttributes.should.have.been.calledWith({ platform: alexaPlatform });
 });
 
-test('setPlatformToSms should call setPlatform', (t) => {
+test('setPlatform should set req.platform to sms if platform parameter undefined ', (t) => {
   sandbox.spy(requestHelper, 'setPlatform');
-  requestHelper.setPlatformToSms(t.context.req);
-  requestHelper.setPlatform.should.have.been.calledWith(t.context.req, 'sms');
+  requestHelper.setPlatform(t.context.req);
+  const smsPlatform = stubs.getPlatform();
+  t.context.req.platform.should.equal(smsPlatform);
+  helpers.analytics.addCustomAttributes.should.have.been.calledWith({ platform: smsPlatform });
 });
 
 test('setUserId should inject a userId property to req', (t) => {

--- a/test/lib/lib-helpers/request.test.js
+++ b/test/lib/lib-helpers/request.test.js
@@ -7,8 +7,8 @@ const sinon = require('sinon');
 const sinonChai = require('sinon-chai');
 const httpMocks = require('node-mocks-http');
 const underscore = require('underscore');
-const helpers = require('../../../lib/helpers');
 
+const helpers = require('../../../lib/helpers');
 const stubs = require('../../helpers/stubs');
 const conversationFactory = require('../../helpers/factories/conversation');
 
@@ -18,11 +18,11 @@ chai.use(sinonChai);
 // module to be tested
 const requestHelper = require('../../../lib/helpers/request');
 
+const sandbox = sinon.sandbox.create();
+
 const campaignId = stubs.getCampaignId();
 const userId = stubs.getUserId();
 const platform = stubs.getPlatform();
-
-const sandbox = sinon.sandbox.create();
 
 test.beforeEach((t) => {
   sandbox.stub(helpers.analytics, 'addCustomAttributes')

--- a/test/lib/lib-helpers/request.test.js
+++ b/test/lib/lib-helpers/request.test.js
@@ -10,6 +10,7 @@ const underscore = require('underscore');
 const helpers = require('../../../lib/helpers');
 
 const stubs = require('../../helpers/stubs');
+const conversationFactory = require('../../helpers/factories/conversation');
 
 chai.should();
 chai.use(sinonChai);
@@ -54,6 +55,24 @@ test('setCampaignId should inject a campaignId property to req', (t) => {
   requestHelper.setCampaignId(t.context.req, campaignId);
   t.context.req.campaignId.should.equal(campaignId);
   helpers.analytics.addCustomAttributes.should.have.been.calledWith({ campaignId });
+});
+
+test('setConversation should inject a conversation property to req', (t) => {
+  const conversation = conversationFactory.getValidConversation();
+  requestHelper.setConversation(t.context.req, conversation);
+  t.context.req.conversation.should.equal(conversation);
+  const conversationId = conversation.id;
+  helpers.analytics.addCustomAttributes.should.have.been.calledWith({ conversationId });
+  t.context.req.should.have.property('lastOutboundTemplate');
+  t.context.req.should.have.property('lastOutboundBroadcastId');
+});
+
+test('setConversation should not inject lastOutbound properties for new Conversations', (t) => {
+  const newConversation = conversationFactory.getValidConversation();
+  newConversation.lastOutboundMessage = null;
+  requestHelper.setConversation(t.context.req, newConversation);
+  t.context.req.should.not.have.property('lastOutboundTemplate');
+  t.context.req.should.not.have.property('lastOutboundBroadcastId');
 });
 
 test('setPlatform should inject a platform property to req', (t) => {

--- a/test/lib/lib-helpers/twilio.test.js
+++ b/test/lib/lib-helpers/twilio.test.js
@@ -38,7 +38,7 @@ test('parseBody should inject vars into req', (t) => {
   twilioHelper.parseBody(t.context.req);
   helpers.request.setPlatformToSms.should.have.been.calledWith(t.context.req);
   twilioHelper.parseUserAddressFromReq.should.have.been.called;
-  t.context.req.userMobile.should.equal(mockTwilioRequestBody.From);
+  t.context.req.platformUserId.should.equal(mockTwilioRequestBody.From);
   t.context.req.should.have.property('platformUserAddress');
 });
 

--- a/test/lib/lib-helpers/twilio.test.js
+++ b/test/lib/lib-helpers/twilio.test.js
@@ -26,7 +26,8 @@ test.beforeEach((t) => {
   t.context.req.body = mockTwilioRequestBody;
 });
 
-test.afterEach(() => {
+test.afterEach((t) => {
+  t.context = {};
   sandbox.restore();
 });
 

--- a/test/lib/lib-helpers/twilio.test.js
+++ b/test/lib/lib-helpers/twilio.test.js
@@ -37,7 +37,7 @@ test('parseBody should inject vars into req', (t) => {
   twilioHelper.parseBody(t.context.req);
   helpers.request.setPlatformToSms.should.have.been.calledWith(t.context.req);
   twilioHelper.parseUserAddressFromReq.should.have.been.called;
-  t.context.req.platformUserId.should.equal(mockTwilioRequestBody.From);
+  t.context.req.userMobile.should.equal(mockTwilioRequestBody.From);
   t.context.req.should.have.property('platformUserAddress');
 });
 

--- a/test/lib/lib-helpers/twilio.test.js
+++ b/test/lib/lib-helpers/twilio.test.js
@@ -33,10 +33,10 @@ test.afterEach((t) => {
 
 // parseBody
 test('parseBody should inject vars into req', (t) => {
-  sandbox.spy(helpers.request, 'setPlatformToSms');
+  sandbox.spy(helpers.request, 'setPlatform');
   sandbox.spy(twilioHelper, 'parseUserAddressFromReq');
   twilioHelper.parseBody(t.context.req);
-  helpers.request.setPlatformToSms.should.have.been.calledWith(t.context.req);
+  helpers.request.setPlatform.should.have.been.calledWith(t.context.req);
   twilioHelper.parseUserAddressFromReq.should.have.been.called;
   t.context.req.platformUserId.should.equal(mockTwilioRequestBody.From);
   t.context.req.should.have.property('platformUserAddress');

--- a/test/lib/lib-helpers/user.test.js
+++ b/test/lib/lib-helpers/user.test.js
@@ -72,7 +72,7 @@ test('getDefaultCreatePayloadFromReq should return object', () => {
   const req = {
     platform: stubs.getPlatform(),
     platformUserAddress: platformUserAddressStub,
-    platformUserId: stubs.getMobileNumber(),
+    userMobile: stubs.getMobileNumber(),
   };
   const mockDefaultPayload = { last_messaged_at: Date.now() };
   sandbox.stub(userHelper, 'getDefaultUpdatePayloadFromReq')
@@ -83,7 +83,7 @@ test('getDefaultCreatePayloadFromReq should return object', () => {
     .returns('taco');
   const result = userHelper.getDefaultCreatePayloadFromReq(req);
   result.source.should.equal(req.platform);
-  result.mobile.should.equal(req.platformUserId);
+  result.mobile.should.equal(req.userMobile);
   userHelper.getDefaultUpdatePayloadFromReq.should.have.been.calledWith(req);
   underscore.extend.should.have.been.calledWith(mockDefaultPayload, req.platformUserAddress);
   userHelper.generatePassword.should.have.been.called;

--- a/test/lib/lib-helpers/user.test.js
+++ b/test/lib/lib-helpers/user.test.js
@@ -70,7 +70,7 @@ test('fetchByMobile calls northstar.fetchUserById', async () => {
 });
 
 // fetchFromReq
-test('fetchFromReq calls fetchById if !req.userMobile', async (t) => {
+test('fetchFromReq calls fetchById if !req.platformUserId', async (t) => {
   sandbox.stub(userHelper, 'fetchById')
     .returns(userLookupStub);
   sandbox.stub(userHelper, 'fetchByMobile')
@@ -82,12 +82,12 @@ test('fetchFromReq calls fetchById if !req.userMobile', async (t) => {
   userHelper.fetchByMobile.should.not.have.been.called;
 });
 
-test('fetchFromReq calls fetchByMobile if req.userMobile', async (t) => {
+test('fetchFromReq calls fetchByMobile if req.platformUserId', async (t) => {
   sandbox.stub(userHelper, 'fetchById')
     .returns(userLookupStub);
   sandbox.stub(userHelper, 'fetchByMobile')
     .returns(userLookupStub);
-  t.context.req.userMobile = stubs.getMobileNumber();
+  t.context.req.platformUserId = stubs.getMobileNumber();
 
   await userHelper.fetchFromReq(t.context.req);
   userHelper.fetchByMobile.should.have.been.called;
@@ -107,7 +107,7 @@ test('getCreatePayloadFromReq should return object', () => {
   const req = {
     platform: stubs.getPlatform(),
     platformUserAddress: platformUserAddressStub,
-    userMobile: stubs.getMobileNumber(),
+    platformUserId: stubs.getMobileNumber(),
   };
   sandbox.stub(underscore, 'extend')
     .returns(platformUserAddressStub);
@@ -115,7 +115,7 @@ test('getCreatePayloadFromReq should return object', () => {
     .returns('taco');
   const result = userHelper.getCreatePayloadFromReq(req);
   result.source.should.equal(req.platform);
-  result.mobile.should.equal(req.userMobile);
+  result.mobile.should.equal(req.platformUserId);
   userHelper.generatePassword.should.have.been.called;
 });
 

--- a/test/lib/lib-helpers/user.test.js
+++ b/test/lib/lib-helpers/user.test.js
@@ -9,7 +9,8 @@ const crypto = require('crypto');
 const underscore = require('underscore');
 const httpMocks = require('node-mocks-http');
 const northstar = require('../../../lib/northstar');
-const macroHelper = require('../../../lib/helpers/macro');
+const helpers = require('../../../lib/helpers');
+
 const subscriptionHelper = require('../../../lib/helpers/subscription');
 const config = require('../../../config/lib/helpers/user');
 
@@ -144,14 +145,14 @@ test('hasAddress should return false if user does not have address properties se
 // updateSubscriptionStatus
 test('getSubscriptionStatusUpdate should return stop value if stop macro is passed', () => {
   const user = userFactory.getValidUser();
-  const stopMacro = macroHelper.macros.subscriptionStatusStop();
+  const stopMacro = helpers.macro.macros.subscriptionStatusStop();
   const result = userHelper.getSubscriptionStatusUpdate(user, stopMacro);
   result.should.equal(subscriptionHelper.statuses.stop());
 });
 
 test('getSubscriptionStatusUpdate should return less value if less macro is passed', () => {
   const user = userFactory.getValidUser();
-  const lessMacro = macroHelper.macros.subscriptionStatusLess();
+  const lessMacro = helpers.macro.macros.subscriptionStatusLess();
   const result = userHelper.getSubscriptionStatusUpdate(user, lessMacro);
   result.should.equal(subscriptionHelper.statuses.less());
 });

--- a/test/lib/lib-helpers/user.test.js
+++ b/test/lib/lib-helpers/user.test.js
@@ -68,24 +68,19 @@ test('generatePassword', () => {
 });
 
 // getDefaultCreatePayloadFromReq
-test('getDefaultCreatePayloadFromReq should return object', () => {
+test('getCreatePayloadFromReq should return object', () => {
   const req = {
     platform: stubs.getPlatform(),
     platformUserAddress: platformUserAddressStub,
     userMobile: stubs.getMobileNumber(),
   };
-  const mockDefaultPayload = { last_messaged_at: Date.now() };
-  sandbox.stub(userHelper, 'getDefaultUpdatePayloadFromReq')
-    .returns(mockDefaultPayload);
   sandbox.stub(underscore, 'extend')
     .returns(platformUserAddressStub);
   sandbox.stub(userHelper, 'generatePassword')
     .returns('taco');
-  const result = userHelper.getDefaultCreatePayloadFromReq(req);
+  const result = userHelper.getCreatePayloadFromReq(req);
   result.source.should.equal(req.platform);
   result.mobile.should.equal(req.userMobile);
-  userHelper.getDefaultUpdatePayloadFromReq.should.have.been.calledWith(req);
-  underscore.extend.should.have.been.calledWith(mockDefaultPayload, req.platformUserAddress);
   userHelper.generatePassword.should.have.been.called;
 });
 

--- a/test/lib/middleware/messages/broadcast/params.test.js
+++ b/test/lib/middleware/messages/broadcast/params.test.js
@@ -30,7 +30,6 @@ test.beforeEach((t) => {
   sandbox.spy(helpers.request, 'setUserId');
   sandbox.spy(helpers.request, 'setBroadcastId');
   sandbox.spy(helpers.request, 'setPlatform');
-  sandbox.spy(helpers.request, 'setPlatformToSms');
   sandbox.stub(helpers, 'sendErrorResponse')
     .returns(underscore.noop);
 
@@ -83,8 +82,7 @@ test('paramsMiddleware should call setPlatformToSms if body.platform not found',
   helpers.sendErrorResponse.should.not.have.been.called;
   helpers.request.setUserId.should.have.been.called;
   helpers.request.setBroadcastId.should.have.been.called;
-  helpers.request.setPlatformToSms.should.have.been.calledWith(t.context.req);
-  t.context.req.should.not.have.property('platformUserId');
+  helpers.request.setPlatform.should.have.been.called;
   next.should.have.been.called;
 });
 

--- a/test/lib/middleware/messages/broadcast/params.test.js
+++ b/test/lib/middleware/messages/broadcast/params.test.js
@@ -102,6 +102,5 @@ test('paramsMiddleware should call setPlatform to body.platform if exists', asyn
   await middleware(t.context.req, t.context.res, next);
   helpers.sendErrorResponse.should.not.have.been.called;
   helpers.request.setPlatform.should.have.been.calledWith(t.context.req, platform);
-  t.context.req.platformUserId.should.equal(userId);
   next.should.have.been.called;
 });

--- a/test/lib/middleware/messages/conversation-create.test.js
+++ b/test/lib/middleware/messages/conversation-create.test.js
@@ -50,7 +50,7 @@ test.afterEach((t) => {
 test('createConversation should call next if req.conversation exists', async (t) => {
   const next = sinon.stub();
   t.context.req.conversation = mockConversation;
-  sandbox.stub(Conversation, 'createForUserIdAndPlatform')
+  sandbox.stub(Conversation, 'createFromReq')
     .returns(conversationCreateStub);
   const middleware = createConversation();
 
@@ -63,7 +63,7 @@ test('createConversation should call next if req.conversation exists', async (t)
 
 test('createConversation should inject a conversation into the req object when successfully creating a new conversation', async (t) => {
   const next = sinon.stub();
-  sandbox.stub(Conversation, 'createForUserIdAndPlatform')
+  sandbox.stub(Conversation, 'createFromReq')
     .returns(conversationCreateStub);
   const middleware = createConversation();
 
@@ -76,7 +76,7 @@ test('createConversation should inject a conversation into the req object when s
 
 test('createConversation sends sendErrorResponse on create Conversation error', async (t) => {
   const next = sinon.stub();
-  sandbox.stub(Conversation, 'createForUserIdAndPlatform')
+  sandbox.stub(Conversation, 'createFromReq')
     .returns(conversationCreateFailStub);
   const middleware = createConversation();
 

--- a/test/lib/middleware/messages/conversation-create.test.js
+++ b/test/lib/middleware/messages/conversation-create.test.js
@@ -32,22 +32,18 @@ const mockConversation = conversationFactory.getValidConversation();
 const conversationCreateStub = Promise.resolve(mockConversation);
 const conversationCreateFailStub = Promise.reject({ status: 500 });
 
-// Setup!
 test.beforeEach((t) => {
-  // setup req, res mocks
-  t.context.req = httpMocks.createRequest();
-  t.context.res = httpMocks.createResponse();
   sandbox.stub(analyticsHelper, 'addCustomAttributes')
     .returns(underscore.noop);
-
-  // add params
+  sandbox.stub(helpers, 'sendErrorResponse')
+    .returns(sendErrorResponseStub);
+  t.context.req = httpMocks.createRequest();
+  t.context.res = httpMocks.createResponse();
   t.context.req.platform = stubs.getPlatform();
-  t.context.req.platformUserId = stubs.getPlatformUserId();
+  t.context.req.userId = stubs.getUserId();
 });
 
-// Cleanup!
 test.afterEach((t) => {
-  // reset stubs, spies, and mocks
   sandbox.restore();
   t.context = {};
 });
@@ -55,29 +51,27 @@ test.afterEach((t) => {
 test('createConversation should inject a conversation into the req object when successfully creating a new conversation', async (t) => {
   // setup
   const next = sinon.stub();
-  sandbox.stub(Conversation, 'createFromReq').returns(conversationCreateStub);
+  sandbox.stub(Conversation, 'createForUserIdAndPlatform')
+    .returns(conversationCreateStub);
   const middleware = createConversation();
 
   // test
   await middleware(t.context.req, t.context.res, next);
   t.context.req.should.have.property('conversation');
   const conversation = t.context.req.conversation;
-  // We can't test object equality with middleware.createConversation.getConversationFromCreate())
-  // because we currently can't pass the createdAt and updatedAt fields that get auto-set.
   const properties = ['_id', 'topic', 'createdAt', 'updatedAt', 'paused'];
   properties.forEach(property => conversation.should.have.property(property));
   conversation.platform.should.be.equal(t.context.req.platform);
-  conversation.platformUserId.should.be.equal(t.context.req.platformUserId);
+  conversation.userId.should.be.equal(t.context.req.userId);
   analyticsHelper.addCustomAttributes.should.have.been.called;
   next.should.have.been.called;
 });
 
-
-test('createConversation should call sendErrorResponse when posting new users fails', async (t) => {
+test('createConversation sends sendErrorResponse on create Conversation error', async (t) => {
   // setup
   const next = sinon.stub();
-  sandbox.stub(Conversation, 'createFromReq').returns(conversationCreateFailStub);
-  sandbox.stub(helpers, 'sendErrorResponse').returns(sendErrorResponseStub);
+  sandbox.stub(Conversation, 'createForUserIdAndPlatform')
+    .returns(conversationCreateFailStub);
   const middleware = createConversation();
 
   // test

--- a/test/lib/middleware/messages/member/user-get.test.js
+++ b/test/lib/middleware/messages/member/user-get.test.js
@@ -12,7 +12,6 @@ const Promise = require('bluebird');
 
 const helpers = require('../../../../../lib/helpers');
 const analyticsHelper = require('../../../../../lib/helpers/analytics');
-const Conversation = require('../../../../../app/models/Conversation');
 const userFactory = require('../../../../helpers/factories/user');
 
 // setup "x.should.y" assertion style
@@ -24,7 +23,6 @@ const getUser = require('../../../../../lib/middleware/messages/member/user-get'
 
 // sinon sandbox object
 const sandbox = sinon.sandbox.create();
-const conversation = new Conversation();
 
 // stubs
 const sendErrorResponseStub = underscore.noop;
@@ -42,7 +40,6 @@ test.beforeEach((t) => {
 
   // setup req, res mocks
   t.context.req = httpMocks.createRequest();
-  t.context.req.conversation = conversation;
   t.context.res = httpMocks.createResponse();
 });
 
@@ -57,7 +54,7 @@ test('getUser should inject a user into the req object when found in Northstar',
   // setup
   const next = sinon.stub();
   const middleware = getUser();
-  sandbox.stub(conversation, 'getNorthstarUser')
+  sandbox.stub(helpers.user, 'fetchFromReq')
     .callsFake(userLookupStub);
 
   // test
@@ -71,11 +68,11 @@ test('getUser should inject a user into the req object when found in Northstar',
   next.should.have.been.called;
 });
 
-test('getUser should call next if Conversation.getNorthstarUser response is null', async (t) => {
+test('getUser should call next if Northstar user not found', async (t) => {
   // setup
   const next = sinon.stub();
   const middleware = getUser();
-  sandbox.stub(conversation, 'getNorthstarUser')
+  sandbox.stub(helpers.user, 'fetchFromReq')
     .callsFake(userLookupNotFoundStub);
 
   // test
@@ -85,11 +82,11 @@ test('getUser should call next if Conversation.getNorthstarUser response is null
   next.should.have.been.called;
 });
 
-test('getUser should call sendErrorResponse if Conversation.getNorthstarUser fails', async (t) => {
+test('getUser should call sendErrorResponse if fetchUser fails', async (t) => {
   // setup
   const next = sinon.stub();
   const middleware = getUser();
-  sandbox.stub(conversation, 'getNorthstarUser')
+  sandbox.stub(helpers.user, 'fetchFromReq')
     .callsFake(userLookupFailStub);
 
   // test

--- a/test/lib/middleware/messages/message-outbound-create.test.js
+++ b/test/lib/middleware/messages/message-outbound-create.test.js
@@ -51,7 +51,7 @@ test.afterEach((t) => {
 
 test('createOutboundMessage calls next if req.outboundMessage exists', async (t) => {
   const next = sinon.stub();
-  sandbox.stub(mockConversation, 'createLastOutboundMessage')
+  sandbox.stub(mockConversation, 'createAndSetLastOutboundMessage')
     .returns(messageCreateStub);
   t.context.req.conversation = mockConversation;
   t.context.req.outboundMessage = mockMessage;
@@ -60,35 +60,35 @@ test('createOutboundMessage calls next if req.outboundMessage exists', async (t)
   // test
   await middleware(t.context.req, t.context.res, next);
   next.should.have.been.called;
-  t.context.req.conversation.createLastOutboundMessage.should.not.have.been.called;
+  t.context.req.conversation.createAndSetLastOutboundMessage.should.not.have.been.called;
   helpers.sendErrorResponse.should.not.have.been.called;
 });
 
-test('createOutboundMessage calls Conversation.createLastOutboundMessage', async (t) => {
+test('createOutboundMessage calls Conversation.createAndSetLastOutboundMessage', async (t) => {
   const next = sinon.stub();
-  sandbox.stub(mockConversation, 'createLastOutboundMessage')
+  sandbox.stub(mockConversation, 'createAndSetLastOutboundMessage')
     .returns(messageCreateStub);
   t.context.req.conversation = mockConversation;
   const middleware = createOutboundMessage(configStub);
 
   // test
   await middleware(t.context.req, t.context.res, next);
-  t.context.req.conversation.createLastOutboundMessage.should.have.been.called;
+  t.context.req.conversation.createAndSetLastOutboundMessage.should.have.been.called;
   t.context.req.should.have.property('outboundMessage');
   next.should.have.been.called;
   helpers.sendErrorResponse.should.not.have.been.called;
 });
 
-test('createOutboundMessage calls sendErrorResponse if createLastOutboundMessage fails', async (t) => {
+test('createOutboundMessage calls sendErrorResponse if createAndSetLastOutboundMessage fails', async (t) => {
   const next = sinon.stub();
-  sandbox.stub(mockConversation, 'createLastOutboundMessage')
+  sandbox.stub(mockConversation, 'createAndSetLastOutboundMessage')
     .returns(messageCreateFailStub);
   t.context.req.conversation = mockConversation;
   const middleware = createOutboundMessage(configStub);
 
   // test
   await middleware(t.context.req, t.context.res, next);
-  t.context.req.conversation.createLastOutboundMessage.should.have.been.called;
+  t.context.req.conversation.createAndSetLastOutboundMessage.should.have.been.called;
   next.should.not.have.been.called;
   helpers.sendErrorResponse.should.have.been.called;
 });

--- a/test/lib/middleware/messages/message-outbound-send.test.js
+++ b/test/lib/middleware/messages/message-outbound-send.test.js
@@ -32,7 +32,6 @@ const sandbox = sinon.sandbox.create();
 // stubs
 const conversation = conversationFactory.getValidConversation();
 const user = userFactory.getValidUser();
-const mobileNumber = stubs.getMobileNumber();
 const outboundMessage = messageFactory.getValidMessage();
 
 test.beforeEach((t) => {
@@ -55,66 +54,20 @@ test.afterEach((t) => {
   t.context = {};
 });
 
-test('sendOutbound does not call postLastOutboundMessageToPlatform if not SMS', async (t) => {
+test('sendOutbound calls req.conversation.postLastOutboundMessageToPlatform', async (t) => {
   const next = sinon.stub();
-  sandbox.stub(conversation, 'isSms')
-    .returns(false);
-  sandbox.stub(helpers, 'formatMobileNumber')
-    .returns(mobileNumber);
   sandbox.stub(conversation, 'postLastOutboundMessageToPlatform')
     .returns(Promise.resolve(twilioSuccessStub));
   const middleware = sendOutbound();
 
   // test
   await middleware(t.context.req, t.context.res, next);
-  conversation.isSms.should.have.been.called;
-  helpers.formatMobileNumber.should.not.have.been.called;
-  conversation.postLastOutboundMessageToPlatform.should.not.have.been.called;
-  helpers.sendResponseWithMessage.should.have.been.calledWith(t.context.res, outboundMessage);
-});
-
-test('sendOutbound calls sendErrorResponseWithSuppressHeaders if formatMobileNumber throws', (t) => {
-  // setup
-  const next = sinon.stub();
-  const middleware = sendOutbound();
-  sandbox.stub(conversation, 'isSms')
-    .returns(true);
-  sandbox.stub(helpers, 'formatMobileNumber')
-    .throws();
-  sandbox.stub(conversation, 'postLastOutboundMessageToPlatform')
-    .returns(Promise.resolve(twilioSuccessStub));
-
-  // test
-  middleware(t.context.req, t.context.res, next);
-  conversation.isSms.should.have.been.called;
-  conversation.postLastOutboundMessageToPlatform.should.not.have.been.called;
-  helpers.sendErrorResponseWithSuppressHeaders.should.have.been.called;
-});
-
-test('sendOutbound calls twilio.postMessage for SMS', async (t) => {
-  const next = sinon.stub();
-  sandbox.stub(conversation, 'isSms')
-    .returns(true);
-  sandbox.stub(helpers, 'formatMobileNumber')
-    .returns(mobileNumber);
-  sandbox.stub(conversation, 'postLastOutboundMessageToPlatform')
-    .returns(Promise.resolve(twilioSuccessStub));
-  const middleware = sendOutbound();
-
-  // test
-  await middleware(t.context.req, t.context.res, next);
-  conversation.isSms.should.have.been.called;
-  helpers.formatMobileNumber.should.have.been.called;
   conversation.postLastOutboundMessageToPlatform.should.have.have.been.called;
   helpers.sendResponseWithMessage.should.have.been.calledWith(t.context.res, outboundMessage);
 });
 
 test('sendOutbound calls sendErrorResponseWithSuppressHeaders if Twilio bad request', async (t) => {
   const next = sinon.stub();
-  sandbox.stub(conversation, 'isSms')
-    .returns(true);
-  sandbox.stub(helpers, 'formatMobileNumber')
-    .returns(mobileNumber);
   sandbox.stub(conversation, 'postLastOutboundMessageToPlatform')
     .returns(Promise.reject(twilioErrorStub));
   sandbox.stub(helpers.twilio, 'isBadRequestError')
@@ -125,7 +78,6 @@ test('sendOutbound calls sendErrorResponseWithSuppressHeaders if Twilio bad requ
 
   // test
   await middleware(t.context.req, t.context.res, next);
-  conversation.isSms.should.have.been.called;
   conversation.postLastOutboundMessageToPlatform.should.have.have.been.called;
   helpers.analytics.addTwilioError.should.have.been.called;
   helpers.sendErrorResponse.should.not.have.been.called;
@@ -135,10 +87,6 @@ test('sendOutbound calls sendErrorResponseWithSuppressHeaders if Twilio bad requ
 
 test('sendOutbound calls sendErrorResponse if error is not Twilio bad request', async (t) => {
   const next = sinon.stub();
-  sandbox.stub(conversation, 'isSms')
-    .returns(true);
-  sandbox.stub(helpers, 'formatMobileNumber')
-    .returns(mobileNumber);
   sandbox.stub(conversation, 'postLastOutboundMessageToPlatform')
     .returns(Promise.reject(twilioErrorStub));
   sandbox.stub(helpers.twilio, 'isBadRequestError')
@@ -149,7 +97,6 @@ test('sendOutbound calls sendErrorResponse if error is not Twilio bad request', 
 
   // test
   await middleware(t.context.req, t.context.res, next);
-  conversation.isSms.should.have.been.called;
   conversation.postLastOutboundMessageToPlatform.should.have.been.called;
   helpers.analytics.addTwilioError.should.not.have.been.called;
   helpers.sendErrorResponse.should.have.been.called;

--- a/test/lib/middleware/messages/message-outbound-send.test.js
+++ b/test/lib/middleware/messages/message-outbound-send.test.js
@@ -55,7 +55,7 @@ test.afterEach((t) => {
   t.context = {};
 });
 
-test('sendOutbound does not call helpers.user.sendTwilioMessage if not SMS', async (t) => {
+test('sendOutbound does not call postLastOutboundMessageToPlatform if not SMS', async (t) => {
   const next = sinon.stub();
   sandbox.stub(conversation, 'isSms')
     .returns(false);

--- a/test/lib/middleware/messages/message-outbound-send.test.js
+++ b/test/lib/middleware/messages/message-outbound-send.test.js
@@ -51,31 +51,31 @@ test.afterEach((t) => {
   t.context = {};
 });
 
-test('sendOutbound does not call postLastOutboundMessageToPlatform if not SMS', async (t) => {
+test('sendOutbound does not call helpers.user.sendTwilioMessage if not SMS', async (t) => {
   const next = sinon.stub();
   sandbox.stub(conversation, 'isSms')
     .returns(false);
-  sandbox.stub(conversation, 'postLastOutboundMessageToPlatform')
+  sandbox.stub(helpers.user, 'sendTwilioMessage')
     .returns(Promise.resolve(twilioSuccessStub));
   const middleware = sendOutbound();
 
   // test
   await middleware(t.context.req, t.context.res, next);
-  t.context.req.conversation.postLastOutboundMessageToPlatform.should.not.have.been.called;
+  helpers.user.sendTwilioMessage.should.not.have.been.called;
   helpers.sendResponseWithMessage.should.have.been.calledWith(t.context.res, outboundMessage);
 });
 
-test('sendOutbound calls postLastOutboundMessageToPlatform for SMS', async (t) => {
+test('sendOutbound calls helpers.user.sendTwilioMessage for SMS', async (t) => {
   const next = sinon.stub();
   sandbox.stub(conversation, 'isSms')
     .returns(true);
-  sandbox.stub(conversation, 'postLastOutboundMessageToPlatform')
+  sandbox.stub(helpers.user, 'sendTwilioMessage')
     .returns(Promise.resolve(twilioSuccessStub));
   const middleware = sendOutbound();
 
   // test
   await middleware(t.context.req, t.context.res, next);
-  t.context.req.conversation.postLastOutboundMessageToPlatform.should.have.been.called;
+  helpers.user.sendTwilioMessage.should.have.have.been.called;
   helpers.sendResponseWithMessage.should.have.been.calledWith(t.context.res, outboundMessage);
 });
 
@@ -83,7 +83,7 @@ test('sendOutbound calls sendErrorResponseWithSuppressHeaders if Twilio bad requ
   const next = sinon.stub();
   sandbox.stub(conversation, 'isSms')
     .returns(true);
-  sandbox.stub(conversation, 'postLastOutboundMessageToPlatform')
+  sandbox.stub(helpers.user, 'sendTwilioMessage')
     .returns(Promise.reject(twilioErrorStub));
   sandbox.stub(helpers.twilio, 'isBadRequestError')
     .returns(true);
@@ -93,7 +93,7 @@ test('sendOutbound calls sendErrorResponseWithSuppressHeaders if Twilio bad requ
 
   // test
   await middleware(t.context.req, t.context.res, next);
-  t.context.req.conversation.postLastOutboundMessageToPlatform.should.have.been.called;
+  helpers.user.sendTwilioMessage.should.have.have.been.called;
   helpers.analytics.addTwilioError.should.have.been.called;
   helpers.sendErrorResponse.should.not.have.been.called;
   helpers.sendErrorResponseWithSuppressHeaders.should.have.been.called;
@@ -104,7 +104,7 @@ test('sendOutbound calls sendErrorResponse if error is not Twilio bad request', 
   const next = sinon.stub();
   sandbox.stub(conversation, 'isSms')
     .returns(true);
-  sandbox.stub(conversation, 'postLastOutboundMessageToPlatform')
+  sandbox.stub(helpers.user, 'sendTwilioMessage')
     .returns(Promise.reject(twilioErrorStub));
   sandbox.stub(helpers.twilio, 'isBadRequestError')
     .returns(false);
@@ -114,7 +114,7 @@ test('sendOutbound calls sendErrorResponse if error is not Twilio bad request', 
 
   // test
   await middleware(t.context.req, t.context.res, next);
-  t.context.req.conversation.postLastOutboundMessageToPlatform.should.have.been.called;
+  helpers.user.sendTwilioMessage.should.have.been.called;
   helpers.analytics.addTwilioError.should.not.have.been.called;
   helpers.sendErrorResponse.should.have.been.called;
   helpers.sendErrorResponseWithSuppressHeaders.should.not.have.been.called;

--- a/test/lib/middleware/messages/message-outbound-validate.test.js
+++ b/test/lib/middleware/messages/message-outbound-validate.test.js
@@ -79,25 +79,6 @@ test('validateOutbound sends error if user is paused and config is not shouldSen
   next.should.not.have.been.called;
 });
 
-test('validateOutbound calls sendErrorResponseWithSuppressHeaders if formatMobileNumber throws', (t) => {
-  // setup
-  const next = sinon.stub();
-  const middleware = validateOutbound(defaultConfigStub);
-  sandbox.stub(helpers.user, 'isSubscriber')
-    .returns(true);
-  sandbox.stub(helpers.user, 'isPaused')
-    .returns(false);
-  sandbox.stub(helpers, 'formatMobileNumber')
-    .throws();
-
-  // test
-  middleware(t.context.req, t.context.res, next);
-  helpers.user.isSubscriber.should.have.been.called;
-  helpers.user.isPaused.should.have.been.called;
-  helpers.formatMobileNumber.should.have.been.called;
-  helpers.sendErrorResponseWithSuppressHeaders.should.have.been.called;
-  next.should.not.have.been.called;
-});
 
 test('validateOutbound calls next if user validates', (t) => {
   // setup
@@ -107,35 +88,11 @@ test('validateOutbound calls next if user validates', (t) => {
     .returns(true);
   sandbox.stub(helpers.user, 'isPaused')
     .returns(false);
-  sandbox.stub(helpers, 'formatMobileNumber')
-    .returns(mockUser.mobile);
 
   // test
   middleware(t.context.req, t.context.res, next);
   helpers.user.isSubscriber.should.have.been.called;
   helpers.user.isPaused.should.have.been.called;
-  helpers.formatMobileNumber.should.have.been.called;
-  helpers.sendErrorResponseWithSuppressHeaders.should.not.have.been.called;
-  next.should.have.been.called;
-});
-
-test('validateOutbound does not call formatMobileNumber if platform is not SMS', (t) => {
-  // setup
-  const next = sinon.stub();
-  const middleware = validateOutbound(defaultConfigStub);
-  sandbox.stub(helpers.user, 'isSubscriber')
-    .returns(true);
-  sandbox.stub(helpers.user, 'isPaused')
-    .returns(false);
-  sandbox.stub(helpers, 'formatMobileNumber')
-    .returns(mockUser.mobile);
-  t.context.req.platform = 'alexa';
-
-  // test
-  middleware(t.context.req, t.context.res, next);
-  helpers.user.isSubscriber.should.have.been.called;
-  helpers.user.isPaused.should.have.been.called;
-  helpers.formatMobileNumber.should.not.have.been.called;
   helpers.sendErrorResponseWithSuppressHeaders.should.not.have.been.called;
   next.should.have.been.called;
 });

--- a/test/lib/middleware/messages/message-outbound-validate.test.js
+++ b/test/lib/middleware/messages/message-outbound-validate.test.js
@@ -79,6 +79,25 @@ test('validateOutbound sends error if user is paused and config is not shouldSen
   next.should.not.have.been.called;
 });
 
+test('validateOutbound calls sendErrorResponseWithSuppressHeaders if formatMobileNumber throws', (t) => {
+  // setup
+  const next = sinon.stub();
+  const middleware = validateOutbound(defaultConfigStub);
+  sandbox.stub(helpers.user, 'isSubscriber')
+    .returns(true);
+  sandbox.stub(helpers.user, 'isPaused')
+    .returns(false);
+  sandbox.stub(helpers, 'formatMobileNumber')
+    .throws();
+
+  // test
+  middleware(t.context.req, t.context.res, next);
+  helpers.user.isSubscriber.should.have.been.called;
+  helpers.user.isPaused.should.have.been.called;
+  helpers.formatMobileNumber.should.have.been.called;
+  helpers.sendErrorResponseWithSuppressHeaders.should.have.been.called;
+  next.should.not.have.been.called;
+});
 
 test('validateOutbound calls next if user validates', (t) => {
   // setup
@@ -88,11 +107,35 @@ test('validateOutbound calls next if user validates', (t) => {
     .returns(true);
   sandbox.stub(helpers.user, 'isPaused')
     .returns(false);
+  sandbox.stub(helpers, 'formatMobileNumber')
+    .returns(mockUser.mobile);
 
   // test
   middleware(t.context.req, t.context.res, next);
   helpers.user.isSubscriber.should.have.been.called;
   helpers.user.isPaused.should.have.been.called;
+  helpers.formatMobileNumber.should.have.been.called;
+  helpers.sendErrorResponseWithSuppressHeaders.should.not.have.been.called;
+  next.should.have.been.called;
+});
+
+test('validateOutbound does not call formatMobileNumber if platform is not SMS', (t) => {
+  // setup
+  const next = sinon.stub();
+  const middleware = validateOutbound(defaultConfigStub);
+  sandbox.stub(helpers.user, 'isSubscriber')
+    .returns(true);
+  sandbox.stub(helpers.user, 'isPaused')
+    .returns(false);
+  sandbox.stub(helpers, 'formatMobileNumber')
+    .returns(mockUser.mobile);
+  t.context.req.platform = 'alexa';
+
+  // test
+  middleware(t.context.req, t.context.res, next);
+  helpers.user.isSubscriber.should.have.been.called;
+  helpers.user.isPaused.should.have.been.called;
+  helpers.formatMobileNumber.should.not.have.been.called;
   helpers.sendErrorResponseWithSuppressHeaders.should.not.have.been.called;
   next.should.have.been.called;
 });

--- a/test/lib/middleware/messages/signup/params.test.js
+++ b/test/lib/middleware/messages/signup/params.test.js
@@ -107,7 +107,6 @@ test('paramsMiddleware should set platformUserId if platform is passed', async (
 
   // test
   await middleware(t.context.req, t.context.res, next);
-  t.context.req.platformUserId.should.equal(userId);
   helpers.sendErrorResponse.should.not.have.been.called;
   next.should.have.been.called;
 });


### PR DESCRIPTION
#### What's this PR do?
Adds a Conversation.userId property, deprecating the `platformUserId` property.

* Alters Twilio Member Message route to find or create Northstar User for given mobile number before getting/creating relevant Conversation. We're now storing Conversations by `userId` instead of `platformUserId` (what we'd use to save mobile numbers)

* Renames `req.platformUserId` as `req.userMobile` to make things a bit more readable. If we ever need to post messages to a different platform, like Facebook Messenger, we can save a separate `req.userFacebookId` property, or potentially revisit using the vaguer `req.platformUserId`.

* Refactors `Conversation.createAndPostOutboundReplyMessage` into separate functions, `createAndSetLastOutboundMessage` and `postLastOutboundMessage`.
    * Tweaks `createAndSetLastOutboundMessage` to update the Conversation.userId property if it doesn't exist (this would happen when we've already created a SMS Conversation for a given mobile number)
   * Tweaks `postLastOutboundMessage` to call `twilio.postMessage` with the `req.userMobile` instead of `req.platformUserId`

* Removes deprecated `import-message` check in Twilio helper per #294 

#### How should this be reviewed?
* Staging: verify that Twilio and Gambit Slack messaging work as expected upon a staging deploy. 
* Local: verify that adding `DS_CONSOLEBOT_SUPPRESS_REPLY=false` to your local `.env` results in expected behavior (success for legitimate mobile number, preferably your own, and failure for invalid mobile number)
 
#### Any background context you want to provide?
Storing the Northstar User `userId` property is late to the game because the early stages of this project didn't rely on creating or getting a Northstar User. Since we've launched, we do rely on Northstar to store the User's subscription status (`user.sms_status`).  Saving the `userId` to Conversations and Messages makes the data team's life easier to query messages to find users who have sent messages that were caught bu certain Rivescript triggers, or to integrate with our [DS GraphQL](https://github.com/dosomething/graphql)

TODO (in a future PR):

* Add new diagrams in wiki with updated logic (check for User first before checking for a Conversation)

* DRY the Get User middleware -- this could be shared betweeen all routes, it just needs a config setting for whether to return 404 if User not found (only time we wouldn't send a 404 is for SMS, when we'd create a new User for the given mobile number)

* DRY setting default platform as `'sms'` if not found as a request body parameter.

#### Relevant tickets
Fixes https://www.pivotaltracker.com/story/show/155527887

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Tested on staging.
