### PR TITLE
Bug/312 save outbound delivery failure metadata

### DIFF
--- a/app/models/Conversation.js
+++ b/app/models/Conversation.js
@@ -338,15 +338,19 @@ conversationSchema.methods.postLastOutboundMessageToPlatform = function (req) {
             message: error.message,
           };
           this.lastOutboundMessage.save()
-            .catch(saveError => logger.error(
-              'twilio.postMessage error: this.lastOutboundMessage.save() failed',
-              saveError
-            ), req);
+            .then(() => reject(error))
+            .catch((saveError) => {
+              logger.error(
+                'twilio.postMessage error: this.lastOutboundMessage.save() failed',
+                saveError, req);
+              reject(error);
+            });
+        } else {
+          /**
+           * Bubble up error so we can either suppress (unrecoverable error) or retry.
+           */
+          reject(error);
         }
-        /**
-         * Bubble up error so we can either suppress (unrecoverable error) or retry.
-         */
-        return reject(error);
       });
   });
 };

--- a/lib/helpers/twilio.js
+++ b/lib/helpers/twilio.js
@@ -8,120 +8,127 @@ const attachmentsHelper = require('./attachments');
 const requestHelper = require('./request');
 const config = require('../../config/lib/helpers/twilio');
 
+
+/**
+ * parseBody - parses properties out of the body of a Twilio request
+ *
+ * @param  {object} req
+ * @return {promise}
+ */
+function parseBody(req) {
+  requestHelper.setPlatform(req);
+  req.inboundMessageText = req.body.Body;
+  req.platformMessageId = req.body.MessageSid;
+  req.platformUserId = req.body.From;
+  req.platformUserAddress = this.parseUserAddressFromReq(req);
+  const attachmentObject = this.parseAttachmentFromReq(req);
+
+  return new Promise((resolve, reject) => {
+    if (attachmentObject.redirectUrl) {
+      module.exports.getAttachmentUrl(attachmentObject.redirectUrl)
+        .then((url) => {
+          req.mediaUrl = url;
+          attachmentObject.url = url;
+          attachmentsHelper.add(req, attachmentObject, 'inbound');
+          resolve(url);
+        })
+        .catch(error => reject(error));
+    } else {
+      resolve('attachmentObject doesn\'t contain a redirectUrl');
+    }
+  });
+}
+
+/**
+ * parseAttachmentFromReq - parses the MediaUrl0 and MediaContentType0 out of Twilio requests
+ * and creates an attachent object
+ *
+ * @param  {object} req
+ * @return {object}
+ */
+function parseAttachmentFromReq(req) {
+  return {
+    redirectUrl: req.body.MediaUrl0,
+    contentType: req.body.MediaContentType0,
+  };
+}
+
+/**
+ * getAttachmentUrl - It makes a GET request to the redirectUrl uri. It redirects the request
+ * and returns the actual attachment's data. We are interested in storing the actual attachment's
+ * address, which we get from the full response object of the request.
+ *
+ * @param  {string} redirectUrl
+ * @return {promise}
+ */
+function getAttachmentUrl(redirectUrl) {
+  const options = {
+    uri: redirectUrl,
+    // needed, otherwise returns the parsed body
+    resolveWithFullResponse: true,
+  };
+
+  return request(options)
+    .then((redirectRes) => {
+      let url = '';
+      try {
+        url = redirectRes.request.uri.href;
+      } catch (error) {
+        // The data structure might have changed and code needs to be updated.
+        logger.error('The Twilio attachment redirectUrl returns an error', error);
+      }
+      return url;
+    });
+}
+
+/**
+ * @param {object} req
+ * @return {object}
+ */
+function parseUserAddressFromReq(req) {
+  const body = req.body;
+  // @see https://github.com/DoSomething/northstar/blob/dev/documentation/endpoints/users.md#create-a-user
+  const data = {
+    addr_city: body.FromCity,
+    addr_state: body.FromState,
+    addr_zip: body.FromZip,
+    country: body.FromCountry,
+    addr_source: req.platform,
+  };
+
+  return data;
+}
+
+/**
+ * @param {object} error
+ * @return {boolean}
+ */
+function isBadRequestError(error) {
+  return error.status === 400;
+}
+
+/**
+ * isUndeliverableError
+ *
+ * @param  {number} errorCode
+ * @return {boolean}
+ */
+function isUndeliverableError(errorCode) {
+  if (!errorCode) {
+    return false;
+  }
+  const stringError = errorCode.toString();
+  return Object.keys(config.undeliverableErrorCodes).includes(stringError);
+}
+
 /**
  * Twilio helper
  */
 module.exports = {
-
-  /**
-   * parseBody - parses properties out of the body of a Twilio request
-   *
-   * @param  {object} req
-   * @return {promise}
-   */
-  parseBody: function parseBody(req) {
-    requestHelper.setPlatform(req);
-    req.inboundMessageText = req.body.Body;
-    req.platformMessageId = req.body.MessageSid;
-    req.platformUserId = req.body.From;
-    req.platformUserAddress = this.parseUserAddressFromReq(req);
-    const attachmentObject = this.parseAttachmentFromReq(req);
-
-    return new Promise((resolve, reject) => {
-      if (attachmentObject.redirectUrl) {
-        module.exports.getAttachmentUrl(attachmentObject.redirectUrl)
-          .then((url) => {
-            req.mediaUrl = url;
-            attachmentObject.url = url;
-            attachmentsHelper.add(req, attachmentObject, 'inbound');
-            resolve(url);
-          })
-          .catch(error => reject(error));
-      } else {
-        resolve('attachmentObject doesn\'t contain a redirectUrl');
-      }
-    });
-  },
-
-  /**
-   * parseAttachmentFromReq - parses the MediaUrl0 and MediaContentType0 out of Twilio requests
-   * and creates an attachent object
-   *
-   * @param  {object} req
-   * @return {object}
-   */
-  parseAttachmentFromReq: function parseAttachmentFromReq(req) {
-    return {
-      redirectUrl: req.body.MediaUrl0,
-      contentType: req.body.MediaContentType0,
-    };
-  },
-
-  /**
-   * getAttachmentUrl - It makes a GET request to the redirectUrl uri. It redirects the request
-   * and returns the actual attachment's data. We are interested in storing the actual attachment's
-   * address, which we get from the full response object of the request.
-   *
-   * @param  {string} redirectUrl
-   * @return {promise}
-   */
-  getAttachmentUrl: function getAttachmentUrl(redirectUrl) {
-    const options = {
-      uri: redirectUrl,
-      // needed, otherwise returns the parsed body
-      resolveWithFullResponse: true,
-    };
-
-    return request(options)
-      .then((redirectRes) => {
-        let url = '';
-        try {
-          url = redirectRes.request.uri.href;
-        } catch (error) {
-          // The data structure might have changed and code needs to be updated.
-          logger.error('The Twilio attachment redirectUrl returns an error', error);
-        }
-        return url;
-      });
-  },
-
-  /**
-   * @param {object} req
-   * @return {object}
-   */
-  parseUserAddressFromReq: function parseUserAddressFromReq(req) {
-    const body = req.body;
-    // @see https://github.com/DoSomething/northstar/blob/dev/documentation/endpoints/users.md#create-a-user
-    const data = {
-      addr_city: body.FromCity,
-      addr_state: body.FromState,
-      addr_zip: body.FromZip,
-      country: body.FromCountry,
-      addr_source: req.platform,
-    };
-
-    return data;
-  },
-
-  /**
-   * @param {object} error
-   * @return {boolean}
-   */
-  isBadRequestError: function isBadRequestError(error) {
-    return error.status === 400;
-  },
-
-  /**
-   * isUndeliverableError
-   *
-   * @param  {number} errorCode
-   * @return {boolean}
-   */
-  isUndeliverableError: function isUndeliverableError(errorCode) {
-    if (!errorCode) {
-      return false;
-    }
-    const stringError = errorCode.toString();
-    return Object.keys(config.undeliverableErrorCodes).includes(stringError);
-  },
+  parseBody,
+  parseAttachmentFromReq,
+  getAttachmentUrl,
+  parseUserAddressFromReq,
+  isBadRequestError,
+  isUndeliverableError,
 };

