### PR TITLE
Set user sms_status to pending if their topic changes to askSubscriptionStatus

### DIFF
--- a/app/models/Conversation.js
+++ b/app/models/Conversation.js
@@ -102,12 +102,19 @@ conversationSchema.methods.changeTopic = function (topicObject) {
  * @return {Promise}
  */
 conversationSchema.methods.setTopic = function (topic) {
-  if (topic === this.topic) {
-    return Promise.resolve();
-  }
   logger.debug('Conversation.setTopic', { topic });
+
+  let promise = Promise.resolve();
+  if (topic === this.topic) {
+    return promise;
+  }
+
+  if (topic === config.topics.askSubscriptionStatus) {
+    promise = helpers.user.setPendingSubscriptionStatusForUserId(this.userId);
+  }
+
   this.topic = topic;
-  return this.save();
+  return promise.then(() => this.save());
 };
 
 /**

--- a/config/app/models/conversation.js
+++ b/config/app/models/conversation.js
@@ -2,6 +2,7 @@
 
 module.exports = {
   topics: {
+    askSubscriptionStatus: 'askSubscriptionStatus',
     default: 'random',
     campaign: 'campaign',
     support: 'support',

--- a/config/lib/helpers/subscription.js
+++ b/config/lib/helpers/subscription.js
@@ -4,9 +4,7 @@ module.exports = {
   subscriptionStatuses: {
     active: 'active',
     less: 'less',
-    // TODO: Set to 'pending' once available as an option.
-    // @see https://www.pivotaltracker.com/n/projects/2019429/stories/158439520
-    pending: 'unknown',
+    pending: 'pending',
     stop: 'stop',
     undeliverable: 'undeliverable',
   },

--- a/config/lib/helpers/subscription.js
+++ b/config/lib/helpers/subscription.js
@@ -4,6 +4,9 @@ module.exports = {
   subscriptionStatuses: {
     active: 'active',
     less: 'less',
+    // TODO: Set to 'pending' once available as an option.
+    // @see https://www.pivotaltracker.com/n/projects/2019429/stories/158439520
+    pending: 'unknown',
     stop: 'stop',
     undeliverable: 'undeliverable',
   },

--- a/lib/helpers/subscription.js
+++ b/lib/helpers/subscription.js
@@ -10,6 +10,7 @@ module.exports = {
   statuses: {
     active: () => getStatusForKey('active'),
     less: () => getStatusForKey('less'),
+    pending: () => getStatusForKey('pending'),
     stop: () => getStatusForKey('stop'),
     undeliverable: () => getStatusForKey('undeliverable'),
   },

--- a/lib/helpers/user.js
+++ b/lib/helpers/user.js
@@ -8,6 +8,14 @@ const macro = require('./macro');
 const statuses = require('./subscription').statuses;
 const config = require('../../config/lib/helpers/user');
 
+/**
+ * @param {String} userId
+ * @return {Promise}
+ */
+function setPendingSubscriptionStatusForUserId(userId) {
+  return northstar.updateUser(userId, { sms_status: statuses.pending() });
+}
+
 module.exports = {
   fetchById: function fetchById(userId) {
     return northstar.fetchUserById(userId);
@@ -160,4 +168,6 @@ module.exports = {
     // TODO: Confirm if status is undefined, should we consider the User a subscriber? Assuming yes.
     return true;
   },
+
+  setPendingSubscriptionStatusForUserId,
 };

--- a/test/unit/app/models/conversation.test.js
+++ b/test/unit/app/models/conversation.test.js
@@ -187,6 +187,20 @@ test('setTopic calls save for new topic', async () => {
   mockConversation.save.should.have.been.called;
 });
 
+test('setTopic calls helpers.user.setPendingSubscriptionStatusForUserId if topic is askSubscriptionStatus', async () => {
+  const mockConversation = conversationFactory.getValidConversation();
+  const mockTopic = topics.askSubscriptionStatus;
+  sandbox.stub(mockConversation, 'save')
+    .returns(Promise.resolve(mockConversation));
+  sandbox.stub(helpers.user, 'setPendingSubscriptionStatusForUserId')
+    .returns(Promise.resolve(true));
+
+  await mockConversation.setTopic(mockTopic);
+  mockConversation.save.should.have.been.called;
+  helpers.user.setPendingSubscriptionStatusForUserId
+    .should.have.been.calledWith(mockConversation.userId);
+});
+
 test('setTopic does not call save for same topic', async () => {
   const mockConversation = conversationFactory.getValidConversation();
   sandbox.stub(mockConversation, 'save')
@@ -196,16 +210,31 @@ test('setTopic does not call save for same topic', async () => {
   mockConversation.save.should.not.have.been.called;
 });
 
-test('setDefaultTopic, setSupportTopic, setCampaignTopic call setTopic', async () => {
+// setDefaultTopic
+test('setDefaultTopic calls setTopic with config.topics.default', async () => {
   const mockConversation = conversationFactory.getValidConversation();
   sandbox.stub(mockConversation, 'setTopic')
     .returns(Promise.resolve(mockConversation));
 
   await mockConversation.setDefaultTopic();
   mockConversation.setTopic.should.have.been.calledWith(topics.default);
+});
+
+// setCampaignTopic
+test('setCampaignTopic calls setTopic with config.topics.campaign', async () => {
+  const mockConversation = conversationFactory.getValidConversation();
+  sandbox.stub(mockConversation, 'setTopic')
+    .returns(Promise.resolve(mockConversation));
 
   await mockConversation.setCampaignTopic();
   mockConversation.setTopic.should.have.been.calledWith(topics.campaign);
+});
+
+// setSupportTopic
+test('setSupportTopic calls setTopic with config.topics.support', async () => {
+  const mockConversation = conversationFactory.getValidConversation();
+  sandbox.stub(mockConversation, 'setTopic')
+    .returns(Promise.resolve(mockConversation));
 
   await mockConversation.setSupportTopic();
   mockConversation.setTopic.should.have.been.calledWith(topics.support);

--- a/test/unit/lib/lib-helpers/subscription.test.js
+++ b/test/unit/lib/lib-helpers/subscription.test.js
@@ -30,6 +30,7 @@ test.afterEach(() => {
 
 test('subscriptionHelper.statuses.x() should be equal to config.subscriptionStatusValues.x', () => {
   Object.keys(statuses).forEach((statusName) => {
-    subscriptionHelper.statuses[statusName]().should.be.equal(statusName);
+    subscriptionHelper.statuses[statusName]()
+      .should.be.equal(config.subscriptionStatuses[statusName]);
   });
 });

--- a/test/unit/lib/lib-helpers/user.test.js
+++ b/test/unit/lib/lib-helpers/user.test.js
@@ -199,3 +199,14 @@ test('isPaused should return user.sms_paused', (t) => {
   const result = userHelper.isPaused(user);
   t.deepEqual(result, user.sms_paused);
 });
+
+// setPendingSubscriptionStatusForUserId
+test('setPendingSubscriptionStatusForUserId should call northstar.updateUser with pending status', async () => {
+  const userId = mockUser.id;
+  sandbox.stub(northstar, 'updateUser')
+    .returns(Promise.resolve({}));
+
+  await userHelper.setPendingSubscriptionStatusForUserId(userId);
+  northstar.updateUser.should.have.been
+    .calledWith(userId, { sms_status: subscriptionHelper.statuses.pending() });
+});


### PR DESCRIPTION
#### What's this PR do?

Adds logic to the `Conversation.setTopic` function to update a user's `sms_status` to `pending` if the topic has been changed to `askSubscriptionStatus`.

* ~~We're waiting on `pending` to be added as a valid `sms_status` option, so this branch sets the status to `unknown` to unblock development and testing. See https://www.pivotaltracker.com/n/projects/2019429/stories/158439520~~

* Adds `helpers.user.setPendingSubscriptionStatusForUserId` to execute the update request to Northstar for given `userId` param

#### How should this be reviewed?

I've set up a test broadcast, `5pcoF2S9ZC68qqQygCCEqG`, with topic `askSubscriptionStatus`. Send yourself the broadcast and verify your Northstar user's status is set to `pending`.




<img width="350" alt="screen shot 2018-06-19 at 10 15 18 am" src="https://user-images.githubusercontent.com/1236811/41613219-e3467f04-73a9-11e8-8b98-a79b903f3da1.png">


#### Any background context you want to provide?

* The `setSupportTopic`, `setCampaignTopic` functions could update NS status as well, but we aim to deprecate both of these topics:

    * No longer use a support topic per https://www.pivotaltracker.com/story/show/157987170
    * A campaign broadcast should set the campaign topic instead of a campaign -- this is one of the last remaining cleanup tasks from the topic work that has been on hold while we drop everything to handle compliance issues.


#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [x] Tests added for new features/bug fixes.
- [x] Tested on staging.
- [x] Pinged a PM if this is a larger PR that would benefit from some additional testing love.
