### PR TITLE
Adds hardcoded topics for May 21 2018 broadcast

### DIFF
--- a/brain/topics.rive
+++ b/brain/topics.rive
@@ -73,3 +73,53 @@
 - Great. You've got yourself on the list. See you in your inbox on Tuesday!{topic=random}
 
 < topic
+
+/**
+ * Campaign-less askSignup broadcast sent May 21 2018
+ */
+> topic 20180521_over18 includes random
+
++ yes
+- I'm happy you're joining this fight! Right now, we're talking to activists from Parkland, Black Lives Matter, The National School Walkout, and others to plan a national Week of Action next week (May 29-June 1).\n
+^ Your opinions matter. How do you want to make an impact on gun violence during our Week of Action? Take 2 mins and tell us here: https://dosomething.typeform.com/to/zi8Lzs?id={{user.id}}&s=sms{topic=survey_response}
+
++ @yes [*]
+@ yes
+
++ (heck|hell|hells|hm|uh|why) @yes [*]
+@ yes
+
++ no
+- Ok - another action you take to keep your community and school safe is to stand up to bullying. We're collecting tips from members on to beat bullying. Text POWER to have your tactic featured in the largest peer-to-peer anti-bullying guide EVER (and enter to win a $5000 scholarship.{topic=survey_response}
+
++ @no [*]
+@ no
+
++ [*]
+- I'm sorry I didn't understand that, but I'm listening. Have a question? Text Q.{topic=survey_response}
+
+< topic
+
+> topic 20180521_under18 includes random
+
++ yes
+- I'm happy you're joining this fight! Right now, we’re talking to activists from Parkland, Black Lives Matter, The National School Walkout, and others to plan a historic Week of Action next week (May 29-June 1). Stay tuned!\n
+^ Your opinions matter. How do you want to make an impact on gun violence during our Week of Action? Tell us here: https://dosomething.typeform.com/to/zi8Lzs?id={{user.id}}&s=sms\n
+^ Then, make sure you're registered and can vote on this issue (2 mins): https://vote.dosomething.org/issue/gun?r=user:{{user.id}},campaignID:8017,campaignRunID:8022,source:sms,source_details:5212018_gun_gtm{topic=survey_response}
+
++ @yes [*]
+@ yes
+
++ (heck|hell|hells|hm|uh|why) @yes [*]
+@ yes
+
++ no
+- Ok - another action you take to keep your community and school safe is to stand up to bullying. We're collecting tips from members on to beat bullying. Text POWER to have your tactic featured in the largest peer-to-peer anti-bullying guide EVER (and enter to win a $5000 scholarship.{topic=survey_response}
+
++ @no [*]
+@ no
+
++ [*]
+- I'm sorry I didn't understand that, but I'm listening. Have a question? Text Q.{topic=survey_response}
+
+< topic

--- a/brain/topics.rive
+++ b/brain/topics.rive
@@ -77,7 +77,7 @@
 /**
  * Campaign-less askSignup broadcast sent May 21 2018
  */
-> topic 20180521_over18 includes random
+> topic 20180521_under18 includes random
 
 + yes
 - I'm happy you're joining this fight! Right now, we're talking to activists from Parkland, Black Lives Matter, The National School Walkout, and others to plan a national Week of Action next week (May 29-June 1).\n
@@ -96,11 +96,12 @@
 @ no
 
 + [*]
-- I'm sorry I didn't understand that, but I'm listening. Have a question? Text Q.{topic=survey_response}
+- I'm sorry I didn't understand that, but I'm listening. Have a question? Text Q.\n
+^ Will you take action with us to end gun violence? Yes or No?
 
 < topic
 
-> topic 20180521_under18 includes random
+> topic 20180521_over18 includes random
 
 + yes
 - I'm happy you're joining this fight! Right now, we’re talking to activists from Parkland, Black Lives Matter, The National School Walkout, and others to plan a historic Week of Action next week (May 29-June 1). Stay tuned!\n
@@ -114,12 +115,14 @@
 @ yes
 
 + no
-- Ok - another action you take to keep your community and school safe is to stand up to bullying. We're collecting tips from members on to beat bullying. Text POWER to have your tactic featured in the largest peer-to-peer anti-bullying guide EVER (and enter to win a $5000 scholarship.{topic=survey_response}
+- Ok - if you're not ready to take direct action right now, you can still be an agent of change through voting.\n
+^ Let's do something about gun violence NOW by electing officials who will pass laws to protect our schools and save lives. It takes 2 minutes to register to vote: https://vote.dosomething.org/issue/gun?r=user:{{user.id}},campaignID:8017,campaignRunID:8022,source:sms,source_details:5212018_gun_kick{topic=survey_response}
 
 + @no [*]
 @ no
 
 + [*]
-- I'm sorry I didn't understand that, but I'm listening. Have a question? Text Q.{topic=survey_response}
+- I'm sorry I didn't understand that, but I'm listening. Have a question? Text Q.\n
+^ Will you take action with us to end gun violence? Yes or No?
 
 < topic


### PR DESCRIPTION
#### What's this PR do?
Adds two hardcoded topics to be used for broadcasts, as we've deprecated the Rivescript content type. 

#### How should this be reviewed?
Upon staging deploy, send yourself test broadcasts via Gambit Slack to verify expected yes/no/other responses: 
* [5bhByrHHzag4uUs2yigI2m](https://gambit-admin-staging.herokuapp.com/broadcasts/5bhByrHHzag4uUs2yigI2m) - Under 18 topic
* [2RwzmNiFFYwgqa6i0Ii6uw](https://gambit-admin-staging.herokuapp.com/broadcasts/2RwzmNiFFYwgqa6i0Ii6uw) - Over 18 topic

#### Any background context you want to provide?
This is a good use-case for a Typeform config rather than a freeform Rivescript topic, but this needs to go out today. 


#### Checklist
- [x] Tested on staging.
- [x] Pinged a PM if this is a larger PR that would benefit from some additional testing love.
