### PR TITLE
Signup middleware refactor + tests [pr]

### DIFF
--- a/app/routes/messages/signup.js
+++ b/app/routes/messages/signup.js
@@ -15,6 +15,8 @@ const validateOutboundMessageMiddleware = require('../../../lib/middleware/messa
 const getConversationMiddleware = require('../../../lib/middleware/messages/conversation-get');
 const createConversationMiddleware = require('../../../lib/middleware/messages/conversation-create');
 const getCampaignMiddleware = require('../../../lib/middleware/messages/signup/campaign-get');
+const validateCampaignMiddleware = require('../../../lib/middleware/messages/signup/campaign-validate');
+const parseCampaignMiddleware = require('../../../lib/middleware/messages/signup/campaign-parse');
 const updateConversationMiddleware = require('../../../lib/middleware/messages/signup/conversation-update');
 const loadOutboundMessageMiddleware = require('../../../lib/middleware/messages/message-outbound-load');
 const createOutboundMessageMiddleware = require('../../../lib/middleware/messages/message-outbound-create');
@@ -22,19 +24,24 @@ const sendOutboundMessageMiddleware = require('../../../lib/middleware/messages/
 
 router.use(paramsMiddleware());
 
-// Validate Campaign Signup should send a Signup Menu message.
+// Fetch campaign for campaignId param.
 router.use(getCampaignMiddleware());
+// Validate the signup campaign should trigger a message.
+router.use(validateCampaignMiddleware());
+// Parse campaign for message to send.
+router.use(parseCampaignMiddleware());
 
-// Fetch Northstar User.
+// Fetch user for userId param.
 router.use(getUserMiddleware(getUserConfig));
 router.use(validateOutboundMessageMiddleware(outboundMessageConfig));
 
-// Find or create Conversation.
+// Find or create conversation for user.
 router.use(getConversationMiddleware());
 router.use(createConversationMiddleware());
-
+// Set the conversation campaign.
 router.use(updateConversationMiddleware());
 
+// Send signup message.
 router.use(loadOutboundMessageMiddleware(outboundMessageConfig));
 router.use(createOutboundMessageMiddleware(outboundMessageConfig));
 router.use(sendOutboundMessageMiddleware());

--- a/config/lib/helpers/campaign.js
+++ b/config/lib/helpers/campaign.js
@@ -1,0 +1,8 @@
+'use strict';
+
+module.exports = {
+  signupMessageTemplateNamesByPostType: {
+    photo: 'webStartPhotoPost',
+    text: 'webAskText',
+  },
+};

--- a/documentation/endpoints/messages.md
+++ b/documentation/endpoints/messages.md
@@ -246,7 +246,7 @@ curl -X "POST" "http://localhost:5100/api/v2/messages?origin=signup" \
         "createdAt": "2018-02-07T21:34:44.382Z",
         "text": "Hey - this is Freddie from DoSomething. Thanks for joining Two Books Blue Books!\n\nIn some low-income neighborhoods, there is only one book for every 300 children.\n\nThe solution is simple: Host a Dr. Seuss book drive to benefit kids in family shelters.\n\nMake sure to take a photo of what you did! When you have Collected some Books, text START to share your photo.",
         "direction": "outbound-api-send",
-        "template": "externalSignupMenu",
+        "template": "webStartPhotoPost",
         "conversationId": "59b0de57e9f1ae00126cd731",
         "campaignId": 2299,
         "topic": "campaign",

--- a/lib/helpers/campaign.js
+++ b/lib/helpers/campaign.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const config = require('../../config/lib/helpers/campaign');
+
+/**
+ * @param {Object} campaign
+ * @return {String}
+ */
+function getPostTypeFromCampaign(campaign) {
+  return campaign.botConfig.postType;
+}
+
+/**
+ * @param {Object} campaign
+ * @return {String}
+ */
+function getSignupMessageTemplateNameFromCampaign(campaign) {
+  const postType = module.exports.getPostTypeFromCampaign(campaign);
+  return config.signupMessageTemplateNamesByPostType[postType];
+}
+
+module.exports = {
+  getPostTypeFromCampaign,
+  getSignupMessageTemplateNameFromCampaign,
+};

--- a/lib/helpers/campaign.js
+++ b/lib/helpers/campaign.js
@@ -1,6 +1,15 @@
 'use strict';
 
+const gambitCampaigns = require('../gambit-campaigns');
 const config = require('../../config/lib/helpers/campaign');
+
+/**
+ * @param {Number} campaignId
+ * @return {String}
+ */
+function fetchById(campaignId) {
+  return gambitCampaigns.getCampaignById(campaignId);
+}
 
 /**
  * @param {Object} campaign
@@ -20,6 +29,7 @@ function getSignupMessageTemplateNameFromCampaign(campaign) {
 }
 
 module.exports = {
+  fetchById,
   getPostTypeFromCampaign,
   getSignupMessageTemplateNameFromCampaign,
 };

--- a/lib/helpers/campaign.js
+++ b/lib/helpers/campaign.js
@@ -23,7 +23,7 @@ function getPostTypeFromCampaign(campaign) {
  * @param {Object} campaign
  * @return {String}
  */
-function getSignupMessageTemplateNameFromCampaign(campaign) {
+function getWebSignupMessageTemplateNameFromCampaign(campaign) {
   const postType = module.exports.getPostTypeFromCampaign(campaign);
   return config.signupMessageTemplateNamesByPostType[postType];
 }
@@ -31,5 +31,5 @@ function getSignupMessageTemplateNameFromCampaign(campaign) {
 module.exports = {
   fetchById,
   getPostTypeFromCampaign,
-  getSignupMessageTemplateNameFromCampaign,
+  getWebSignupMessageTemplateNameFromCampaign,
 };

--- a/lib/helpers/index.js
+++ b/lib/helpers/index.js
@@ -4,6 +4,7 @@ const analytics = require('./analytics');
 const attachments = require('./attachments');
 const broadcast = require('./broadcast');
 const cache = require('./cache');
+const campaign = require('./campaign');
 const front = require('./front');
 const macro = require('./macro');
 const request = require('./request');
@@ -21,6 +22,7 @@ module.exports = {
   attachments,
   broadcast,
   cache,
+  campaign,
   front,
   macro,
   request,

--- a/lib/middleware/messages/signup/campaign-get.js
+++ b/lib/middleware/messages/signup/campaign-get.js
@@ -1,41 +1,15 @@
 'use strict';
 
 const gambitCampaigns = require('../../../gambit-campaigns');
-const UnprocessibleEntityError = require('../../../../app/exceptions/UnprocessibleEntityError');
 const helpers = require('../../../helpers');
 
 module.exports = function getCampaign() {
   return (req, res, next) => gambitCampaigns.getCampaignById(req.campaignId)
     .then((campaign) => {
-      req.campaign = campaign;
-      // These are sanity checks. We shouldn't ever receive a Signup with Campaign not found.
       if (!campaign) {
         return helpers.sendResponseWithStatusCode(res, 404, 'Campaign not found.');
       }
-      // Or for a closed Campaign.
-      if (gambitCampaigns.isClosedCampaign(campaign)) {
-        return helpers.sendErrorResponse(res, new UnprocessibleEntityError('Campaign is closed.'));
-      }
-
-      // All Signups get forwarded to this route. If a Campaign doesn't have keywords, we don't
-      // want to send a confirmation message for this Signup, as a User wouldn't be able to return
-      // back to the Campaign.
-      if (!gambitCampaigns.hasKeywords(campaign)) {
-        helpers.addBlinkSuppressHeaders(res);
-        return helpers.sendResponseWithStatusCode(res, 204, 'Campaign does not have keywords.');
-      }
-
-      // TODO: Move hardcoded template param into middleware config.
-      helpers.request.setOutboundMessageTemplate(req, 'externalSignupMenu');
-
-      try {
-        const outboundMessageText = gambitCampaigns
-          .getMessageTextFromMessageTemplate(campaign, req.outboundMessageTemplate);
-        helpers.request.setOutboundMessageText(req, outboundMessageText);
-      } catch (err) {
-        return helpers.sendErrorResponse(res, err);
-      }
-
+      req.campaign = campaign;
       return next();
     })
     .catch(err => helpers.sendErrorResponse(res, err));

--- a/lib/middleware/messages/signup/campaign-get.js
+++ b/lib/middleware/messages/signup/campaign-get.js
@@ -1,13 +1,14 @@
 'use strict';
 
-const gambitCampaigns = require('../../../gambit-campaigns');
+const NotFoundError = require('../../../../app/exceptions/NotFoundError');
 const helpers = require('../../../helpers');
 
 module.exports = function getCampaign() {
-  return (req, res, next) => gambitCampaigns.getCampaignById(req.campaignId)
+  return (req, res, next) => helpers.campaign.fetchById(req.campaignId)
     .then((campaign) => {
       if (!campaign) {
-        return helpers.sendResponseWithStatusCode(res, 404, 'Campaign not found.');
+        const errorMessage = `Campaign ${req.campaignId} not found.`;
+        return helpers.sendErrorResponse(res, new NotFoundError(errorMessage));
       }
       req.campaign = campaign;
       return next();

--- a/lib/middleware/messages/signup/campaign-parse.js
+++ b/lib/middleware/messages/signup/campaign-parse.js
@@ -6,7 +6,7 @@ const helpers = require('../../../helpers');
 module.exports = function parseCampaign() {
   return (req, res, next) => {
     try {
-      const template = helpers.campaign.getSignupMessageTemplateNameFromCampaign(req.campaign);
+      const template = helpers.campaign.getWebSignupMessageTemplateNameFromCampaign(req.campaign);
       helpers.request.setOutboundMessageTemplate(req, template);
       const text = gambitCampaigns.getMessageTextFromMessageTemplate(req.campaign, template);
       helpers.request.setOutboundMessageText(req, text);

--- a/lib/middleware/messages/signup/campaign-parse.js
+++ b/lib/middleware/messages/signup/campaign-parse.js
@@ -3,15 +3,13 @@
 const gambitCampaigns = require('../../../gambit-campaigns');
 const helpers = require('../../../helpers');
 
-module.exports = function getCampaign() {
+module.exports = function parseCampaign() {
   return (req, res, next) => {
-    // TODO: Move hardcoded template param into middleware config.
-    helpers.request.setOutboundMessageTemplate(req, 'externalSignupMenu');
-
     try {
-      const outboundMessageText = gambitCampaigns
-        .getMessageTextFromMessageTemplate(req.campaign, req.outboundMessageTemplate);
-      helpers.request.setOutboundMessageText(req, outboundMessageText);
+      const template = helpers.campaign.getSignupMessageTemplateNameFromCampaign(req.campaign);
+      helpers.request.setOutboundMessageTemplate(req, template);
+      const text = gambitCampaigns.getMessageTextFromMessageTemplate(req.campaign, template);
+      helpers.request.setOutboundMessageText(req, text);
     } catch (err) {
       return helpers.sendErrorResponse(res, err);
     }

--- a/lib/middleware/messages/signup/campaign-parse.js
+++ b/lib/middleware/messages/signup/campaign-parse.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const gambitCampaigns = require('../../../gambit-campaigns');
+const helpers = require('../../../helpers');
+
+module.exports = function getCampaign() {
+  return (req, res, next) => {
+    // TODO: Move hardcoded template param into middleware config.
+    helpers.request.setOutboundMessageTemplate(req, 'externalSignupMenu');
+
+    try {
+      const outboundMessageText = gambitCampaigns
+        .getMessageTextFromMessageTemplate(req.campaign, req.outboundMessageTemplate);
+      helpers.request.setOutboundMessageText(req, outboundMessageText);
+    } catch (err) {
+      return helpers.sendErrorResponse(res, err);
+    }
+
+    return next();
+  };
+};

--- a/lib/middleware/messages/signup/campaign-validate.js
+++ b/lib/middleware/messages/signup/campaign-validate.js
@@ -4,7 +4,7 @@ const gambitCampaigns = require('../../../gambit-campaigns');
 const UnprocessibleEntityError = require('../../../../app/exceptions/UnprocessibleEntityError');
 const helpers = require('../../../helpers');
 
-module.exports = function getCampaign() {
+module.exports = function validateCampaign() {
   return (req, res, next) => {
     if (gambitCampaigns.isClosedCampaign(req.campaign)) {
       return helpers.sendErrorResponse(res, new UnprocessibleEntityError('Campaign is closed.'));

--- a/lib/middleware/messages/signup/campaign-validate.js
+++ b/lib/middleware/messages/signup/campaign-validate.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const gambitCampaigns = require('../../../gambit-campaigns');
+const UnprocessibleEntityError = require('../../../../app/exceptions/UnprocessibleEntityError');
+const helpers = require('../../../helpers');
+
+module.exports = function getCampaign() {
+  return (req, res, next) => {
+    if (gambitCampaigns.isClosedCampaign(req.campaign)) {
+      return helpers.sendErrorResponse(res, new UnprocessibleEntityError('Campaign is closed.'));
+    }
+
+    // All Signups get forwarded to this route. If a Campaign doesn't have keywords, we don't
+    // want to send a confirmation message for this Signup, as a User wouldn't be able to return
+    // back to the Campaign.
+    if (!gambitCampaigns.hasKeywords(req.campaign)) {
+      helpers.addBlinkSuppressHeaders(res);
+      return helpers.sendResponseWithStatusCode(res, 204, 'Campaign does not have keywords.');
+    }
+
+    return next();
+  };
+};

--- a/test/helpers/stubs.js
+++ b/test/helpers/stubs.js
@@ -150,6 +150,9 @@ module.exports = {
   getRequestId: function getRequestId() {
     return '2512b2e5-76b1-4efb-916b-5d14bbb2555f';
   },
+  getSignupMessageTemplateName: function getSignupMessageTemplateName() {
+    return 'webAskText';
+  },
   getTemplate: function getTemplate() {
     return 'askSignup';
   },

--- a/test/unit/lib/lib-helpers/campaign.test.js
+++ b/test/unit/lib/lib-helpers/campaign.test.js
@@ -6,6 +6,7 @@ const chai = require('chai');
 const sinon = require('sinon');
 const sinonChai = require('sinon-chai');
 
+const gambitCampaigns = require('../../../../lib/gambit-campaigns');
 const campaignHelperConfig = require('../../../../config/lib/helpers/campaign');
 
 const stubs = require('../../../helpers/stubs');
@@ -13,6 +14,7 @@ const campaignFactory = require('../../../helpers/factories/campaign');
 
 const campaignStub = campaignFactory.getValidCampaign();
 const postTypeStub = stubs.getPostType();
+const campaignLookupStub = () => Promise.resolve(campaignStub);
 
 chai.should();
 chai.use(sinonChai);
@@ -25,6 +27,17 @@ const sandbox = sinon.sandbox.create();
 
 test.afterEach(() => {
   sandbox.restore();
+});
+
+// fetchById
+test('fetchById calls gambitCampaigns.getCampaignById', async () => {
+  sandbox.stub(gambitCampaigns, 'getCampaignById')
+    .returns(campaignLookupStub);
+  const campaignId = campaignStub.id;
+
+  const result = await campaignHelper.fetchById(campaignId);
+  gambitCampaigns.getCampaignById.should.have.been.calledWith(campaignId);
+  result.should.deep.equal(campaignLookupStub);
 });
 
 // getPostTypeFromCampaign

--- a/test/unit/lib/lib-helpers/campaign.test.js
+++ b/test/unit/lib/lib-helpers/campaign.test.js
@@ -1,0 +1,41 @@
+'use strict';
+
+require('dotenv').config();
+const test = require('ava');
+const chai = require('chai');
+const sinon = require('sinon');
+const sinonChai = require('sinon-chai');
+
+const campaignHelperConfig = require('../../../../config/lib/helpers/campaign');
+
+const stubs = require('../../../helpers/stubs');
+const campaignFactory = require('../../../helpers/factories/campaign');
+
+const campaignStub = campaignFactory.getValidCampaign();
+const postTypeStub = stubs.getPostType();
+
+chai.should();
+chai.use(sinonChai);
+
+// module to be tested
+const campaignHelper = require('../../../../lib/helpers/campaign');
+
+// sinon sandbox object
+const sandbox = sinon.sandbox.create();
+
+test.afterEach(() => {
+  sandbox.restore();
+});
+
+// getPostTypeFromCampaign
+test('getPostTypeFromCampaign should return a string', () => {
+  const result = campaignHelper.getPostTypeFromCampaign(campaignStub);
+  result.should.equal(postTypeStub);
+});
+
+// getSignupMessageTemplateNameFromCampaign
+test('getSignupMessageTemplateNameFromCampaign returns string from config.signupMessageTemplateNamesByPostType', () => {
+  const result = campaignHelper.getSignupMessageTemplateNameFromCampaign(campaignStub);
+  const templateName = campaignHelperConfig.signupMessageTemplateNamesByPostType[postTypeStub];
+  result.should.equal(templateName);
+});

--- a/test/unit/lib/lib-helpers/campaign.test.js
+++ b/test/unit/lib/lib-helpers/campaign.test.js
@@ -46,9 +46,9 @@ test('getPostTypeFromCampaign should return a string', () => {
   result.should.equal(postTypeStub);
 });
 
-// getSignupMessageTemplateNameFromCampaign
-test('getSignupMessageTemplateNameFromCampaign returns string from config.signupMessageTemplateNamesByPostType', () => {
-  const result = campaignHelper.getSignupMessageTemplateNameFromCampaign(campaignStub);
+// getWebSignupMessageTemplateNameFromCampaign
+test('getWebSignupMessageTemplateNameFromCampaign returns string from config.signupMessageTemplateNamesByPostType', () => {
+  const result = campaignHelper.getWebSignupMessageTemplateNameFromCampaign(campaignStub);
   const templateName = campaignHelperConfig.signupMessageTemplateNamesByPostType[postTypeStub];
   result.should.equal(templateName);
 });

--- a/test/unit/lib/middleware/messages/signup/campaign-get.test.js
+++ b/test/unit/lib/middleware/messages/signup/campaign-get.test.js
@@ -1,0 +1,88 @@
+'use strict';
+
+require('dotenv').config();
+
+const test = require('ava');
+const chai = require('chai');
+const sinon = require('sinon');
+const sinonChai = require('sinon-chai');
+const httpMocks = require('node-mocks-http');
+const underscore = require('underscore');
+const Promise = require('bluebird');
+
+const helpers = require('../../../../../../lib/helpers');
+const campaignFactory = require('../../../../../helpers/factories/campaign');
+
+// stubs
+const sendErrorResponseStub = underscore.noop;
+const campaignStub = campaignFactory.getValidCampaign();
+const campaignIdStub = campaignStub.id;
+const campaignLookupStub = () => Promise.resolve(campaignStub);
+const campaignLookupFailStub = () => Promise.reject({ message: 'Epic fail' });
+const campaignLookupNotFoundStub = () => Promise.resolve(null);
+
+// setup "x.should.y" assertion style
+chai.should();
+chai.use(sinonChai);
+
+// module to be tested
+const getCampaign = require('../../../../../../lib/middleware/messages/signup/campaign-get');
+
+// sinon sandbox object
+const sandbox = sinon.sandbox.create();
+
+test.beforeEach((t) => {
+  sandbox.stub(helpers, 'sendErrorResponse')
+    .returns(sendErrorResponseStub);
+  t.context.req = httpMocks.createRequest();
+  t.context.req.campaignId = campaignIdStub;
+  t.context.res = httpMocks.createResponse();
+});
+
+test.afterEach((t) => {
+  sandbox.restore();
+  t.context = {};
+});
+
+/**
+ * Tests
+ */
+test('getCampaign should call fetchById and inject campaign property to req', async (t) => {
+  const next = sinon.stub();
+  const middleware = getCampaign();
+  sandbox.stub(helpers.campaign, 'fetchById')
+    .callsFake(campaignLookupStub);
+
+  // test
+  await middleware(t.context.req, t.context.res, next);
+  t.context.req.campaign.should.deep.equal(campaignStub);
+  helpers.sendErrorResponse.should.not.have.been.called;
+  next.should.have.been.called;
+});
+
+
+test('getCampaign should call sendErrorResponse if campaign not found', async (t) => {
+  const next = sinon.stub();
+  const middleware = getCampaign();
+  sandbox.stub(helpers.campaign, 'fetchById')
+    .callsFake(campaignLookupNotFoundStub);
+
+  // test
+  await middleware(t.context.req, t.context.res, next);
+  helpers.sendErrorResponse.should.have.been.called;
+  t.context.req.should.not.have.property('campaign');
+  next.should.not.have.been.called;
+});
+
+test('getCampaign should call sendErrorResponse if fetchById fails', async (t) => {
+  const next = sinon.stub();
+  const middleware = getCampaign();
+  sandbox.stub(helpers.campaign, 'fetchById')
+    .callsFake(campaignLookupFailStub);
+
+  // test
+  await middleware(t.context.req, t.context.res, next);
+  helpers.sendErrorResponse.should.have.been.called;
+  t.context.req.should.not.have.property('campaign');
+  next.should.not.have.been.called;
+});

--- a/test/unit/lib/middleware/messages/signup/campaign-parse.test.js
+++ b/test/unit/lib/middleware/messages/signup/campaign-parse.test.js
@@ -64,7 +64,7 @@ test('parseCampaign calls request helper functions with campaign helper results'
   helpers.request.setOutboundMessageText.should.have.been.calledWith(t.context.req, textStub);
 });
 
-test('parseCampaign calls request helper functions with campaign helper results', async (t) => {
+test('parseCampaign sends sendErrorResponse if getSignupMessageTemplateName throws', async (t) => {
   const next = sinon.stub();
   const middleware = parseCampaign();
   sandbox.stub(helpers.campaign, 'getSignupMessageTemplateNameFromCampaign')

--- a/test/unit/lib/middleware/messages/signup/campaign-parse.test.js
+++ b/test/unit/lib/middleware/messages/signup/campaign-parse.test.js
@@ -50,7 +50,7 @@ test.afterEach((t) => {
 test('parseCampaign calls request helper functions with campaign helper results', async (t) => {
   const next = sinon.stub();
   const middleware = parseCampaign();
-  sandbox.stub(helpers.campaign, 'getSignupMessageTemplateNameFromCampaign')
+  sandbox.stub(helpers.campaign, 'getWebSignupMessageTemplateNameFromCampaign')
     .returns(templateStub);
   sandbox.stub(gambitCampaigns, 'getMessageTextFromMessageTemplate')
     .returns(textStub);
@@ -67,7 +67,7 @@ test('parseCampaign calls request helper functions with campaign helper results'
 test('parseCampaign sends sendErrorResponse if getSignupMessageTemplateName throws', async (t) => {
   const next = sinon.stub();
   const middleware = parseCampaign();
-  sandbox.stub(helpers.campaign, 'getSignupMessageTemplateNameFromCampaign')
+  sandbox.stub(helpers.campaign, 'getWebSignupMessageTemplateNameFromCampaign')
     .throws();
 
   // test

--- a/test/unit/lib/middleware/messages/signup/campaign-parse.test.js
+++ b/test/unit/lib/middleware/messages/signup/campaign-parse.test.js
@@ -1,0 +1,77 @@
+'use strict';
+
+require('dotenv').config();
+
+const test = require('ava');
+const chai = require('chai');
+const sinon = require('sinon');
+const sinonChai = require('sinon-chai');
+const httpMocks = require('node-mocks-http');
+const underscore = require('underscore');
+
+const gambitCampaigns = require('../../../../../../lib/gambit-campaigns');
+const helpers = require('../../../../../../lib/helpers');
+const stubs = require('../../../../../helpers/stubs');
+const campaignFactory = require('../../../../../helpers/factories/campaign');
+
+// setup "x.should.y" assertion style
+chai.should();
+chai.use(sinonChai);
+
+const templateStub = stubs.getSignupMessageTemplateName();
+const textStub = stubs.getRandomMessageText();
+
+// module to be tested
+const parseCampaign = require('../../../../../../lib/middleware/messages/signup/campaign-parse');
+
+// sinon sandbox object
+const sandbox = sinon.sandbox.create();
+
+test.beforeEach((t) => {
+  sandbox.stub(helpers.request, 'setOutboundMessageTemplate')
+    .returns(underscore.noop);
+  sandbox.stub(helpers.request, 'setOutboundMessageText')
+    .returns(underscore.noop);
+  sandbox.stub(helpers, 'sendErrorResponse')
+    .returns(underscore.noop);
+  t.context.req = httpMocks.createRequest();
+  t.context.req.campaign = campaignFactory.getValidCampaign();
+  t.context.res = httpMocks.createResponse();
+});
+
+test.afterEach((t) => {
+  sandbox.restore();
+  t.context = {};
+});
+
+/**
+ * Tests
+ */
+test('parseCampaign calls request helper functions with campaign helper results', async (t) => {
+  const next = sinon.stub();
+  const middleware = parseCampaign();
+  sandbox.stub(helpers.campaign, 'getSignupMessageTemplateNameFromCampaign')
+    .returns(templateStub);
+  sandbox.stub(gambitCampaigns, 'getMessageTextFromMessageTemplate')
+    .returns(textStub);
+
+  // test
+  await middleware(t.context.req, t.context.res, next);
+  helpers.sendErrorResponse.should.not.have.been.called;
+  next.should.have.been.called;
+  helpers.request
+    .setOutboundMessageTemplate.should.have.been.calledWith(t.context.req, templateStub);
+  helpers.request.setOutboundMessageText.should.have.been.calledWith(t.context.req, textStub);
+});
+
+test('parseCampaign calls request helper functions with campaign helper results', async (t) => {
+  const next = sinon.stub();
+  const middleware = parseCampaign();
+  sandbox.stub(helpers.campaign, 'getSignupMessageTemplateNameFromCampaign')
+    .throws();
+
+  // test
+  await middleware(t.context.req, t.context.res, next);
+  helpers.sendErrorResponse.should.have.been.called;
+  next.should.have.not.been.called;
+});

--- a/test/unit/lib/middleware/messages/signup/campaign-validate.test.js
+++ b/test/unit/lib/middleware/messages/signup/campaign-validate.test.js
@@ -1,0 +1,87 @@
+'use strict';
+
+require('dotenv').config();
+
+const test = require('ava');
+const chai = require('chai');
+const sinon = require('sinon');
+const sinonChai = require('sinon-chai');
+const httpMocks = require('node-mocks-http');
+const underscore = require('underscore');
+
+const gambitCampaigns = require('../../../../../../lib/gambit-campaigns');
+const helpers = require('../../../../../../lib/helpers');
+const campaignFactory = require('../../../../../helpers/factories/campaign');
+
+// setup "x.should.y" assertion style
+chai.should();
+chai.use(sinonChai);
+
+// module to be tested
+const validateCampaign = require('../../../../../../lib/middleware/messages/signup/campaign-validate');
+
+// sinon sandbox object
+const sandbox = sinon.sandbox.create();
+
+test.beforeEach((t) => {
+  sandbox.stub(helpers, 'addBlinkSuppressHeaders')
+    .returns(underscore.noop);
+  sandbox.stub(helpers, 'sendErrorResponse')
+    .returns(underscore.noop);
+  sandbox.stub(helpers, 'sendResponseWithStatusCode')
+    .returns(underscore.noop);
+  t.context.req = httpMocks.createRequest();
+  t.context.req.campaign = campaignFactory.getValidCampaign();
+  t.context.res = httpMocks.createResponse();
+});
+
+test.afterEach((t) => {
+  sandbox.restore();
+  t.context = {};
+});
+
+/**
+ * Tests
+ */
+test('validateCampaign should call sendErrorResponse if campaign is closed', async (t) => {
+  const next = sinon.stub();
+  const middleware = validateCampaign();
+  sandbox.stub(gambitCampaigns, 'isClosedCampaign')
+    .returns(true);
+
+  // test
+  await middleware(t.context.req, t.context.res, next);
+  helpers.sendErrorResponse.should.have.been.called;
+  next.should.not.have.been.called;
+});
+
+test('validateCampaign should send 204 if campaign does not have keywords', async (t) => {
+  const next = sinon.stub();
+  const middleware = validateCampaign();
+  sandbox.stub(gambitCampaigns, 'isClosedCampaign')
+    .returns(false);
+  sandbox.stub(gambitCampaigns, 'hasKeywords')
+    .returns(false);
+
+  // test
+  await middleware(t.context.req, t.context.res, next);
+  helpers.sendResponseWithStatusCode.should.have.been.called;
+  helpers.addBlinkSuppressHeaders.should.have.been.called;
+  helpers.sendErrorResponse.should.not.have.been.called;
+  next.should.not.have.been.called;
+});
+
+test('validateCampaign should next if campaign is not closed and has keywords', async (t) => {
+  const next = sinon.stub();
+  const middleware = validateCampaign();
+  sandbox.stub(gambitCampaigns, 'isClosedCampaign')
+    .returns(false);
+  sandbox.stub(gambitCampaigns, 'hasKeywords')
+    .returns(true);
+
+  // test
+  await middleware(t.context.req, t.context.res, next);
+  helpers.sendResponseWithStatusCode.should.not.have.been.called;
+  helpers.sendErrorResponse.should.not.have.been.called;
+  next.should.have.been.called;
+});


### PR DESCRIPTION
#### What's this PR do?

Splits out the `lib/middleware/signup/campaign-get` into separate files for `campaign-get`, `campaign-validate`, and `campaign-parse`, and adds tests.

* Deprecates use of the `externalSignupMenu` template in favor of the `webStartPhotoPost` and `webAskText` templates introduced in https://github.com/DoSomething/gambit-campaigns/pull/1035

* Starts on a campaign helper, adding functions like `getSignupMessageTemplateNameFromCampaign` to set the outbound template in a signup message request. 

#### How should this be reviewed?
Upon staging deploy, send the `staging` command to our Gambit Slack bot to test sending web signup messages for a photo post campaign (MIRRORBOT) and a text post campaigns (LUCKYBOT). The `POST /messages?origin=signup` request should return an outbound message with `webStartPhotoPost` and `webAskText` templates respectively.

#### Any background context you want to provide?
* Once this is deployed to production, we'll remove the templates we're no longer using from the Gambit Campaigns response.

* Eventually want to move `gambitCampaigns` functions like `isClosedCampaign` and `hasKeywords` into the campaign helper, to decouple these functions from fetching campaign data -- the source is currently the Gambit Campaigns API, but could one day be Phoenix or GraphQL

#### Relevant tickets
* #317 
* https://github.com/DoSomething/gambit-campaigns/issues/1021

#### Checklist
- [x] Documentation added for new features/changed endpoints.
- [x] Tests added for new features/bug fixes.
- [x] Tested on staging.
