### PR TITLE
Twilio smart encoding + Gambit Campaigns API updates

### DIFF
--- a/lib/gambit-campaigns.js
+++ b/lib/gambit-campaigns.js
@@ -144,7 +144,7 @@ function getCampaignActivityPayloadFromReq(req) {
 }
 
 /**
- * Posts data to the /receive-message endpoint.
+ * Posts campaign activity to Gambit Campaigns.
  */
 module.exports.postCampaignActivity = function (req) {
   const data = getCampaignActivityPayloadFromReq(req);

--- a/lib/gambit-campaigns.js
+++ b/lib/gambit-campaigns.js
@@ -246,3 +246,16 @@ module.exports.getRandomActiveCampaignNotEqualTo = function (campaignId) {
       return exports.getCampaignById(randomCampaignId);
     });
 };
+
+/**
+ * @param {Object} campaign
+ * @param {String} templateName
+ * @return {String}
+ */
+module.exports.getMessageTextFromMessageTemplate = function (campaign, templateName) {
+  const result = campaign.botConfig.templates[templateName].rendered;
+  if (!result) {
+    throw new Error(`Template ${templateName} undefined for campaignId ${campaign.id}`);
+  }
+  return result;
+};

--- a/lib/gambit-campaigns.js
+++ b/lib/gambit-campaigns.js
@@ -125,7 +125,7 @@ function getActiveCampaigns() {
  * @param {object} req
  * @return {object}
  */
-function parseReceiveMessageRequest(req) {
+function getCampaignActivityPayloadFromReq(req) {
   const data = {
     userId: req.userId,
     campaignId: req.campaign.id,
@@ -146,13 +146,13 @@ function parseReceiveMessageRequest(req) {
 /**
  * Posts data to the /receive-message endpoint.
  */
-module.exports.postReceiveMessage = function (req) {
-  const data = parseReceiveMessageRequest(req);
-  const loggerMessage = 'gambitCampaigns.postReceiveMessage';
+module.exports.postCampaignActivity = function (req) {
+  const data = getCampaignActivityPayloadFromReq(req);
+  const loggerMessage = 'gambitCampaigns.postCampaignActivity';
   logger.debug(loggerMessage, data, req);
 
   return new Promise((resolve, reject) => {
-    executePost('receive-message', data)
+    executePost('campaignActivity', data)
       .then((res) => {
         logger.debug(`${loggerMessage} response`, res.data, req);
         return resolve(res.data);

--- a/lib/helpers/replies.js
+++ b/lib/helpers/replies.js
@@ -79,9 +79,9 @@ module.exports.sendReplyWithCampaignTemplate = function (req, res, messageTempla
     return helpers.sendErrorResponse(res, 'req.campaign undefined');
   }
 
-  const template = campaign.templates[messageTemplate];
+  const template = campaign.botConfig.templates[messageTemplate];
   if (!template) {
-    return helpers.sendErrorResponse(res, `req.campaign.templates.${messageTemplate} undefined`);
+    return helpers.sendErrorResponse(res, `${messageTemplate} template undefined for campaign.`);
   }
   let messageText = template.rendered;
 

--- a/lib/helpers/replies.js
+++ b/lib/helpers/replies.js
@@ -79,11 +79,12 @@ module.exports.sendReplyWithCampaignTemplate = function (req, res, messageTempla
     return helpers.sendErrorResponse(res, 'req.campaign undefined');
   }
 
-  const template = campaign.botConfig.templates[messageTemplate];
-  if (!template) {
-    return helpers.sendErrorResponse(res, `${messageTemplate} template undefined for campaign.`);
+  let messageText;
+  try {
+    messageText = gambitCampaigns.getMessageTextFromMessageTemplate(campaign, messageTemplate);
+  } catch (err) {
+    return helpers.sendErrorResponse(res, err);
   }
-  let messageText = template.rendered;
 
   if (req.signup) {
     messageText = replaceQuantity(messageText, req.signup);

--- a/lib/helpers/replies.js
+++ b/lib/helpers/replies.js
@@ -103,7 +103,7 @@ module.exports.continueCampaign = function (req, res) {
     return helpers.sendErrorResponse(res, 'req.campaign undefined');
   }
 
-  return gambitCampaigns.postReceiveMessage(req)
+  return gambitCampaigns.postCampaignActivity(req)
     .then((gambitCampaignsRes) => {
       req.signup = gambitCampaignsRes.signup;
       logger.debug('continueCampaign', { signupId: req.signup.id }, req);

--- a/lib/middleware/messages/signup/campaign-get.js
+++ b/lib/middleware/messages/signup/campaign-get.js
@@ -8,16 +8,13 @@ module.exports = function getCampaign() {
   return (req, res, next) => gambitCampaigns.getCampaignById(req.campaignId)
     .then((campaign) => {
       req.campaign = campaign;
-      let error;
-
       // These are sanity checks. We shouldn't ever receive a Signup with Campaign not found.
       if (!campaign) {
         return helpers.sendResponseWithStatusCode(res, 404, 'Campaign not found.');
       }
       // Or for a closed Campaign.
       if (gambitCampaigns.isClosedCampaign(campaign)) {
-        error = new UnprocessibleEntityError('Campaign is closed.');
-        return helpers.sendErrorResponse(res, error);
+        return helpers.sendErrorResponse(res, new UnprocessibleEntityError('Campaign is closed.'));
       }
 
       // All Signups get forwarded to this route. If a Campaign doesn't have keywords, we don't
@@ -28,13 +25,15 @@ module.exports = function getCampaign() {
         return helpers.sendResponseWithStatusCode(res, 204, 'Campaign does not have keywords.');
       }
 
+      // TODO: Move hardcoded template param into middleware config.
       helpers.request.setOutboundMessageTemplate(req, 'externalSignupMenu');
-      const outboundMessageText = campaign.templates[req.outboundMessageTemplate].rendered;
-      helpers.request.setOutboundMessageText(req, outboundMessageText);
-      if (!req.outboundMessageText) {
-        const errorMsg = `Campaign ${req.outboundMessageTemplate} template is undefined.`;
-        error = new UnprocessibleEntityError(errorMsg);
-        return helpers.sendErrorResponse(res, error);
+
+      try {
+        const outboundMessageText = gambitCampaigns
+          .getMessageTextFromMessageTemplate(campaign, req.outboundMessageTemplate);
+        helpers.request.setOutboundMessageText(req, outboundMessageText);
+      } catch (err) {
+        return helpers.sendErrorResponse(res, err);
       }
 
       return next();

--- a/lib/twilio.js
+++ b/lib/twilio.js
@@ -63,6 +63,10 @@ module.exports.getMessagePayload = function (phone, messageText, mediaUrl) {
     to: useTestCreds ? config.testToNumber : phone,
     body: messageText,
     mediaUrl,
+    // Currently undocumented parameter to use Twilio smart encoding to replace unicode characters.
+    // @see https://www.twilio.com/docs/sms/services/copilot-smart-encoding-char-list for spec.
+    // @see https://dosomething.slack.com/archives/C5TSNJ6GL/p1523047665000246 for recommendation.
+    smartEncoded: true,
   };
 
   /**

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "git+https://github.com/DoSomething/gambit-conversations.git"
   },
   "scripts": {
-    "test-fast": "NODE=test ava --serial --fail-fast test/unit",
+    "test-fast": "NODE=test ava --serial --fail-fast",
     "test:unit": "NODE=test ava --serial test/unit",
     "test:integration": "NODE=test ava --serial test/integration",
     "test:full": "npm run lint && npm run coverage && npm run test:integration",

--- a/test/helpers/factories/campaign.js
+++ b/test/helpers/factories/campaign.js
@@ -14,12 +14,24 @@ const numericIdRange = {
  * @see https://github.com/DoSomething/gambit-campaigns/blob/master/documentation/endpoints/campaigns.md#retrieve-a-campaign
 */
 module.exports.getValidCampaign = function getValidCampaign() {
-  return {
+  const messageTemplate = stubs.getTemplate();
+  const messageText = stubs.getRandomMessageText();
+  const result = {
     id: chance.integer(numericIdRange),
     title: chance.sentence({ words: 3 }),
     currentCampaignRun: {
       id: chance.integer(numericIdRange),
     },
     keywords: [stubs.getKeyword()],
+    botConfig: {
+      postType: stubs.getPostType(),
+      templates: {},
+    },
   };
+  result.botConfig.templates[messageTemplate] = {
+    raw: messageText,
+    rendered: messageText,
+    override: true,
+  };
+  return result;
 };

--- a/test/helpers/stubs.js
+++ b/test/helpers/stubs.js
@@ -144,6 +144,9 @@ module.exports = {
   getPlatformUserId: function getPlatformUserId() {
     return mobileNumber;
   },
+  getPostType: function getPostType() {
+    return 'text';
+  },
   getRequestId: function getRequestId() {
     return '2512b2e5-76b1-4efb-916b-5d14bbb2555f';
   },

--- a/test/unit/lib/gambit-campaigns.test.js
+++ b/test/unit/lib/gambit-campaigns.test.js
@@ -18,6 +18,7 @@ const sandbox = sinon.sandbox.create();
 const gambitCampaigns = require('../../../lib/gambit-campaigns');
 
 // stubs
+const stubs = require('../../helpers/stubs');
 const campaignFactory = require('../../helpers/factories/campaign');
 
 test.afterEach(() => {
@@ -50,4 +51,18 @@ test('hasKeywords should return false when campaign does not have keywords', (t)
   campaign.keywords = [];
   const result = gambitCampaigns.hasKeywords(campaign);
   t.falsy(result);
+});
+
+// getMessageTextFromMessageTemplate
+test('getMessageTextFromMessageTemplate returns a string when template exists', () => {
+  const campaign = campaignFactory.getValidCampaign();
+  const templateName = stubs.getTemplate();
+  const result = gambitCampaigns.getMessageTextFromMessageTemplate(campaign, templateName);
+  result.should.equal(campaign.botConfig.templates[templateName].rendered);
+});
+
+test('getMessageTextFromMessageTemplate throws when template undefined', (t) => {
+  const campaign = { id: stubs.getCampaignId() };
+  const templateName = stubs.getTemplate();
+  t.throws(() => gambitCampaigns.getMessageTextFromMessageTemplate(campaign, templateName));
 });

--- a/test/unit/lib/lib-helpers/replies.test.js
+++ b/test/unit/lib/lib-helpers/replies.test.js
@@ -171,7 +171,7 @@ test('sendReply(): should call sendErrorResponse on failure', async (t) => {
 });
 
 test('continueCampaign(): sendReplyWithCampaignTemplate should be called', async (t) => {
-  sandbox.stub(gambitCampaigns, 'postReceiveMessage')
+  sandbox.stub(gambitCampaigns, 'postCampaignActivity')
     .returns(Promise.resolve(gCampResponse.data));
   sandbox.stub(repliesHelper, 'sendReplyWithCampaignTemplate')
     .returns(resolvedPromise);
@@ -181,7 +181,7 @@ test('continueCampaign(): sendReplyWithCampaignTemplate should be called', async
 });
 
 test('continueCampaign(): helpers.sendErrorResponse should be called if no campaign exists', async (t) => {
-  sandbox.stub(gambitCampaigns, 'postReceiveMessage')
+  sandbox.stub(gambitCampaigns, 'postCampaignActivity')
     .returns(Promise.reject(gCampResponse.data));
   sandbox.stub(repliesHelper, 'sendReplyWithCampaignTemplate')
     .returns(resolvedPromise);

--- a/test/unit/lib/twilio.test.js
+++ b/test/unit/lib/twilio.test.js
@@ -87,6 +87,7 @@ test('getMessagePayload should return object with valid to/from numbers when not
   result.from.should.equal(config.fromNumber);
   result.to.should.equal(mockToNumber);
   result.body.should.equal(mockMessageText);
+  result.smartEncoded.should.equal(true);
 });
 
 test('getMessagePayload should return object with test to/from numbers when testing', () => {
@@ -95,6 +96,7 @@ test('getMessagePayload should return object with test to/from numbers when test
   result.from.should.equal(config.testFromNumber);
   result.to.should.equal(config.testToNumber);
   result.body.should.equal(mockMessageText);
+  result.smartEncoded.should.equal(true);
 });
 
 // postMessage


### PR DESCRIPTION
#### What's this PR do?
* Makes name change per  https://github.com/DoSomething/gambit-campaigns/pull/1031, posting campaign activity to `/campaignActivity` instead of `/receive-message` Gambit Campaigns endpoint (identical routes, just a rename)
* Loads templates from the `botConfig` property instead of root campaign, to eventually deprecate `campaign.templates` in the Campaigns API
* Adds a `smartEncoded` parameter to encode outbound Twilio messages using Copilot's smart encoding per [Slack thread](https://dosomething.slack.com/archives/C5TSNJ6GL/p1523047665000246).

#### How should this be reviewed?
Verify campaign conversations work as expected.

#### Checklist
- [x] Tested on staging.
