### PR TITLE
Starts on Change Topic Macro middleware [pr]

### DIFF
--- a/app/routes/messages/member.js
+++ b/app/routes/messages/member.js
@@ -17,6 +17,7 @@ const createUserIfNotFoundMiddleware = require('../../../lib/middleware/messages
 const loadInboundMessageMiddleware = require('../../../lib/middleware/messages/member/message-inbound-load');
 const createInboundMessageMiddleware = require('../../../lib/middleware/messages/member/message-inbound-create');
 const loadOutboundMessageMiddleware = require('../../../lib/middleware/messages/message-outbound-load');
+const changeTopicMacroMiddleware = require('../../../lib/middleware/messages/member/macro-change-topic');
 const macroReplyMiddleware = require('../../../lib/middleware/messages/member/template-macro-reply');
 const badWordsMiddleware = require('../../../lib/middleware/messages/member/bad-words');
 const campaignKeywordMiddleware = require('../../../lib/middleware/messages/member/campaign-keyword');
@@ -58,7 +59,10 @@ router.use(loadOutboundMessageMiddleware(loadOutboundMessageConfig));
 // Updates Last Messaged At, Subscription Status, Paused.
 router.use(updateUserMiddleware());
 
-// Sends macro reply if exists.
+// If bot reply is a changeTopic macro, execute it.
+router.use(changeTopicMacroMiddleware());
+
+// If bot reply is a macro with hardcoded reply message, send the reply.
 router.use(macroReplyMiddleware());
 
 // Scolds User if inbound message contains bad words.

--- a/config/lib/helpers/macro.js
+++ b/config/lib/helpers/macro.js
@@ -1,6 +1,7 @@
 'use strict';
 
 module.exports = {
+  changeTopicPrefix: 'changeTopicTo',
   macros: {
     campaignMenu: 'campaignMenu',
     confirmedCampaign: 'confirmedCampaign',

--- a/lib/helpers/macro.js
+++ b/lib/helpers/macro.js
@@ -6,7 +6,33 @@ function getMacroForKey(key) {
   return config.macros[key];
 }
 
+/**
+ * @param {String} topicId
+ * @return {String}
+ */
+function getChangeTopicMacroFromTopicId(topicId) {
+  return `${config.changeTopicPrefix}${topicId}`;
+}
+
+/**
+ * @param {String} macroName
+ * @return {String}
+ */
+function getTopicIdFromChangeTopicMacro(macroName) {
+  return macroName.substring(config.changeTopicPrefix.length);
+}
+
+/**
+ * @param {String} macroName
+ * @return {Boolean}
+ */
+function isChangeTopic(macroName) {
+  return macroName.includes(config.changeTopicPrefix);
+}
+
 module.exports = {
+  getChangeTopicMacroFromTopicId,
+  getTopicIdFromChangeTopicMacro,
   /**
    * @param {string} macroName
    * @return {string}
@@ -14,10 +40,14 @@ module.exports = {
   getReply: function getReply(macroName) {
     return config.replies[macroName];
   },
+  isChangeTopic,
   /**
    * Is given string a Rivescript macro?
    */
   isMacro: function isMacro(text) {
+    if (module.exports.isChangeTopic(text)) {
+      return true;
+    }
     return getMacroForKey(text);
   },
   macros: {

--- a/lib/helpers/macro.js
+++ b/lib/helpers/macro.js
@@ -27,7 +27,7 @@ function getTopicIdFromChangeTopicMacro(macroName) {
  * @return {Boolean}
  */
 function isChangeTopic(macroName) {
-  return macroName.includes(config.changeTopicPrefix);
+  return macroName.startsWith(config.changeTopicPrefix);
 }
 
 /**

--- a/lib/helpers/macro.js
+++ b/lib/helpers/macro.js
@@ -30,6 +30,18 @@ function isChangeTopic(macroName) {
   return macroName.includes(config.changeTopicPrefix);
 }
 
+/**
+ * Is given string a Rivescript macro?
+ * @param {String} text
+ * @return {Boolean}
+ */
+function isMacro(text) {
+  if (module.exports.isChangeTopic(text)) {
+    return true;
+  }
+  return !!getMacroForKey(text);
+}
+
 module.exports = {
   getChangeTopicMacroFromTopicId,
   getTopicIdFromChangeTopicMacro,
@@ -41,15 +53,7 @@ module.exports = {
     return config.replies[macroName];
   },
   isChangeTopic,
-  /**
-   * Is given string a Rivescript macro?
-   */
-  isMacro: function isMacro(text) {
-    if (module.exports.isChangeTopic(text)) {
-      return true;
-    }
-    return getMacroForKey(text);
-  },
+  isMacro,
   macros: {
     campaignMenu: () => getMacroForKey('campaignMenu'),
     confirmedCampaign: () => getMacroForKey('confirmedCampaign'),

--- a/lib/helpers/topic.js
+++ b/lib/helpers/topic.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const gambitCampaigns = require('../gambit-campaigns');
+const helpers = require('../helpers');
 
 /**
  * Queries Content API for first page of defaultTopicTriggers and returns as an array of
@@ -29,8 +30,7 @@ function parseDefaultTopicTrigger(defaultTopicTrigger) {
   }
   const data = Object.assign({}, defaultTopicTrigger);
   if (data.topicId) {
-    // TODO: Add macro helper functions to get the macro name to output, as well as code to execute.
-    data.reply = `changeTopicTo${data.topicId}`;
+    data.reply = helpers.macro.getChangeTopicMacroFromTopicId(data.topicId);
   }
   return data;
 }

--- a/lib/middleware/messages/member/macro-change-topic.js
+++ b/lib/middleware/messages/member/macro-change-topic.js
@@ -5,11 +5,11 @@ const helpers = require('../../../helpers');
 module.exports = function changeTopicMacro() {
   return (req, res, next) => {
     try {
-      if (!helpers.macro.isChangeTopic(req.macro)) {
-        return next();
+      if (req.macro && helpers.macro.isChangeTopic(req.macro)) {
+        // Placeholder for testing.
+        return helpers.replies.noCampaign(req, res);
       }
-      // Placeholder for testing.
-      return helpers.replies.noCampaign(req, res);
+      return next();
     } catch (err) {
       return helpers.sendErrorResponse(res, err);
     }

--- a/lib/middleware/messages/member/macro-change-topic.js
+++ b/lib/middleware/messages/member/macro-change-topic.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const helpers = require('../../../helpers');
+
+module.exports = function changeTopicMacro() {
+  return (req, res, next) => {
+    try {
+      if (!helpers.macro.isChangeTopic(req.macro)) {
+        return next();
+      }
+      // Placeholder for testing.
+      return helpers.replies.noCampaign(req, res);
+    } catch (err) {
+      return helpers.sendErrorResponse(res, err);
+    }
+  };
+};

--- a/lib/middleware/messages/member/template-macro-reply.js
+++ b/lib/middleware/messages/member/template-macro-reply.js
@@ -5,10 +5,6 @@ const helpers = require('../../../helpers');
 module.exports = function sendMacroReply() {
   return (req, res, next) => {
     try {
-      if (helpers.macro.isChangeTopic(req.macro)) {
-        // Placeholder for testing.
-        return helpers.replies.noCampaign(req, res);
-      }
       const macroReply = helpers.macro.getReply(req.macro);
       if (macroReply) {
         return helpers.replies[macroReply](req, res);

--- a/lib/middleware/messages/member/template-macro-reply.js
+++ b/lib/middleware/messages/member/template-macro-reply.js
@@ -5,6 +5,10 @@ const helpers = require('../../../helpers');
 module.exports = function sendMacroReply() {
   return (req, res, next) => {
     try {
+      if (helpers.macro.isChangeTopic(req.macro)) {
+        // Placeholder for testing.
+        return helpers.replies.noCampaign(req, res);
+      }
       const macroReply = helpers.macro.getReply(req.macro);
       if (macroReply) {
         return helpers.replies[macroReply](req, res);

--- a/test/helpers/factories/defaultTopicTrigger.js
+++ b/test/helpers/factories/defaultTopicTrigger.js
@@ -2,6 +2,13 @@
 
 const stubs = require('../stubs');
 
+function getValidChangeTopicDefaultTopicTrigger() {
+  return {
+    trigger: stubs.getRandomWord(),
+    topicId: stubs.getContentfulId(),
+  };
+}
+
 function getValidRedirectDefaultTopicTrigger() {
   return {
     trigger: stubs.getRandomWord(),
@@ -17,6 +24,7 @@ function getValidReplyDefaultTopicTrigger() {
 }
 
 module.exports = {
+  getValidChangeTopicDefaultTopicTrigger,
   getValidRedirectDefaultTopicTrigger,
   getValidReplyDefaultTopicTrigger,
 };

--- a/test/helpers/stubs.js
+++ b/test/helpers/stubs.js
@@ -17,6 +17,17 @@ const totalInboundConfirmedCampaign = 23;
 const totalInboundDeclinedCampaign = 10;
 const totalInboundNoMacro = 19;
 
+/**
+ * @return {String}
+ */
+function getContentfulId() {
+  return '72mon4jUeQOaokEIkQMaoa';
+}
+
+function getTopicId() {
+  return module.exports.getContentfulId();
+}
+
 module.exports = {
   config: {
     getMessageOutbound: function getMessageOutbound(shouldSendWhenPaused = false) {
@@ -133,6 +144,7 @@ module.exports = {
   getCampaignRunId: function getCampaignRunId() {
     return 6441;
   },
+  getContentfulId,
   getKeyword: function getKeyword() {
     return chance.word();
   },
@@ -166,6 +178,7 @@ module.exports = {
   getTopic: function getTopic() {
     return 'random';
   },
+  getTopicId,
   getUserId: function getUserId() {
     return '597b9ef910707d07c84b00aa';
   },

--- a/test/unit/lib/lib-helpers/macro.test.js
+++ b/test/unit/lib/lib-helpers/macro.test.js
@@ -13,8 +13,11 @@ chai.use(sinonChai);
 
 // app modules
 const config = require('../../../../config/lib/helpers/macro');
+const stubs = require('../../../helpers/stubs');
 
 const macros = config.macros;
+const topicId = stubs.getTopicId();
+const changeTopicMacroName = `${config.changeTopicPrefix}${topicId}`;
 const undefinedMacroName = 'trialByCombat';
 
 // module to be tested
@@ -29,6 +32,7 @@ test.afterEach(() => {
   sandbox.restore();
 });
 
+// getReply
 test('getReply should return text for given macro', () => {
   const macro = config.macros.subscriptionStatusStop;
   const reply = config.replies[macro];
@@ -40,16 +44,43 @@ test('getReply should return falsy for undefined macro reply', (t) => {
   t.falsy(macroHelper.getReply(undefinedMacroName));
 });
 
-test('isMacro should return text for given macro', () => {
+// getChangeTopicMacroFromTopicId
+test('getChangeTopicMacroFromTopicId returns string with changeTopicMacro prefix and topicId', () => {
+  const result = macroHelper.getChangeTopicMacroFromTopicId(topicId);
+  result.should.equal(changeTopicMacroName);
+});
+
+// getTopicIdFromChangeTopicMacro
+test('getTopicIdFromChangeTopicMacro returns topicId from given changeTopic macro name', () => {
+  const result = macroHelper.getTopicIdFromChangeTopicMacro(changeTopicMacroName);
+  result.should.equal(topicId);
+});
+
+// isChangeTopic
+test('isChangeTopic returns whether string includes changeTopic macro prefix', (t) => {
+  t.truthy(macroHelper.isChangeTopic(changeTopicMacroName));
+  t.falsy(macroHelper.isChangeTopic(undefinedMacroName));
+});
+
+// isMacro
+test('isMacro returns true if macro isChangeTopic', (t) => {
+  sandbox.stub(macroHelper, 'isChangeTopic')
+    .returns(true);
+  t.truthy(macroHelper.isMacro());
+});
+
+test('isMacro returns whether text exists for given macro if not isChangeTopic', (t) => {
+  sandbox.stub(macroHelper, 'isChangeTopic')
+    .returns(false);
   const macro = config.macros.confirmedCampaign;
-  const result = macroHelper.isMacro(macro);
-  macro.should.equal(result);
+  t.truthy(macroHelper.isMacro(macro));
 });
 
 test('isMacro should return falsy for undefined macro', (t) => {
   t.falsy(macroHelper.isMacro(undefinedMacroName));
 });
 
+// isCampaignMenu
 test('isCampaignMenu should return boolean', (t) => {
   t.true(macroHelper.isCampaignMenu(macros.campaignMenu));
   t.falsy(macroHelper.isCampaignMenu(undefinedMacroName));

--- a/test/unit/lib/lib-helpers/topic.test.js
+++ b/test/unit/lib/lib-helpers/topic.test.js
@@ -7,6 +7,8 @@ const sinon = require('sinon');
 const sinonChai = require('sinon-chai');
 
 const gambitCampaigns = require('../../../../lib/gambit-campaigns');
+const helpers = require('../../../../lib/helpers');
+const stubs = require('../../../helpers/stubs');
 const defaultTopicTriggerFactory = require('../../../helpers/factories/defaultTopicTrigger');
 
 chai.should();
@@ -50,4 +52,25 @@ test('fetchAllDefaultTopicTriggers should throw on gambitCampaigns.fetchDefaultT
   gambitCampaigns.fetchDefaultTopicTriggers.should.have.been.called;
   topicHelper.parseDefaultTopicTrigger.should.not.have.been.called;
   result.should.deep.equal(mockError);
+});
+
+// parseDefaultTopicTrigger
+test('parseDefaultTopicTrigger should return null if defaultTopicTrigger undefined', (t) => {
+  const result = topicHelper.parseDefaultTopicTrigger();
+  t.is(result, null);
+});
+
+test('parseDefaultTopicTrigger should return defaultTopicTrigger if defaultTopicTrigger.topicId undefined', () => {
+  const defaultTopicTrigger = defaultTopicTriggerFactory.getValidReplyDefaultTopicTrigger();
+  const result = topicHelper.parseDefaultTopicTrigger(defaultTopicTrigger);
+  result.should.deep.equal(defaultTopicTrigger);
+});
+
+test('parseDefaultTopicTrigger should return object with a changeTopic macro reply if defaultTopicTrigger.topicId', () => {
+  const mockChangeTopicMacro = `changeTopicTo${stubs.getTopicId()}`;
+  sandbox.stub(helpers.macro, 'getChangeTopicMacroFromTopicId')
+    .returns(mockChangeTopicMacro);
+  const defaultTopicTrigger = defaultTopicTriggerFactory.getValidChangeTopicDefaultTopicTrigger();
+  const result = topicHelper.parseDefaultTopicTrigger(defaultTopicTrigger);
+  result.reply.should.equal(mockChangeTopicMacro);
 });

--- a/test/unit/lib/middleware/messages/member/macro-change-topic.test.js
+++ b/test/unit/lib/middleware/messages/member/macro-change-topic.test.js
@@ -26,7 +26,6 @@ test.beforeEach((t) => {
   sandbox.stub(helpers, 'sendErrorResponse')
     .returns(underscore.noop);
   t.context.req = httpMocks.createRequest();
-  t.context.req.macro = stubs.getRandomWord();
   t.context.res = httpMocks.createResponse();
 });
 
@@ -35,9 +34,24 @@ test.afterEach((t) => {
   t.context = {};
 });
 
+test('changeTopicMacro returns next if req.macro undefined', async (t) => {
+  const next = sinon.stub();
+  const middleware = changeTopicMacro();
+  sandbox.stub(helpers.macro, 'isChangeTopic')
+    .returns(false);
+
+  // test
+  await middleware(t.context.req, t.context.res, next);
+  helpers.macro.isChangeTopic.should.not.have.been.called;
+  next.should.have.been.called;
+  helpers.replies.noCampaign.should.not.have.been.called;
+  helpers.sendErrorResponse.should.not.have.been.called;
+});
+
 test('changeTopicMacro returns next if not macro.isChangeTopic', async (t) => {
   const next = sinon.stub();
   const middleware = changeTopicMacro();
+  t.context.req.macro = stubs.getRandomWord();
   sandbox.stub(helpers.macro, 'isChangeTopic')
     .returns(false);
 
@@ -52,6 +66,7 @@ test('changeTopicMacro returns next if not macro.isChangeTopic', async (t) => {
 test('changeTopicMacro returns noCampaign reply if macro.isChangeTopic', async (t) => {
   const next = sinon.stub();
   const middleware = changeTopicMacro();
+  t.context.req.macro = stubs.getRandomWord();
   sandbox.stub(helpers.macro, 'isChangeTopic')
     .returns(true);
 
@@ -67,6 +82,7 @@ test('changeTopicMacro should call sendErrorResponse if postMessageToSupport fai
   const next = sinon.stub();
   const middleware = changeTopicMacro();
   const error = new Error('epic fail');
+  t.context.req.macro = stubs.getRandomWord();
   sandbox.stub(helpers.macro, 'isChangeTopic')
     .throws(error);
 
@@ -77,4 +93,3 @@ test('changeTopicMacro should call sendErrorResponse if postMessageToSupport fai
   helpers.replies.noCampaign.should.not.have.been.called;
   helpers.sendErrorResponse.should.have.been.calledWith(t.context.res, error);
 });
-

--- a/test/unit/lib/middleware/messages/member/macro-change-topic.test.js
+++ b/test/unit/lib/middleware/messages/member/macro-change-topic.test.js
@@ -1,0 +1,80 @@
+'use strict';
+
+require('dotenv').config();
+
+const test = require('ava');
+const chai = require('chai');
+const sinon = require('sinon');
+const sinonChai = require('sinon-chai');
+const httpMocks = require('node-mocks-http');
+const underscore = require('underscore');
+
+const helpers = require('../../../../../../lib/helpers');
+const stubs = require('../../../../../helpers/stubs');
+
+chai.should();
+chai.use(sinonChai);
+
+// module to be tested
+const changeTopicMacro = require('../../../../../../lib/middleware/messages/member/macro-change-topic');
+
+const sandbox = sinon.sandbox.create();
+
+test.beforeEach((t) => {
+  sandbox.stub(helpers.replies, 'noCampaign')
+    .returns(underscore.noop);
+  sandbox.stub(helpers, 'sendErrorResponse')
+    .returns(underscore.noop);
+  t.context.req = httpMocks.createRequest();
+  t.context.req.macro = stubs.getRandomWord();
+  t.context.res = httpMocks.createResponse();
+});
+
+test.afterEach((t) => {
+  sandbox.restore();
+  t.context = {};
+});
+
+test('changeTopicMacro returns next if not macro.isChangeTopic', async (t) => {
+  const next = sinon.stub();
+  const middleware = changeTopicMacro();
+  sandbox.stub(helpers.macro, 'isChangeTopic')
+    .returns(false);
+
+  // test
+  await middleware(t.context.req, t.context.res, next);
+  helpers.macro.isChangeTopic.should.have.been.called;
+  next.should.have.been.called;
+  helpers.replies.noCampaign.should.not.have.been.called;
+  helpers.sendErrorResponse.should.not.have.been.called;
+});
+
+test('changeTopicMacro returns noCampaign reply if macro.isChangeTopic', async (t) => {
+  const next = sinon.stub();
+  const middleware = changeTopicMacro();
+  sandbox.stub(helpers.macro, 'isChangeTopic')
+    .returns(true);
+
+  // test
+  await middleware(t.context.req, t.context.res, next);
+  helpers.macro.isChangeTopic.should.have.been.called;
+  next.should.not.have.been.called;
+  helpers.replies.noCampaign.should.have.been.calledWith(t.context.req, t.context.res);
+  helpers.sendErrorResponse.should.not.have.been.called;
+});
+
+test('changeTopicMacro should call sendErrorResponse if postMessageToSupport fails', async (t) => {
+  const next = sinon.stub();
+  const middleware = changeTopicMacro();
+  const error = new Error('epic fail');
+  sandbox.stub(helpers.macro, 'isChangeTopic')
+    .throws(error);
+
+  // test
+  await middleware(t.context.req, t.context.res, next);
+  helpers.macro.isChangeTopic.should.have.been.called;
+  next.should.not.have.been.called;
+  helpers.replies.noCampaign.should.not.have.been.called;
+  helpers.sendErrorResponse.should.have.been.calledWith(t.context.res, error);
+});
+


### PR DESCRIPTION
#### What's this PR do?

Starts on a Change Topic middleware function for use in our Member messages route, in anticipation of the `defaultTopicTriggers` content type to change a user's conversation topic and deprecating the `keyword` content type.

* Adds macro helper functions to get a Change Topic macro string for a given `topicId`, and parse the `topicId` from a Change Topic macro string.

* If the Rivescript reply to a user message returns a Change Topic macro, for now Gambit will return the `noCampaign` reply for the sake of internal testing. This shouldn't happen on production because we should not publish any of the `defaultTopicTriggers` that have a topic set (e.g.its response is set to a  `textPostConfig`, `photoPostConfig` or `externalPhostConfig` entry), 

#### How should this be reviewed?
* Set your Gambit Campaigns instance to query Contentful in Preview mode and start
* Run this branch locally, posting to your local Campaigns instance
* Verify that a draft defaultTopicTrigger with a topic set, like SPIT, returns the `noCampaign` response.
* Set your Gambit Campaigns instance back to query Contentful in regular production mode, restart
* Restart your Conversations instance -- verify the expected reply is returned. For Give a Spit, it will be the campaign closed template.

#### Any background context you want to provide?
This is part 2 of piece-mealing the never-merged #328, with part 1 being #332. Part 3 will entail changing the user's conversation `topic` property to the Topic Id parsed from the Change Macro string returned by Rivescript.

Docs to follow in part 3 as well once setting the `defaultTopicTrigger.response` field to a topic entry is functional. 

#### Checklist
- [x] Tests added for new features/bug fixes.
- [x] Tested on staging.
