### PR TITLE
Support cleanup + tests: part 1

### DIFF
--- a/app/models/Conversation.js
+++ b/app/models/Conversation.js
@@ -137,11 +137,6 @@ conversationSchema.methods.setCampaign = function (campaign) {
 };
 
 /**
- * Sets the Conversation topic to campaignTopic to enable Campaign Rivescript triggers.
- */
-
-
-/**
  * Prompt signup for current campaign.
  * @param {Campaign} campaign
  * @param {string} source

--- a/app/models/Conversation.js
+++ b/app/models/Conversation.js
@@ -7,9 +7,7 @@ const helpers = require('../../lib/helpers');
 const front = require('../../lib/front');
 const twilio = require('../../lib/twilio');
 
-const campaignTopic = 'campaign';
-const defaultTopic = 'random';
-const supportTopic = 'support';
+const config = require('../../config/app/models/conversation');
 
 /**
  * Schema.
@@ -46,7 +44,7 @@ conversationSchema.statics.createFromReq = function (req) {
     userId: req.userId,
     platform: req.platform,
     platformUserId: req.platformUserId,
-    topic: defaultTopic,
+    topic: config.topics.default,
   };
 
   return this.create(data);
@@ -95,21 +93,21 @@ conversationSchema.methods.setTopic = function (topic) {
  * @return {Promise}
  */
 conversationSchema.methods.setDefaultTopic = function () {
-  return this.setTopic(defaultTopic);
+  return this.setTopic(config.topics.default);
 };
 
 /**
  * @return {Promise}
  */
 conversationSchema.methods.setCampaignTopic = function () {
-  return this.setTopic(campaignTopic);
+  return this.setTopic(config.topics.campaign);
 };
 
 /**
  * @return {Promise}
  */
 conversationSchema.methods.setSupportTopic = function () {
-  return this.setTopic(supportTopic);
+  return this.setTopic(config.topics.support);
 };
 
 /**
@@ -343,7 +341,7 @@ conversationSchema.methods.isSms = function () {
  * @return {boolean}
  */
 conversationSchema.methods.isSupportTopic = function () {
-  return this.topic === supportTopic;
+  return this.topic === config.topics.support;
 };
 
 module.exports = mongoose.model('Conversation', conversationSchema);

