### PR TITLE
prioritize userId over platformUserId

### DIFF
--- a/lib/helpers/user.js
+++ b/lib/helpers/user.js
@@ -16,16 +16,16 @@ module.exports = {
     return northstar.fetchUserByMobile(mobileNumber);
   },
   /**
-   * fetchFromReq - The conversation's `platformUserId` has precedence over `userId`
+   * fetchFromReq - The conversation's `userId` has precedence over `platformUserId`
    *
    * @param  {Object} req
    * @return {Promise}
    */
   fetchFromReq: function fetchFromReq(req) {
-    if (req.platformUserId) {
-      return this.fetchByMobile(req.platformUserId);
+    if (req.userId) {
+      return this.fetchById(req.userId);
     }
-    return this.fetchById(req.userId);
+    return this.fetchByMobile(req.platformUserId);
   },
   /**
    * @param {string} stringToEncrypt

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gambit-conversations",
-  "version": "2.4.1",
+  "version": "2.5.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "engines": {
     "node": "6.13.1",
-    "npm": "5.8.0"
+    "npm": "5.7.1"
   },
   "dependencies": {
     "@dosomething/northstar-js": "git://github.com/DoSomething/northstar-js.git",

--- a/test/integration/app/v2-routes/messages-update.test.js
+++ b/test/integration/app/v2-routes/messages-update.test.js
@@ -9,6 +9,7 @@ const Message = require('../../../../app/models/Message');
 const stubs = require('../../../helpers/stubs');
 const subscriptionHelper = require('../../../../config/lib/helpers/subscription');
 const seederHelper = require('../../../helpers/integration/seeder');
+const northstarConfig = require('../../../../config/lib/northstar');
 
 const should = chai.should();
 const expect = chai.expect;
@@ -66,7 +67,7 @@ test('PATCH /api/v2/messages/:id should update the message failedAt and failureD
    * TODO: Should be using routes integration helper
    */
   nock(integrationHelper.routes.northstar.baseURI)
-    .get(`/users/mobile/${stubs.getMobileNumber()}`)
+    .get(`/users/${northstarConfig.getUserFields.id}/${stubs.getUserId()}`)
     .reply(200, stubs.northstar.getUser());
 
   /**


### PR DESCRIPTION
#### What's this PR do?
- It retrieves the Northstar user based on the Conversation's `userId` first if it exists. Otherwise, fallback to `platformUserId`.
- Downgrades NPM to `5.7.1` to keep it consistent with G-Campaigns. Also because `5.8.0` it doesn't work correctly in my local env, but `5.7.1` does. 

#### How should this be reviewed?
- 👀 
- Run all tests including integration.

#### Relevant tickets
Fixes #315 

#### Tasks
- [x] tested on staging.