### PR TITLE
Fix 404 errors when user is not found while updating message delivery metadata

### DIFF
--- a/config/lib/middleware/messages/update/user-get.js
+++ b/config/lib/middleware/messages/update/user-get.js
@@ -1,5 +1,5 @@
 'use strict';
 
 module.exports = {
-  shouldSendErrorIfNotFound: false,
+  shouldSendErrorIfNotFound: true,
 };


### PR DESCRIPTION
#### What's this PR do?
It fixes the 404 error storm we get when users are not found while updating message delivery metadata. These error will now be suppressed in Blink and not retried.

#### How should this be reviewed?
- 👀 

#### Relevant tickets
Fixes #316 
