### PR TITLE
Don't resubscribe unless subscriber macro triggered

### DIFF
--- a/brain/index.rive
+++ b/brain/index.rive
@@ -89,7 +89,7 @@
 ! array question  = is there|who|what|when|why|how
 ! array send      = send submit text
 ! array social    = social media|facebook|twitter|instagram|social
-! array unsubscribe = sotp|stop|stopp|quit|end|unsubscribe|cancel|do not|remove
+! array unsubscribe = sotp|stop|stopp|stopall|quit|end|unsubscribe|cancel|do not|remove
 ! array want      = want|am going|am thinking about
 ! array why       = why y how
 ! array yes       = y ya yas yea yeah yep yes yup

--- a/brain/topics.rive
+++ b/brain/topics.rive
@@ -15,6 +15,9 @@
 + join
 - subscriptionStatusResubscribed{topic=random}
 
++ @unsubscribe
+- subscriptionStatusStop
+
 + [*]
 - noReply
 

--- a/lib/helpers/user.js
+++ b/lib/helpers/user.js
@@ -97,14 +97,20 @@ module.exports = {
    * @return {string}
    */
   getSubscriptionStatusUpdate: function getSubscriptionStatusUpdate(user, rivescriptReplyText) {
-    const activeStatus = statuses.active();
+    const activeStatusValue = statuses.active();
+    // Note: We're checking SMS status for Slack users. If we ever integrate with another platform,
+    // we'll want to store separate platform subscription values on a Northstar User.
+    const currentSubscriptionStatus = user.sms_status;
 
+    /**
+     * Check if rivescriptReplyText is a subscriptionStatus macro.
+     */
     if (macro.isSubscriptionStatusActive(rivescriptReplyText)) {
-      return activeStatus;
+      return activeStatusValue;
     }
 
     if (macro.isSubscriptionStatusResubscribed(rivescriptReplyText)) {
-      return activeStatus;
+      return activeStatusValue;
     }
 
     if (macro.isSubscriptionStatusStop(rivescriptReplyText)) {
@@ -115,23 +121,20 @@ module.exports = {
       return statuses.less();
     }
 
-    // Note: We're checking SMS status for Slack users. If we ever integrate with another platform,
-    // we'll want to store separate platform subscription values on a Northstar User.
-    // TODO: Shouldn't this check be handled via the isSubscriber check below?
-    if (!user.sms_status) {
-      return activeStatus;
-    }
-    // If this user is currently not a subscriber, and now we're hearing from them
-    // (with a non subscription status macro), subscribe them.
-    //
-    // TODO: Instead of blindly accepting rivescriptReplyText as a subscription at this point,
-    // validate that rivescriptReplyText is a reserved JOIN or campaign signup trigger.
-    //
-    if (!this.isSubscriber(user)) {
-      return activeStatus;
+    // TODO: Once we deprecate keywords, check if rivescriptReplyText is a changeTopic macro,
+    // and return active status value.
+    // @see https://www.pivotaltracker.com/story/show/158444719
+
+    // If a macro hasn't been triggered and we don't have a subscription status saved for this
+    // user, assume they are now active.
+    // TODO: Do not assume that, and send a new template prompting user to confirm subscription by
+    // replying with a join keyword.
+    // @see https://www.pivotaltracker.com/story/show/158416129
+    if (!currentSubscriptionStatus) {
+      return activeStatusValue;
     }
 
-    // Nothing to update.
+    // If we've made it this far, no need to update user's subscription status.
     return null;
   },
 

--- a/lib/helpers/user.js
+++ b/lib/helpers/user.js
@@ -123,7 +123,6 @@ module.exports = {
 
     // TODO: Once we deprecate keywords, check if rivescriptReplyText is a changeTopic macro,
     // and return active status value.
-    // @see https://www.pivotaltracker.com/story/show/158444719
 
     // If a macro hasn't been triggered and we don't have a subscription status saved for this
     // user, assume they are now active.

--- a/test/unit/lib/lib-helpers/user.test.js
+++ b/test/unit/lib/lib-helpers/user.test.js
@@ -145,7 +145,7 @@ test('hasAddress should return false if user does not have address properties se
   t.falsy(userHelper.hasAddress(user));
 });
 
-// updateSubscriptionStatus
+// getSubscriptionStatusUpdate
 test('getSubscriptionStatusUpdate should return active value if active macro is passed', () => {
   const user = userFactory.getValidUser();
   const activeMacro = helpers.macro.macros.subscriptionStatusActive();
@@ -174,20 +174,6 @@ test('getSubscriptionStatusUpdate should return less value if less macro is pass
   result.should.equal(subscriptionHelper.statuses.less());
 });
 
-test('getSubscriptionStatusUpdate should return active value if current status is stop', () => {
-  const user = userFactory.getValidUser();
-  user.sms_status = subscriptionHelper.statuses.stop();
-  const result = userHelper.getSubscriptionStatusUpdate(user, stubs.getRandomMessageText());
-  result.should.equal(subscriptionHelper.statuses.active());
-});
-
-test('getSubscriptionStatusUpdate should return active value if current status is undeliverable', () => {
-  const user = userFactory.getValidUser();
-  user.sms_status = subscriptionHelper.statuses.undeliverable();
-  const result = userHelper.getSubscriptionStatusUpdate(user, stubs.getRandomMessageText());
-  result.should.equal(subscriptionHelper.statuses.active());
-});
-
 test('getSubscriptionStatusUpdate should return active value if current status is null', () => {
   const user = userFactory.getValidUser();
   user.sms_status = null;
@@ -195,13 +181,20 @@ test('getSubscriptionStatusUpdate should return active value if current status i
   result.should.equal(subscriptionHelper.statuses.active());
 });
 
-test('getSubscriptionStatusUpdate should return falsy if current status is active', (t) => {
+test('getSubscriptionStatusUpdate should return null if current status exists and non macro is passed', (t) => {
   const user = userFactory.getValidUser();
-  const result = userHelper.getSubscriptionStatusUpdate(user, stubs.getRandomMessageText());
-  t.falsy(result);
+  user.sms_status = subscriptionHelper.statuses.active();
+  let result = userHelper.getSubscriptionStatusUpdate(user, stubs.getRandomMessageText());
+  t.is(result, null);
+  user.sms_status = subscriptionHelper.statuses.stop();
+  result = userHelper.getSubscriptionStatusUpdate(user, stubs.getRandomMessageText());
+  t.is(result, null);
+  user.sms_status = subscriptionHelper.statuses.undeliverable();
+  result = userHelper.getSubscriptionStatusUpdate(user, stubs.getRandomMessageText());
+  t.is(result, null);
 });
 
-test('isPaused should return user.sms_status', (t) => {
+test('isPaused should return user.sms_paused', (t) => {
   const user = userFactory.getValidUser();
   const result = userHelper.isPaused(user);
   t.deepEqual(result, user.sms_paused);


### PR DESCRIPTION
#### What's this PR do?

Fixes bug in #344 -- sending Gambit a subsequent message after sending a STOP request would silently set the user's status back to active.

* Also adds our [`@unsubscribe` substitution](https://github.com/DoSomething/gambit-conversations/blob/2.10.0/brain/index.rive#L92) as a trigger to return the `subscriptionStatusStop` value. A todo here could be to return `null` if the subscriptionStatusMacro triggered is equal to the user's current status. 

#### How should this be reviewed?
* Verify your user is sms subscribed (status `active` or `less`)
* Send a STOP message to Gambit, verify user status is `stop`
* Send random message to Gambit, verify user status is still set to `stop`
* Send JOIN message to Gambit, verify user status is` active`, repeat all steps with LESS message to verify status is saved as `less`

#### Any background context you want to provide?

Would be nice to start up on more integration tests for 🐛 like these 🤦‍♂️ 💻 

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [x] Tests added for new features/bug fixes.
- [x] Tested on staging.
