### PR TITLE
Adds additional properties to Campaigns /POST receive-message

### DIFF
--- a/lib/gambit-campaigns.js
+++ b/lib/gambit-campaigns.js
@@ -129,9 +129,12 @@ function parseReceiveMessageRequest(req) {
   const data = {
     userId: req.userId,
     campaignId: req.campaign.id,
+    campaignRunId: req.campaign.currentCampaignRun.id,
+    postType: req.campaign.botConfig.postType,
     text: req.inboundMessageText,
     mediaUrl: req.mediaUrl,
     broadcastId: req.broadcastId,
+    platform: req.platform,
   };
   if (req.keyword) {
     data.keyword = req.keyword.toLowerCase();


### PR DESCRIPTION
#### What's this PR do?
Includes the `req.platform` as well as the campaign run id and post type (introduced in https://github.com/DoSomething/gambit-campaigns/pull/1027)  in the body of a `POST /receive-message` request to Gambit Campaigns.

#### How should this be reviewed?
Verify the parameters is passed in the logs for Campaign conversations. PR coming in Gambit Campaigns to consume the new parameters.

#### Any background context you want to provide?
The Gambit Campaigns `POST /receive-message` middleware will inspect the `postType` parameter, and create a text post if set to `'text'`.

#### Relevant tickets
* https://github.com/DoSomething/gambit-campaigns/issues/1021
* https://github.com/DoSomething/gambit-campaigns/issues/1018

