### PR TITLE
Deprecating rivescript entries for defaultRivescriptTopicTrigger entries

### DIFF
--- a/lib/contentful.js
+++ b/lib/contentful.js
@@ -132,6 +132,17 @@ module.exports.fetchRivescripts = function () {
 };
 
 /**
+ * TODO: Return all pages of results, this only returns first page.
+ * @return {Promise}
+ */
+module.exports.fetchDefaultRivescriptTopicTriggers = function () {
+  const query = exports.getQueryBuilder()
+    .contentType('defaultRivescriptTopicTrigger')
+    .build();
+  return getEntries(query);
+};
+
+/**
  * @param {object} broadcastObject
  * @return {string}
  */
@@ -178,4 +189,33 @@ module.exports.getMessageTextFromBroadcast = function (broadcastObject) {
  */
 module.exports.getMessageTemplateFromBroadcast = function (broadcastObject) {
   return broadcastObject.fields.template;
+};
+
+module.exports.getResponseFromDefaultRivescriptTopicTrigger = function (defaultRivescriptTopicTrigger) {
+  return defaultRivescriptTopicTrigger.fields.response;
+};
+
+module.exports.getTriggerFromDefaultRivescriptTopicTrigger = function (defaultRivescriptTopicTrigger) {
+  return defaultRivescriptTopicTrigger.fields.trigger;
+};
+
+module.exports.getTextFromMessage = function (messageObject) {
+  return messageObject.fields.text;
+};
+
+module.exports.parseContentTypeFromContentfulEntry = function (entry) {
+  return entry.sys.contentType.sys.id;
+};
+
+module.exports.isContentType = function (contentfulEntry, match) {
+  const contentType = module.exports.parseContentTypeFromContentfulEntry(contentfulEntry);
+  return contentType === match;
+};
+
+module.exports.isDefaultRivescriptTopicTrigger = function (entry) {
+  return module.exports.isContentType(entry, 'defaultRivescriptTopicTrigger');
+};
+
+module.exports.isMessage = function (entry) {
+  return module.exports.isContentType(entry, 'message');
 };

--- a/lib/contentful.js
+++ b/lib/contentful.js
@@ -121,17 +121,6 @@ module.exports.fetchBroadcasts = function () {
 };
 
 /**
- * TODO: Support query params to page through results.
- * @return {Promise}
- */
-module.exports.fetchRivescripts = function () {
-  const query = exports.getQueryBuilder()
-    .contentType('rivescript')
-    .build();
-  return getEntries(query);
-};
-
-/**
  * TODO: Return all pages of results, this only returns first page.
  * @return {Promise}
  */

--- a/lib/helpers/index.js
+++ b/lib/helpers/index.js
@@ -9,6 +9,7 @@ const front = require('./front');
 const macro = require('./macro');
 const request = require('./request');
 const replies = require('./replies');
+const rivescript = require('./rivescript');
 const tags = require('./tags');
 const template = require('./template');
 const twilio = require('./twilio');
@@ -27,6 +28,7 @@ module.exports = {
   macro,
   request,
   replies,
+  rivescript,
   tags,
   template,
   twilio,

--- a/lib/helpers/rivescript.js
+++ b/lib/helpers/rivescript.js
@@ -1,0 +1,69 @@
+'use strict';
+
+const contentful = require('../contentful');
+const logger = require('../logger');
+
+function fetchDefaultRivescriptTopicTriggers() {
+  return new Promise((resolve, reject) => {
+    // TODO: fetch all rivescriptTopic entries to add any additional topics
+    contentful.fetchDefaultRivescriptTopicTriggers()
+      .then((triggers) => {
+        const result = triggers.map((trigger) => {
+          const rivescriptTrigger = module.exports.parseDefaultRivescriptTopicTrigger(trigger);
+          return rivescriptTrigger;
+        });
+        return resolve(result);
+      })
+      .catch(err => reject(err));
+  });
+}
+
+function parseDefaultRivescriptTopicTriggerResponse(contentfulEntry) {
+  if (contentful.isDefaultRivescriptTopicTrigger(contentfulEntry)) {
+    const triggerText = contentful.getTriggerFromDefaultRivescriptTopicTrigger(contentfulEntry);
+    return module.exports.formatTextAsRivescriptRedirect(triggerText);
+  }
+
+  if (contentful.isMessage(contentfulEntry)) {
+    const messageText = contentful.getTextFromMessage(contentfulEntry);
+    return module.exports.formatTextAsRivescriptReply(messageText);
+  }
+
+  throw new Error('Invalid content type for defaultRivescriptTopicTrigger.response');
+}
+
+function formatTextAsRivescriptRedirect(text) {
+  return `@ ${text}`;
+}
+
+function formatTextAsRivescriptReply(text) {
+  return `- ${text}`;
+}
+
+function formatTextAsRivescriptTrigger(text) {
+  return `+ ${text}`;
+}
+
+function formatRivescriptTrigger(triggerText, responseText) {
+  logger.debug('formatRivescriptTrigger', { triggerText, responseText });
+  const result = `${triggerText}\n${responseText}\n`;
+  return result;
+}
+
+function parseDefaultRivescriptTopicTrigger(trigger) {
+  const triggerText = contentful.getTriggerFromDefaultRivescriptTopicTrigger(trigger);
+  const rsTrigger = module.exports.formatTextAsRivescriptTrigger(triggerText);
+  const responseEntry = contentful.getResponseFromDefaultRivescriptTopicTrigger(trigger);
+  const rsResponse = module.exports.parseDefaultRivescriptTopicTriggerResponse(responseEntry);
+  return module.exports.formatRivescriptTrigger(rsTrigger, rsResponse);
+}
+
+module.exports = {
+  formatRivescriptTrigger,
+  formatTextAsRivescriptRedirect,
+  formatTextAsRivescriptReply,
+  formatTextAsRivescriptTrigger,
+  fetchDefaultRivescriptTopicTriggers,
+  parseDefaultRivescriptTopicTrigger,
+  parseDefaultRivescriptTopicTriggerResponse,
+};

--- a/server.js
+++ b/server.js
@@ -13,7 +13,7 @@ const app = require('./app');
 const mongoose = require('mongoose');
 const logger = require('heroku-logger');
 const fs = require('fs');
-const contentful = require('./lib/contentful');
+
 const rivescript = require('./lib/rivescript');
 const rivescriptHelper = require('./lib/helpers/rivescript');
 
@@ -23,9 +23,7 @@ if (!fs.existsSync(dir)) {
 }
 
 /**
- * Fetch rivescript files from Contentful.
- * TODO: Page through results.
- * @see https://github.com/DoSomething/gambit-conversations/issues/197
+ * Fetch default Rivescrippt topic triggers from Contentful to write chatbot Rivescript.
  */
 rivescriptHelper.fetchDefaultRivescriptTopicTriggers()
   .then((rivescriptTriggers) => {

--- a/server.js
+++ b/server.js
@@ -15,6 +15,7 @@ const logger = require('heroku-logger');
 const fs = require('fs');
 const contentful = require('./lib/contentful');
 const rivescript = require('./lib/rivescript');
+const rivescriptHelper = require('./lib/helpers/rivescript');
 
 const dir = './brain/contentful';
 if (!fs.existsSync(dir)) {
@@ -26,23 +27,19 @@ if (!fs.existsSync(dir)) {
  * TODO: Page through results.
  * @see https://github.com/DoSomething/gambit-conversations/issues/197
  */
-contentful.fetchRivescripts()
-  .then((entries) => {
-    entries.forEach((entry) => {
-      const id = entry.sys.id;
-      const script = entry.fields.rivescript;
-      const filename = `${dir}/${id}.rive`;
-      // Write them.
-      fs.writeFile(filename, script, ((err) => {
-        logger.debug('writeFile', { filename });
-        if (err) logger.error('writeFile', { err });
-      }));
-    });
-    logger.info('fetchRivescripts success', { count: entries.length });
+rivescriptHelper.fetchDefaultRivescriptTopicTriggers()
+  .then((rivescriptTriggers) => {
+    const filename = `${dir}/default.rive`;
+    const data = rivescriptTriggers.join('\n');
+    fs.writeFile(filename, data, ((err) => {
+      logger.debug('writeFile', { filename });
+      if (err) logger.error('writeFile', { err });
+    }));
+    logger.info('fetchDefaultRivescriptTopicTriggers success', { count: rivescriptTriggers.length });
     // Load the Rivescript bot.
     rivescript.getBot();
   })
-  .catch(err => logger.error('fetchRivescripts', { err }));
+  .catch(err => logger.error('fetchDefaultRivescriptTopicTriggers', { err }));
 
 
 const db = mongoose.connection;


### PR DESCRIPTION
#### What's this PR do?
This branch was an experiment in refactoring how we write the Rivescript that makes our chatbot reply. A Rivescript entry contains two fields:

* name - Single-value short text field for internal use, single value 
* rivescript - Single-value long text field to add freeform [Rivescript](https://www.rivescript.com/docs/tutorial)

Per our [spec](https://docs.google.com/document/d/1z5qLj2o-WTw4QDL0HlDMYoXQryvi_bfj_0IIuyOkkrY/edit#heading=h.ke7e6tx28a6f), the new `defaultRivescriptTopicTrigger`  entry contains two fields:

* `trigger` - Single-value text field to be used as a Rivescript trigger
* `response` - Single-value reference field to source the Rivescript reply, only allowing for content types:
    * `Message` - new content type with `text` and `attachments` fields
    *  `defaultRivescriptTopicTrigger` - this would be used for redirects, like how FORD should trigger the same message as JOIN does

This branch queries for all `defaultRivescriptTopicTrigger` entries instead of `rivescript` entries, and parses them as Rivescript triggers and replies via new `lib/helpers/rivescript`.

I've migrated the [Hello rivescript entry](https://app.contentful.com/spaces/owik07lyerdj/entries/i2a4NzCJsAoA2AekOSCmq) into two separate `defaultRivescriptTopicTrigger` entries:
* [hello](https://app.contentful.com/spaces/owik07lyerdj/entries/22UaWJW3AoUMG8QKA6Ym0) - with response set to a new Message entry
* [@hello [*] ](https://app.contentful.com/spaces/owik07lyerdj/entries/6fjKY5FNTycsyG2MeseMGg) - with response set to our "hello" `defaultRivescriptTopicTrigger` entry

I think this helps error-proof our Rivescript content, as well as making it easier to maintain:
<img width="1153" alt="screen shot 2018-05-10 at 10 37 23 am" src="https://user-images.githubusercontent.com/1236811/39886403-43b33b8c-5444-11e8-8e4d-2c729553d8fc.png">



#### How should this be reviewed?
Hello, hi, hey there, join, ford should all work locally but I haven't migrated any other entries yet. Wanted to make sure we nail down naming and the big picture before going to far into it.

#### Any background context you want to provide?

* Eventually the `defaultRivescriptTopicTrigger.response` field will allow for postConfigs, to deprecate the `keyword` content type and support multiple postConfig conversations for a campaign.

* I like the name `defaultRivescriptTopicTrigger` because it is very descriptive but wow it is just way too long. I did consider just `defaultTopicTrigger`.... but naming a `rivescriptTopic` content type as `topic` just felt too general, so went with keeping the Rivescript in the name.