--- a/test/helpers/stubs.js
+++ b/test/helpers/stubs.js
@@ -3,6 +3,7 @@
 const httpMocks = require('node-mocks-http');
 const url = require('url');
 const Chance = require('chance');
+const moment = require('moment');
 
 const twilioHelperConfig = require('../../config/lib/helpers/twilio');
 const subscriptionHelper = require('../../config/lib/helpers/subscription');
@@ -261,6 +262,8 @@ module.exports = {
       return {
         sid: this.getSmsMessageSid(),
         status: 'queued',
+        numSegments: 1,
+        dateCreated: moment().format(),
       };
     },
     getPostMessageError: function getPostMessageError() {

--- a/test/helpers/stubs.js
+++ b/test/helpers/stubs.js
@@ -258,7 +258,7 @@ module.exports = {
         SmsStatus: 'received',
       };
     },
-    getPostMessageSuccessBody: function getPostMessageSuccessBody() {
+    getPostMessageSuccess: function getPostMessageSuccess() {
       return {
         sid: this.getSmsMessageSid(),
         status: 'queued',

--- a/test/unit/app/models/conversation.test.js
+++ b/test/unit/app/models/conversation.test.js
@@ -30,6 +30,7 @@ const resolvedPromise = Promise.resolve({});
 
 chai.should();
 chai.use(sinonChai);
+const expect = chai.expect;
 
 const sandbox = sinon.sandbox.create();
 
@@ -112,6 +113,21 @@ test('postLastOutboundMessageToPlatform calls twilio.postMessage if conversation
 
   await smsConversation.postLastOutboundMessageToPlatform(t.context.req);
   twilio.postMessage.should.have.been.called;
+});
+
+test('postLastOutboundMessageToPlatform should save metadata conversation when POST to Twilio is successful', async (t) => {
+  const postMessageResponse = Promise.resolve(stubs.twilio.getPostMessageSuccessBody());
+  sandbox.stub(twilio, 'postMessage')
+    .returns(postMessageResponse);
+  sandbox.stub(smsConversation.lastOutboundMessage, 'save')
+    .returns(resolvedPromise);
+  t.context.req.conversation = smsConversation;
+
+  await smsConversation.postLastOutboundMessageToPlatform(t.context.req);
+  twilio.postMessage.should.have.been.called;
+  smsConversation.lastOutboundMessage.save.should.have.been.called;
+  expect(smsConversation.lastOutboundMessage.metadata.delivery.queuedAt).to.exist;
+  expect(smsConversation.lastOutboundMessage.metadata.delivery.totalSegments).to.exist;
 });
 
 // postMessageToSupport

--- a/test/unit/lib/middleware/messages/message-outbound-send.test.js
+++ b/test/unit/lib/middleware/messages/message-outbound-send.test.js
@@ -16,7 +16,7 @@ const conversationFactory = require('../../../../helpers/factories/conversation'
 const messageFactory = require('../../../../helpers/factories/message');
 const userFactory = require('../../../../helpers/factories/user');
 
-const twilioSuccessStub = stubs.twilio.getPostMessageSuccessBody();
+const twilioSuccessStub = stubs.twilio.getPostMessageSuccess();
 const twilioErrorStub = stubs.twilio.getPostMessageError();
 
 // setup "x.should.y" assertion style


### PR DESCRIPTION
#### What's this PR do?
It saves failure data for outbound messages that fail to be queued by Twilio.

#### How should this be reviewed?
- 👀 
- Run all tests

#### Relevant tickets
Fixes #312

#### Checklist
- [x] Tests added for new features/bug fixes.
- [x] Tested on staging.
