### PR TITLE
New textPostConfig templates

### DIFF
--- a/config/lib/helpers/template.js
+++ b/config/lib/helpers/template.js
@@ -27,6 +27,7 @@ const templatesMap = {
     askPhoto: 'askPhoto',
     askQuantity: 'askQuantity',
     askWhyParticipated: 'askWhyParticipated',
+    botSignupConfirmed: 'botSignupConfirmed',
     completedMenu: 'completedMenu',
     externalSignupMenu: 'externalSignupMenu',
     gambitSignupMenu: 'gambitSignupMenu',
@@ -35,8 +36,11 @@ const templatesMap = {
     invalidPhoto: 'invalidPhoto',
     invalidQuantity: 'invalidQuantity',
     invalidSignupMenuCommand: 'invalidSignupMenuCommand',
+    invalidText: 'invalidText',
     invalidWhyParticipated: 'invalidWhyParticipated',
     signupMenu: 'signupMenu',
+    textPostCompleted: 'textPostCompleted',
+    webSignupConfirmed: 'webSignupConfirmed',
   },
   gambitConversationsTemplates: {
     badWords: {


### PR DESCRIPTION
#### What's this PR do?
Adds new Gambit Campaigns templates per https://github.com/dosomething/gambit-campaigns/pull/1033

#### How should this be reviewed?
Both text and photo postType campaigns should work on both `master` and `askText` branches of Gambit Campaigns. 

#### Any background context you want to provide?
Once https://github.com/dosomething/gambit-campaigns/pull/1033 is merged, we can change the outbound template of a Signup Menu from `externalSignupMenu` to `webSignupConfirmed`.

#### Relevant tickets
#304 

#### Checklist
- [ ] Tested on staging.
