### PR TITLE
Create Front contacts from userId instead of mobile [pr]

### DIFF
--- a/app/models/Conversation.js
+++ b/app/models/Conversation.js
@@ -324,7 +324,7 @@ conversationSchema.methods.postMessageToSupport = function (req, message) {
     return Promise.resolve();
   }
 
-  return front.postMessage(req.platformUserId, message.text)
+  return front.postMessage(req.userId, message.text)
     .then((res) => {
       logger.debug('front.postMessage response', { body: res.body }, req);
       return res;

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,12 +1,10 @@
 'use strict';
 
 const logger = require('./logger');
-const { PhoneNumberFormat, PhoneNumberUtil } = require('google-libphonenumber');
 
 const config = require('../config/lib/helpers');
 const helpers = require('./helpers/index');
 const InternalServerError = require('../app/exceptions/InternalServerError');
-const UnprocessibleEntityError = require('../app/exceptions/UnprocessibleEntityError');
 
 // TODO: Move contents of this helper.js file into lib/helpers/index.js or to modular helpers
 
@@ -88,17 +86,4 @@ module.exports.sendResponseWithMessage = function (res, message) {
 module.exports.addBlinkSuppressHeaders = function addBlinkSuppressHeaders(res) {
   logger.debug('Adding Blink suppress headers', {}, res);
   return res.setHeader('x-blink-retry-suppress', true);
-};
-
-module.exports.formatMobileNumber = function formatMobileNumber(mobile, format = 'E164', countryCode = 'US') {
-  logger.debug('formatMobileNumber params', { mobile });
-  const phoneUtil = PhoneNumberUtil.getInstance();
-  const phoneNumberObject = phoneUtil.parse(mobile, countryCode);
-  if (!phoneUtil.isValidNumber(phoneNumberObject)) {
-    const error = new UnprocessibleEntityError('Cannot format mobile number.');
-    throw error;
-  }
-  const result = phoneUtil.format(phoneNumberObject, PhoneNumberFormat[format]);
-  logger.debug('formatMobileNumber return', { result });
-  return result;
 };

--- a/lib/helpers/front.js
+++ b/lib/helpers/front.js
@@ -1,8 +1,8 @@
 'use strict';
 
-const logger = require('../logger');
 const frontClient = require('../front');
-const requestHelper = require('./request');
+const helpers = require('../helpers');
+const logger = require('../logger');
 
 module.exports = {
   getConversationByUrl: function getConversationByUrl(url) {
@@ -18,14 +18,24 @@ module.exports = {
    */
   parseBody: function parseBody(req) {
     const body = req.body;
-    requestHelper.setOutboundMessageText(req, body.text);
-    logger.debug('origin=front', { text: req.outboundMessageText }, req);
+    helpers.request.setOutboundMessageText(req, body.text);
+    req.frontConversationUrl = body._links.related.conversation;
+    logger.debug('origin=front', {
+      text: req.outboundMessageText,
+      url: req.frontConversationUrl,
+    }, req);
     const recipients = body.recipients;
+
     const fromRecipient = recipients.find(recipient => recipient.role === 'from');
     req.agentId = fromRecipient.handle;
+
     const toRecipient = recipients.find(recipient => recipient.role === 'to');
-    requestHelper.setUserId(req, toRecipient.handle);
-    req.platformMessageId = body.id;
-    req.frontConversationUrl = body._links.related.conversation;
+    try {
+      // TODO: Remove this check once all Front Conversations saved by mobile have been archived.
+      const mobileNumber = helpers.util.formatMobileNumber(toRecipient.handle);
+      helpers.request.setPlatformUserId(req, mobileNumber);
+    } catch (err) {
+      helpers.request.setUserId(req, toRecipient.handle);
+    }
   },
 };

--- a/lib/helpers/front.js
+++ b/lib/helpers/front.js
@@ -1,6 +1,8 @@
 'use strict';
 
+const logger = require('../logger');
 const frontClient = require('../front');
+const requestHelper = require('./request');
 
 module.exports = {
   getConversationByUrl: function getConversationByUrl(url) {
@@ -8,5 +10,22 @@ module.exports = {
   },
   isConversationArchived: function isConversationArchived(frontConversation) {
     return frontConversation.status === 'archived';
+  },
+  /**
+   * Parses properties out of the body of a Front request.
+   * @see https://dev.frontapp.com/#sending-messages
+   * @param {object} req
+   */
+  parseBody: function parseBody(req) {
+    const body = req.body;
+    requestHelper.setOutboundMessageText(req, body.text);
+    logger.debug('origin=front', { text: req.outboundMessageText }, req);
+    const recipients = body.recipients;
+    const fromRecipient = recipients.find(recipient => recipient.role === 'from');
+    req.agentId = fromRecipient.handle;
+    const toRecipient = recipients.find(recipient => recipient.role === 'to');
+    requestHelper.setUserId(req, toRecipient.handle);
+    req.platformMessageId = body.id;
+    req.frontConversationUrl = body._links.related.conversation;
   },
 };

--- a/lib/helpers/index.js
+++ b/lib/helpers/index.js
@@ -13,6 +13,7 @@ const template = require('./template');
 const twilio = require('./twilio');
 const subscription = require('./subscription');
 const user = require('./user');
+const util = require('./util');
 
 // TODO: Add "Helper" postfix to prevent name confusion with npm modules like twilio.
 module.exports = {
@@ -29,4 +30,5 @@ module.exports = {
   twilio,
   subscription,
   user,
+  util,
 };

--- a/lib/helpers/util.js
+++ b/lib/helpers/util.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const { PhoneNumberFormat, PhoneNumberUtil } = require('google-libphonenumber');
+const logger = require('../logger');
+const UnprocessibleEntityError = require('../../app/exceptions/UnprocessibleEntityError');
+
+const phoneUtil = PhoneNumberUtil.getInstance();
+
+module.exports = {
+  formatMobileNumber: function formatMobileNumber(mobile, format = 'E164', countryCode = 'US') {
+    logger.debug('formatMobileNumber params', { mobile });
+    let error;
+    if (!mobile) {
+      error = new UnprocessibleEntityError('Mobile undefined.');
+    }
+    const phoneNumberObject = phoneUtil.parse(mobile, countryCode);
+    if (!phoneUtil.isValidNumber(phoneNumberObject)) {
+      error = new UnprocessibleEntityError('Cannot format mobile number.');
+      throw error;
+    }
+    const result = phoneUtil.format(phoneNumberObject, PhoneNumberFormat[format]);
+    logger.debug('formatMobileNumber return', { result });
+    return result;
+  },
+};

--- a/lib/helpers/util.js
+++ b/lib/helpers/util.js
@@ -9,15 +9,12 @@ const phoneUtil = PhoneNumberUtil.getInstance();
 module.exports = {
   formatMobileNumber: function formatMobileNumber(mobile, format = 'E164', countryCode = 'US') {
     logger.debug('formatMobileNumber params', { mobile });
-    let error;
     if (!mobile) {
-      error = new UnprocessibleEntityError('Mobile undefined.');
-      throw error;
+      throw new UnprocessibleEntityError('Mobile undefined.');
     }
     const phoneNumberObject = phoneUtil.parse(mobile, countryCode);
     if (!phoneUtil.isValidNumber(phoneNumberObject)) {
-      error = new UnprocessibleEntityError('Cannot format mobile number.');
-      throw error;
+      throw new UnprocessibleEntityError('Cannot format mobile number.');
     }
     const result = phoneUtil.format(phoneNumberObject, PhoneNumberFormat[format]);
     logger.debug('formatMobileNumber return', { result });

--- a/lib/helpers/util.js
+++ b/lib/helpers/util.js
@@ -12,6 +12,7 @@ module.exports = {
     let error;
     if (!mobile) {
       error = new UnprocessibleEntityError('Mobile undefined.');
+      throw error;
     }
     const phoneNumberObject = phoneUtil.parse(mobile, countryCode);
     if (!phoneUtil.isValidNumber(phoneNumberObject)) {

--- a/lib/middleware/messages/message-outbound-validate.js
+++ b/lib/middleware/messages/message-outbound-validate.js
@@ -23,7 +23,7 @@ module.exports = function validateOutbound(config) {
       /**
        * Verify that User has valid mobile number to send a SMS.
        */
-      const mobileNumber = helpers.formatMobileNumber(req.user.mobile);
+      const mobileNumber = helpers.util.formatMobileNumber(req.user.mobile);
       helpers.request.setPlatformUserId(req, mobileNumber);
     } catch (err) {
       return helpers.sendErrorResponseWithSuppressHeaders(res, err);

--- a/lib/middleware/messages/support/params.js
+++ b/lib/middleware/messages/support/params.js
@@ -11,6 +11,8 @@ module.exports = function supportParams() {
     if (!front.isValidRequest(req)) {
       return helpers.sendResponseWithStatusCode(res, 401, 'X-Front-Signature is not valid.');
     }
+
+    helpers.request.setPlatform(req);
     // Set template to support to indicate this was a message sent from a human support agent.
     helpers.request.setOutboundMessageTemplate(req, 'support');
 
@@ -23,7 +25,7 @@ module.exports = function supportParams() {
     const fromRecipient = recipients.find(recipient => recipient.role === 'from');
     req.agentId = fromRecipient.handle;
     const toRecipient = recipients.find(recipient => recipient.role === 'to');
-    helpers.request.setPlatformUserId(req, toRecipient.handle);
+    helpers.request.setUserId(req, toRecipient.handle);
     req.platformMessageId = body.id;
     req.frontConversationUrl = body._links.related.conversation;
 

--- a/lib/middleware/messages/support/params.js
+++ b/lib/middleware/messages/support/params.js
@@ -1,33 +1,20 @@
 'use strict';
 
 const front = require('../../../front');
-const logger = require('../../../logger');
 const helpers = require('../../../helpers');
 
-module.exports = function supportParams() {
+module.exports = function params() {
   return (req, res, next) => {
-    const body = req.body;
-
     if (!front.isValidRequest(req)) {
       return helpers.sendResponseWithStatusCode(res, 401, 'X-Front-Signature is not valid.');
     }
-
-    helpers.request.setPlatform(req);
-    // Set template to support to indicate this was a message sent from a human support agent.
-    helpers.request.setOutboundMessageTemplate(req, 'support');
-
-    // TODO: Create helpers.front and move this to its parseBody method
-    // @see https://dev.frontapp.com/#sending-messages
-
-    helpers.request.setOutboundMessageText(req, body.text);
-    logger.debug('origin=front', { text: req.outboundMessageText }, req);
-    const recipients = body.recipients;
-    const fromRecipient = recipients.find(recipient => recipient.role === 'from');
-    req.agentId = fromRecipient.handle;
-    const toRecipient = recipients.find(recipient => recipient.role === 'to');
-    helpers.request.setUserId(req, toRecipient.handle);
-    req.platformMessageId = body.id;
-    req.frontConversationUrl = body._links.related.conversation;
+    try {
+      helpers.front.parseBody(req);
+      helpers.request.setPlatform(req);
+      helpers.request.setOutboundMessageTemplate(req, 'support');
+    } catch (err) {
+      return helpers.sendErrorResponse(res, err);
+    }
 
     return next();
   };

--- a/lib/middleware/messages/support/params.js
+++ b/lib/middleware/messages/support/params.js
@@ -1,13 +1,9 @@
 'use strict';
 
-const front = require('../../../front');
 const helpers = require('../../../helpers');
 
 module.exports = function params() {
   return (req, res, next) => {
-    if (!front.isValidRequest(req)) {
-      return helpers.sendResponseWithStatusCode(res, 401, 'X-Front-Signature is not valid.');
-    }
     try {
       helpers.front.parseBody(req);
       helpers.request.setPlatform(req);

--- a/test/app/models/conversation.test.js
+++ b/test/app/models/conversation.test.js
@@ -125,10 +125,11 @@ test('postMessageToSupport does not call front.postMessage if conversation is no
 test('postMessageToSupport calls front.postMessage if conversation is SMS', async (t) => {
   sandbox.stub(front, 'postMessage')
     .returns(resolvedPromise);
+  t.context.req.userId = stubs.getUserId();
   t.context.req.conversation = smsConversation;
 
   await smsConversation.postMessageToSupport(t.context.req, message);
-  front.postMessage.should.have.been.called;
+  front.postMessage.should.have.been.calledWith(t.context.req.userId, message.text);
 });
 
 // setTopic

--- a/test/helpers/stubs.js
+++ b/test/helpers/stubs.js
@@ -165,6 +165,34 @@ module.exports = {
         status,
       };
     },
+    getInboundRequestBody: function getInboundRequestBody() {
+      const data = {
+        _links: {
+          self: 'https://api2.frontapp.com/messages/msg_55c8c149',
+          related: {
+            conversation: 'https://api2.frontapp.com/conversations/cnv_55c8c149',
+            message_replied_to: 'https://api2.frontapp.com/messages/msg_1ab23cd4',
+          },
+        },
+        id: 'msg_55c8c149',
+        type: 'custom',
+        recipients: [
+          {
+            handle: 'calculon@momsbot.com',
+            role: 'to',
+          },
+          {
+            handle: 'puppet@puppetsloth.com',
+            role: 'from',
+          },
+        ],
+        body: 'A Lannister always pays his debts.',
+        text: 'A Lannister always pays his debts.',
+        attachments: [],
+        metadata: {},
+      };
+      return data;
+    },
   },
   twilio: {
     getSmsMessageSid: function getSmsMessageSid() {

--- a/test/lib/lib-helpers/front.test.js
+++ b/test/lib/lib-helpers/front.test.js
@@ -59,8 +59,8 @@ test('parseBody should inject vars into req', (t) => {
 
   frontHelper.parseBody(t.context.req);
   helpers.request.setOutboundMessageText.should.have.been.called;
+  // TODO: Add test for setPlatformUserId when Front Conversation is saved by mobile number.
   helpers.request.setUserId.should.have.been.called;
   t.context.req.should.have.property('agentId');
-  t.context.req.should.have.property('platformMessageId');
   t.context.req.should.have.property('frontConversationUrl');
 });

--- a/test/lib/lib-helpers/front.test.js
+++ b/test/lib/lib-helpers/front.test.js
@@ -1,0 +1,66 @@
+'use strict';
+
+// libs
+require('dotenv').config();
+const test = require('ava');
+const chai = require('chai');
+const sinon = require('sinon');
+const sinonChai = require('sinon-chai');
+const httpMocks = require('node-mocks-http');
+const underscore = require('underscore');
+
+const frontClient = require('../../../lib/front');
+const helpers = require('../../../lib/helpers');
+const stubs = require('../../helpers/stubs');
+
+chai.should();
+chai.use(sinonChai);
+
+// module to be tested
+const frontHelper = require('../../../lib/helpers/front');
+
+const sandbox = sinon.sandbox.create();
+
+const noop = underscore.noop;
+const resolvedPromise = Promise.resolve();
+
+test.beforeEach((t) => {
+  t.context.req = httpMocks.createRequest();
+});
+
+test.afterEach((t) => {
+  t.context = {};
+  sandbox.restore();
+});
+
+test('getConversationByUrl should call frontClient.get', async () => {
+  sandbox.stub(frontClient, 'get')
+    .returns(resolvedPromise);
+  const url = stubs.front.getConversationUrl();
+
+  await frontHelper.getConversationByUrl(url);
+  frontClient.get.should.have.been.calledWith(url);
+});
+
+test('isConversationArchived should return boolean', (t) => {
+  const archivedConversation = stubs.front.getConversationSuccessBody();
+  t.truthy(frontHelper.isConversationArchived(archivedConversation));
+
+  const openConversation = stubs.front.getConversationSuccessBody('open');
+  t.falsy(frontHelper.isConversationArchived(openConversation));
+});
+
+test('parseBody should inject vars into req', (t) => {
+  sandbox.stub(helpers.request, 'setOutboundMessageText')
+    .returns(noop);
+  sandbox.stub(helpers.request, 'setUserId')
+    .returns(noop);
+  t.context.req.body = stubs.front.getInboundRequestBody();
+
+  frontHelper.parseBody(t.context.req);
+  helpers.request.setOutboundMessageText.should.have.been.called;
+  helpers.request.setUserId.should.have.been.called;
+  t.context.req.should.have.property('agentId');
+  t.context.req.should.have.property('platformMessageId');
+  t.context.req.should.have.property('frontConversationUrl');
+});

--- a/test/lib/middleware/messages/message-outbound-validate.test.js
+++ b/test/lib/middleware/messages/message-outbound-validate.test.js
@@ -89,14 +89,14 @@ test('validateOutbound calls sendErrorResponseWithSuppressHeaders if formatMobil
     .returns(true);
   sandbox.stub(helpers.user, 'isPaused')
     .returns(false);
-  sandbox.stub(helpers, 'formatMobileNumber')
+  sandbox.stub(helpers.util, 'formatMobileNumber')
     .throws();
 
   // test
   middleware(t.context.req, t.context.res, next);
   helpers.user.isSubscriber.should.have.been.called;
   helpers.user.isPaused.should.have.been.called;
-  helpers.formatMobileNumber.should.have.been.called;
+  helpers.util.formatMobileNumber.should.have.been.called;
   helpers.sendErrorResponseWithSuppressHeaders.should.have.been.called;
   next.should.not.have.been.called;
 });
@@ -109,14 +109,14 @@ test('validateOutbound calls next if user validates', (t) => {
     .returns(true);
   sandbox.stub(helpers.user, 'isPaused')
     .returns(false);
-  sandbox.stub(helpers, 'formatMobileNumber')
+  sandbox.stub(helpers.util, 'formatMobileNumber')
     .returns(mockUser.mobile);
 
   // test
   middleware(t.context.req, t.context.res, next);
   helpers.user.isSubscriber.should.have.been.called;
   helpers.user.isPaused.should.have.been.called;
-  helpers.formatMobileNumber.should.have.been.called;
+  helpers.util.formatMobileNumber.should.have.been.called;
   helpers.request.setPlatformUserId.should.have.been.called;
   helpers.sendErrorResponseWithSuppressHeaders.should.not.have.been.called;
   next.should.have.been.called;
@@ -130,7 +130,7 @@ test('validateOutbound does not call formatMobileNumber if platform is not SMS',
     .returns(true);
   sandbox.stub(helpers.user, 'isPaused')
     .returns(false);
-  sandbox.stub(helpers, 'formatMobileNumber')
+  sandbox.stub(helpers.util, 'formatMobileNumber')
     .returns(mockUser.mobile);
   t.context.req.platform = 'alexa';
 
@@ -138,7 +138,7 @@ test('validateOutbound does not call formatMobileNumber if platform is not SMS',
   middleware(t.context.req, t.context.res, next);
   helpers.user.isSubscriber.should.have.been.called;
   helpers.user.isPaused.should.have.been.called;
-  helpers.formatMobileNumber.should.not.have.been.called;
+  helpers.util.formatMobileNumber.should.not.have.been.called;
   helpers.request.setPlatformUserId.should.not.have.been.called;
   helpers.sendErrorResponseWithSuppressHeaders.should.not.have.been.called;
   next.should.have.been.called;

--- a/test/lib/middleware/messages/support/params.test.js
+++ b/test/lib/middleware/messages/support/params.test.js
@@ -1,0 +1,64 @@
+'use strict';
+
+require('dotenv').config();
+
+const test = require('ava');
+const chai = require('chai');
+const sinon = require('sinon');
+const sinonChai = require('sinon-chai');
+const httpMocks = require('node-mocks-http');
+const underscore = require('underscore');
+
+const helpers = require('../../../../../lib/helpers');
+
+chai.should();
+chai.use(sinonChai);
+
+// module to be tested
+const params = require('../../../../../lib/middleware/messages/support/params');
+
+const sandbox = sinon.sandbox.create();
+
+test.beforeEach((t) => {
+  sandbox.stub(helpers, 'sendErrorResponse')
+    .returns(underscore.noop);
+  t.context.req = httpMocks.createRequest();
+  t.context.res = httpMocks.createResponse();
+});
+
+test.afterEach((t) => {
+  sandbox.restore();
+  t.context = {};
+});
+
+test('params should call error if helpers.front.parseBody throws', async (t) => {
+  // setup
+  const next = sinon.stub();
+  const middleware = params();
+  sandbox.stub(helpers.front, 'parseBody')
+    .throws();
+
+  // test
+  await middleware(t.context.req, t.context.res, next);
+  next.should.not.have.been.called;
+  helpers.sendErrorResponse.should.have.been.called;
+});
+
+test('params validation', async (t) => {
+  // setup
+  const next = sinon.stub();
+  const middleware = params();
+  sandbox.stub(helpers.front, 'parseBody')
+    .returns(underscore.noop);
+  sandbox.stub(helpers.request, 'setPlatform')
+    .returns(underscore.noop);
+  sandbox.stub(helpers.request, 'setOutboundMessageTemplate')
+    .returns(underscore.noop);
+
+  // test
+  await middleware(t.context.req, t.context.res, next);
+  helpers.front.parseBody.should.have.been.called;
+  helpers.request.setPlatform.should.have.been.called;
+  helpers.request.setOutboundMessageTemplate.should.have.been.called;
+  helpers.sendErrorResponse.should.not.have.been.called;
+});


### PR DESCRIPTION
#### What's this PR do?

Alters `Conversation. postMessageToSupport ` to pass `req.userId`  instead of `req.platformUserId` for the `sender.handle` when making a Front API `POST /incoming_messages` request, so the User Id appears as the sender name within the Front app.

* Moves `helpers.formatMobileNumber` into new `lib/helpers/util`

* Completes TODO to move parsing an inbound Front message into `lib/helpers/front`

#### How should this be reviewed?
Verify replying via Front works for both variations of Conversation sender: by user id and by mobile. 

#### Any background context you want to provide?
Support agents will be able to quickly lookup the Conversation for the given User in Gambit Admin by loading gambit-admin/users/:userId to avoid having to lookup a Conversation by mobile for each Front thread.


#### Checklist
- [x] Documentation added for new features/changed endpoints. -- Updated our Support Style guide and linked to it from the [Gambit Admin wiki](https://github.com/dosomething/gambit-admin/wiki#admin-apps).
- [x] Tests added for new features/bug fixes.
- [x] Tested on staging.