--- a/app/models/Conversation.js
+++ b/app/models/Conversation.js
@@ -85,6 +85,10 @@ conversationSchema.statics.findOneAndPopulateLastOutboundMessage = function (que
  * @return {Promise}
  */
 conversationSchema.methods.setTopic = function (topic) {
+  if (topic === this.topic) {
+    return Promise.resolve();
+  }
+  logger.debug('Conversation.setTopic', { topic });
   this.topic = topic;
   return this.save();
 };

--- a/config/app/models/conversation.js
+++ b/config/app/models/conversation.js
@@ -1,0 +1,9 @@
+'use strict';
+
+module.exports = {
+  topics: {
+    default: 'random',
+    campaign: 'campaign',
+    support: 'support',
+  },
+};

--- a/lib/helpers/front.js
+++ b/lib/helpers/front.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const frontClient = require('../front');
+
+module.exports = {
+  getConversationByUrl: function getConversationByUrl(url) {
+    return frontClient.get(url);
+  },
+  isConversationArchived: function isConversationArchived(frontConversation) {
+    return frontConversation.status === 'archived';
+  },
+};

--- a/lib/helpers/index.js
+++ b/lib/helpers/index.js
@@ -4,6 +4,7 @@ const analytics = require('./analytics');
 const attachments = require('./attachments');
 const broadcast = require('./broadcast');
 const cache = require('./cache');
+const front = require('./front');
 const macro = require('./macro');
 const request = require('./request');
 const replies = require('./replies');
@@ -19,6 +20,7 @@ module.exports = {
   attachments,
   broadcast,
   cache,
+  front,
   macro,
   request,
   replies,

--- a/lib/helpers/user.js
+++ b/lib/helpers/user.js
@@ -70,7 +70,7 @@ module.exports = {
   getDefaultUpdatePayloadFromReq: function getDefaultUpdatePayloadFromReq(req) {
     return {
       last_messaged_at: req.inboundMessage.createdAt.toISOString(),
-      sms_paused: req.conversation.paused,
+      sms_paused: req.conversation.isSupportTopic(),
     };
   },
 

--- a/lib/middleware/messages/member/support-message.js
+++ b/lib/middleware/messages/member/support-message.js
@@ -4,7 +4,7 @@ const helpers = require('../../../helpers');
 
 module.exports = function postMessageToSupport() {
   return (req, res, next) => {
-    if (!req.conversation.paused) {
+    if (!req.conversation.isSupportTopic()) {
       return next();
     }
 

--- a/lib/middleware/messages/member/support-requested.js
+++ b/lib/middleware/messages/member/support-requested.js
@@ -8,7 +8,7 @@ module.exports = function requestSupport() {
       return next();
     }
 
-    return req.conversation.supportRequested()
+    return req.conversation.setSupportTopic()
       .then(() => helpers.replies.supportRequested(req, res))
       .catch(err => helpers.sendErrorResponse(res, err));
   };

--- a/lib/middleware/messages/member/support-requested.js
+++ b/lib/middleware/messages/member/support-requested.js
@@ -8,6 +8,9 @@ module.exports = function requestSupport() {
       return next();
     }
 
+    // TODO? This should update Northstar User sms_status. Currently doesn't change until User sends
+    // another inbound message. We may want to move updating a User into our replies helper instead
+    // of using User Update middleware that already updated the User by the time we get here.
     return req.conversation.setSupportTopic()
       .then(() => helpers.replies.supportRequested(req, res))
       .catch(err => helpers.sendErrorResponse(res, err));

--- a/lib/middleware/messages/support/conversation-update.js
+++ b/lib/middleware/messages/support/conversation-update.js
@@ -1,22 +1,23 @@
 'use strict';
 
 const logger = require('../../../logger');
-const front = require('../../../front');
+const helpers = require('../../../helpers');
 
 module.exports = function updateConversation() {
-  return (req, res, next) => front.get(req.frontConversationUrl)
-    .then((frontResponse) => {
-      const frontConversation = frontResponse.body;
-      logger.debug('front.getConversation response', { status: frontConversation.status }, req);
-      // Check if the Front agent archived the conversation.
-      if (frontConversation.status === 'archived') {
-        logger.debug('support request resolved', {}, req);
-        // TODO: We should update Northstar User's sms_status here, setting it to false.
-        // It currently won't get updated until User sends another inbound message back to Gambit.
-        return req.conversation.setDefaultTopic().then(() => next());
+  return (req, res, next) => helpers.front.getConversationByUrl(req.frontConversationUrl)
+    .then((frontRes) => {
+      const frontConversation = frontRes.body;
+      logger.debug('front.getConversationByUrl success', { status: frontConversation.status }, req);
+      // If Front agent didn't archive the Front conversation, we don't need to update our
+      // Gambit Conversation.
+      if (!helpers.front.isConversationArchived(frontConversation)) {
+        return next();
       }
 
-      return next();
+      // TODO: We should update Northstar User's sms_status here, setting it to false.
+      // It currently won't get updated until User sends another inbound message back to Gambit.
+      return req.conversation.setDefaultTopic()
+        .then(() => next());
     })
-    .catch(err => err);
+    .catch(err => helpers.sendErrorResponse(res, err));
 };

--- a/lib/middleware/messages/support/conversation-update.js
+++ b/lib/middleware/messages/support/conversation-update.js
@@ -11,7 +11,9 @@ module.exports = function updateConversation() {
       // Check if the Front agent archived the conversation.
       if (frontConversation.status === 'archived') {
         logger.debug('support request resolved', {}, req);
-        return req.conversation.supportResolved().then(() => next());
+        // TODO: We should update Northstar User's sms_status here, setting it to false.
+        // It currently won't get updated until User sends another inbound message back to Gambit.
+        return req.conversation.setDefaultTopic().then(() => next());
       }
 
       return next();

--- a/test/app/models/conversation.test.js
+++ b/test/app/models/conversation.test.js
@@ -132,7 +132,7 @@ test('postMessageToSupport calls front.postMessage if conversation is SMS', asyn
 });
 
 // setTopic
-test('setTopic calls save', async () => {
+test('setTopic calls save for new topic', async () => {
   const mockConversation = conversationFactory.getValidConversation();
   const mockTopic = 'lannisters';
   sandbox.stub(mockConversation, 'save')
@@ -140,6 +140,15 @@ test('setTopic calls save', async () => {
 
   await mockConversation.setTopic(mockTopic);
   mockConversation.save.should.have.been.called;
+});
+
+test('setTopic does not call save for same topic', async () => {
+  const mockConversation = conversationFactory.getValidConversation();
+  sandbox.stub(mockConversation, 'save')
+    .returns(Promise.resolve(mockConversation));
+
+  await mockConversation.setTopic(mockConversation.topic);
+  mockConversation.save.should.not.have.been.called;
 });
 
 test('setDefaultTopic, setSupportTopic, setCampaignTopic call setTopic', async () => {

--- a/test/helpers/factories/conversation.js
+++ b/test/helpers/factories/conversation.js
@@ -5,6 +5,8 @@ const Conversation = require('../../../app/models/Conversation');
 const messageFactory = require('./message');
 const stubs = require('../stubs');
 
+const config = require('../../../config/app/models/conversation');
+
 module.exports.getValidConversation = function getValidConversation(platformString) {
   let platform = platformString;
   if (!platform) {
@@ -23,4 +25,11 @@ module.exports.getValidConversation = function getValidConversation(platformStri
     updatedAt: date,
     lastOutboundMessage: messageFactory.getValidMessage(),
   });
+};
+
+module.exports.getValidSupportConversation = function getValidSupportConversation() {
+  const conversation = module.exports.getValidConversation();
+  conversation.topic = config.topics.support;
+  conversation.lastOutboundMessage = messageFactory.getValidOutboundNoReplyMessage();
+  return conversation;
 };

--- a/test/helpers/factories/conversation.js
+++ b/test/helpers/factories/conversation.js
@@ -19,7 +19,6 @@ module.exports.getValidConversation = function getValidConversation(platformStri
     userId: stubs.getUserId(),
     platformUserId: stubs.getMobileNumber(),
     topic: stubs.getTopic(),
-    paused: false,
     createdAt: date,
     updatedAt: date,
     lastOutboundMessage: messageFactory.getValidMessage(),

--- a/test/helpers/factories/message.js
+++ b/test/helpers/factories/message.js
@@ -21,3 +21,10 @@ module.exports.getValidMessage = function getValidMessage(direction) {
 module.exports.getValidOutboundReplyMessage = function getValidOutboundReplyMessage() {
   return exports.getValidMessage('outbound-reply');
 };
+
+module.exports.getValidOutboundNoReplyMessage = function getValidOutboundReplyMessage() {
+  const message = exports.getValidOutboundReplyMessage();
+  message.template = 'noReply';
+  message.text = '';
+  return message;
+};

--- a/test/helpers/stubs.js
+++ b/test/helpers/stubs.js
@@ -146,6 +146,19 @@ module.exports = {
   getUserId: function getUserId() {
     return '597b9ef910707d07c84b00aa';
   },
+  front: {
+    // @see https://dev.frontapp.com/#get-conversation
+    getConversationUrl: function getConversationUrl() {
+      return 'https://api2.frontapp.com/conversations/cnv_55c8c149';
+    },
+    getConversationSuccessBody: function getConversationSuccessBody(status = 'archived') {
+      return {
+        id: 'cnv_55c8c149',
+        subject: 'You broke my heart, Hubert.',
+        status,
+      };
+    },
+  },
   twilio: {
     getSmsMessageSid: function getSmsMessageSid() {
       return 'SMe62bd767ea4438d7f7f307ff9d3212e0';

--- a/test/lib/lib-helpers/user.test.js
+++ b/test/lib/lib-helpers/user.test.js
@@ -123,12 +123,15 @@ test('getCreatePayloadFromReq should return object', () => {
 test('getDefaultUpdatePayloadFromReq should return object', () => {
   const inboundMessage = messageFactory.getValidMessage();
   const conversation = conversationFactory.getValidConversation();
+  const isSupportTopic = true;
+  sandbox.stub(conversation, 'isSupportTopic')
+    .returns(isSupportTopic);
   const result = userHelper.getDefaultUpdatePayloadFromReq({
     inboundMessage,
     conversation,
   });
   result.last_messaged_at.should.equal(inboundMessage.createdAt.toISOString());
-  result.sms_paused.should.equal(conversation.paused);
+  result.sms_paused.should.equal(isSupportTopic);
 });
 
 // hasAddress

--- a/test/lib/middleware/messages/member/support-message.test.js
+++ b/test/lib/middleware/messages/member/support-message.test.js
@@ -1,0 +1,97 @@
+'use strict';
+
+require('dotenv').config();
+
+const test = require('ava');
+const chai = require('chai');
+const sinon = require('sinon');
+const sinonChai = require('sinon-chai');
+const httpMocks = require('node-mocks-http');
+const underscore = require('underscore');
+
+const helpers = require('../../../../../lib/helpers');
+const conversationFactory = require('../../../../helpers/factories/conversation');
+
+const resolvedPromise = Promise.resolve({});
+
+chai.should();
+chai.use(sinonChai);
+
+// module to be tested
+const supportMessage = require('../../../../../lib/middleware/messages/member/support-message');
+
+const sandbox = sinon.sandbox.create();
+
+test.beforeEach((t) => {
+  sandbox.stub(helpers.replies, 'noReply')
+    .returns(underscore.noop);
+  sandbox.stub(helpers, 'sendErrorResponse')
+    .returns(underscore.noop);
+  t.context.req = httpMocks.createRequest();
+  t.context.res = httpMocks.createResponse();
+});
+
+test.afterEach((t) => {
+  sandbox.restore();
+  t.context = {};
+});
+
+test('supportMessage should call next if conversation is not in support', async (t) => {
+  // setup
+  const next = sinon.stub();
+  const middleware = supportMessage();
+  const conversation = conversationFactory.getValidConversation();
+  t.context.req.conversation = conversation;
+  sandbox.stub(conversation, 'isSupportTopic')
+    .returns(false);
+  sandbox.stub(conversation, 'postMessageToSupport')
+    .returns(resolvedPromise);
+
+  // test
+  await middleware(t.context.req, t.context.res, next);
+  conversation.isSupportTopic.should.have.been.called;
+  next.should.have.been.called;
+  conversation.postMessageToSupport.should.not.have.been.called;
+  helpers.replies.noReply.should.not.have.been.called;
+  helpers.sendErrorResponse.should.not.have.been.called;
+});
+
+test('supportMessage should call postMessageToSupport if conversation is in support', async (t) => {
+  // setup
+  const next = sinon.stub();
+  const middleware = supportMessage();
+  const conversation = conversationFactory.getValidConversation();
+  t.context.req.conversation = conversation;
+  sandbox.stub(conversation, 'isSupportTopic')
+    .returns(true);
+  sandbox.stub(conversation, 'postMessageToSupport')
+    .returns(resolvedPromise);
+
+  // test
+  await middleware(t.context.req, t.context.res, next);
+  conversation.isSupportTopic.should.have.been.called;
+  next.should.not.have.been.called;
+  conversation.postMessageToSupport.should.have.been.called;
+  helpers.replies.noReply.should.have.been.called;
+  helpers.sendErrorResponse.should.not.have.been.called;
+});
+
+test('supportMessage should call sendErrorResponse if postMessageToSupport fails', async (t) => {
+  // setup
+  const next = sinon.stub();
+  const middleware = supportMessage();
+  const conversation = conversationFactory.getValidConversation();
+  t.context.req.conversation = conversation;
+  sandbox.stub(conversation, 'isSupportTopic')
+    .returns(true);
+  sandbox.stub(conversation, 'postMessageToSupport')
+    .returns(Promise.reject('Epic fail'));
+
+  // test
+  await middleware(t.context.req, t.context.res, next);
+  conversation.isSupportTopic.should.have.been.called;
+  next.should.not.have.been.called;
+  conversation.postMessageToSupport.should.have.been.called;
+  helpers.replies.noReply.should.not.have.been.called;
+  helpers.sendErrorResponse.should.have.been.called;
+});

--- a/test/lib/middleware/messages/member/support-requested.test.js
+++ b/test/lib/middleware/messages/member/support-requested.test.js
@@ -1,0 +1,97 @@
+'use strict';
+
+require('dotenv').config();
+
+const test = require('ava');
+const chai = require('chai');
+const sinon = require('sinon');
+const sinonChai = require('sinon-chai');
+const httpMocks = require('node-mocks-http');
+const underscore = require('underscore');
+
+const helpers = require('../../../../../lib/helpers');
+const conversationFactory = require('../../../../helpers/factories/conversation');
+
+const resolvedPromise = Promise.resolve({});
+
+chai.should();
+chai.use(sinonChai);
+
+// module to be tested
+const supportRequested = require('../../../../../lib/middleware/messages/member/support-requested');
+
+const sandbox = sinon.sandbox.create();
+
+test.beforeEach((t) => {
+  sandbox.stub(helpers.replies, 'supportRequested')
+    .returns(underscore.noop);
+  sandbox.stub(helpers, 'sendErrorResponse')
+    .returns(underscore.noop);
+  t.context.req = httpMocks.createRequest();
+  t.context.res = httpMocks.createResponse();
+});
+
+test.afterEach((t) => {
+  sandbox.restore();
+  t.context = {};
+});
+
+test('supportRequested should call next if macro.isSupportRequested is false', async (t) => {
+  // setup
+  const next = sinon.stub();
+  const middleware = supportRequested();
+  const conversation = conversationFactory.getValidConversation();
+  t.context.req.conversation = conversation;
+  sandbox.stub(helpers.macro, 'isSupportRequested')
+    .returns(false);
+  sandbox.stub(conversation, 'setSupportTopic')
+    .returns(resolvedPromise);
+
+  // test
+  await middleware(t.context.req, t.context.res, next);
+  helpers.macro.isSupportRequested.should.have.been.called;
+  next.should.have.been.called;
+  conversation.setSupportTopic.should.not.have.been.called;
+  helpers.replies.supportRequested.should.not.have.been.called;
+  helpers.sendErrorResponse.should.not.have.been.called;
+});
+
+test('supportRequested should call setSupportTopic if macro.isSupportRequested is true', async (t) => {
+  // setup
+  const next = sinon.stub();
+  const middleware = supportRequested();
+  const conversation = conversationFactory.getValidConversation();
+  t.context.req.conversation = conversation;
+  sandbox.stub(helpers.macro, 'isSupportRequested')
+    .returns(true);
+  sandbox.stub(conversation, 'setSupportTopic')
+    .returns(resolvedPromise);
+
+  // test
+  await middleware(t.context.req, t.context.res, next);
+  helpers.macro.isSupportRequested.should.have.been.called;
+  next.should.not.have.been.called;
+  conversation.setSupportTopic.should.have.been.called;
+  helpers.replies.supportRequested.should.have.been.called;
+  helpers.sendErrorResponse.should.not.have.been.called;
+});
+
+test('supportMessage should call sendErrorResponse if postMessageToSupport fails', async (t) => {
+  // setup
+  const next = sinon.stub();
+  const middleware = supportRequested();
+  const conversation = conversationFactory.getValidConversation();
+  t.context.req.conversation = conversation;
+  sandbox.stub(helpers.macro, 'isSupportRequested')
+    .returns(true);
+  sandbox.stub(conversation, 'setSupportTopic')
+    .returns(Promise.reject('Epic fail'));
+
+  // test
+  await middleware(t.context.req, t.context.res, next);
+  helpers.macro.isSupportRequested.should.have.been.called;
+  next.should.not.have.been.called;
+  conversation.setSupportTopic.should.have.been.called;
+  helpers.replies.supportRequested.should.not.have.been.called;
+  helpers.sendErrorResponse.should.have.been.called;
+});

--- a/test/lib/middleware/messages/support/conversation-update.test.js
+++ b/test/lib/middleware/messages/support/conversation-update.test.js
@@ -1,0 +1,81 @@
+'use strict';
+
+require('dotenv').config();
+
+const test = require('ava');
+const chai = require('chai');
+const sinon = require('sinon');
+const sinonChai = require('sinon-chai');
+const httpMocks = require('node-mocks-http');
+const underscore = require('underscore');
+
+const helpers = require('../../../../../lib/helpers');
+const stubs = require('../../../../helpers/stubs');
+const conversationFactory = require('../../../../helpers/factories/conversation');
+
+const conversation = conversationFactory.getValidConversation();
+const frontSuccessStub = Promise.resolve({ body: stubs.front.getConversationSuccessBody() });
+const resolvedPromise = Promise.resolve({});
+
+chai.should();
+chai.use(sinonChai);
+
+// module to be tested
+const updateConversation = require('../../../../../lib/middleware/messages/support/conversation-update');
+
+const sandbox = sinon.sandbox.create();
+
+test.beforeEach((t) => {
+  sandbox.stub(helpers, 'sendErrorResponse')
+    .returns(underscore.noop);
+  t.context.req = httpMocks.createRequest();
+  t.context.req.conversation = conversation;
+  t.context.req.frontConversationUrl = stubs.front.getConversationUrl();
+  t.context.res = httpMocks.createResponse();
+});
+
+test.afterEach((t) => {
+  sandbox.restore();
+  t.context = {};
+});
+
+test('updateConversation should call error if helpers.front.getConversationByUrl fails', async (t) => {
+  // setup
+  const next = sinon.stub();
+  const middleware = updateConversation();
+  sandbox.stub(helpers.front, 'getConversationByUrl')
+    .returns(Promise.reject('epic fail'));
+  sandbox.stub(helpers.front, 'isConversationArchived')
+    .returns(true);
+  sandbox.stub(conversation, 'setDefaultTopic')
+    .returns(resolvedPromise);
+
+  // test
+  await middleware(t.context.req, t.context.res, next);
+  helpers.front.getConversationByUrl.should.have.been.called;
+  helpers.front.isConversationArchived.should.not.have.been.called;
+  conversation.setDefaultTopic.should.not.have.been.called;
+  next.should.not.have.been.called;
+  helpers.sendErrorResponse.should.have.been.called;
+});
+
+test('updateConversation should call setDefaultTopic if Front Conversation is archived', async (t) => {
+  // setup
+  const next = sinon.stub();
+  const middleware = updateConversation();
+  sandbox.stub(helpers.front, 'getConversationByUrl')
+    .returns(frontSuccessStub);
+  sandbox.stub(helpers.front, 'isConversationArchived')
+    .returns(true);
+  sandbox.stub(conversation, 'setDefaultTopic')
+    .returns(resolvedPromise);
+
+  // test
+  await middleware(t.context.req, t.context.res, next);
+  helpers.front.getConversationByUrl.should.have.been.called;
+  helpers.front.isConversationArchived.should.have.been.called;
+  conversation.setDefaultTopic.should.have.been.called;
+  next.should.have.been.called;
+  helpers.sendErrorResponse.should.not.have.been.called;
+});
+

--- a/test/lib/middleware/messages/support/conversation-update.test.js
+++ b/test/lib/middleware/messages/support/conversation-update.test.js
@@ -79,3 +79,22 @@ test('updateConversation should call setDefaultTopic if Front Conversation is ar
   helpers.sendErrorResponse.should.not.have.been.called;
 });
 
+test('updateConversation should not call setDefaultTopic if Front Conversation is not archived', async (t) => {
+  // setup
+  const next = sinon.stub();
+  const middleware = updateConversation();
+  sandbox.stub(helpers.front, 'getConversationByUrl')
+    .returns(frontSuccessStub);
+  sandbox.stub(helpers.front, 'isConversationArchived')
+    .returns(false);
+  sandbox.stub(conversation, 'setDefaultTopic')
+    .returns(resolvedPromise);
+
+  // test
+  await middleware(t.context.req, t.context.res, next);
+  helpers.front.getConversationByUrl.should.have.been.called;
+  helpers.front.isConversationArchived.should.have.been.called;
+  conversation.setDefaultTopic.should.not.have.been.called;
+  next.should.have.been.called;
+  helpers.sendErrorResponse.should.not.have.been.called;
+});


### PR DESCRIPTION
#### What's this PR do?
* Deprecates maintaining `Conversation.paused` property in favor of a `Conversation.isSupportTopic()` function to simplify
* Renames Conversation `supportRequested`, `supportResolved`  functions as `setSupportTopic` and `setDefaultTopic`, adds tests
* Adds tests for Member Support Message, Support Requested, and Signup Conversation Update middleware
* Starts on `lib/helpers/front`

#### How should this be reviewed?
Verify support conversations and Front messages work as expected upon staging deploy.

#### Any background context you want to provide?
TODO in future PR: More tests, update User's SMS Paused status upon Conversation update (instead of waiting for next inbound message)

#### Checklist
- [x] Tests added for new features/bug fixes.
- [x] Tested on staging.
