### PR TITLE
Rivescript updates for subscription status templates and topic

### DIFF
--- a/brain/macros.rive
+++ b/brain/macros.rive
@@ -18,10 +18,10 @@
 /**
  * Subscription update triggers.
  */
-+ weekly
++ (week|weekly)
 - subscriptionStatusActive
 
-+ monthly
++ (month|monthly)
 - subscriptionStatusLess
 
 + less

--- a/brain/macros.rive
+++ b/brain/macros.rive
@@ -19,13 +19,10 @@
  * Subscription update triggers.
  */
 + (week|weekly)
-- subscriptionStatusActive
+- subscriptionStatusActive{topic=random}
 
-+ (month|monthly)
-- subscriptionStatusLess
-
-+ less
-- subscriptionStatusLess
++ (less|month|monthly)
+- subscriptionStatusLess{topic=random}
 
 + stop
 - subscriptionStatusStop{topic=unsubscribed}

--- a/brain/topics.rive
+++ b/brain/topics.rive
@@ -60,10 +60,7 @@
 + d
 - subscriptionStatusStop{topic=unsubscribed}
 
-+ need more
-@ c
-
-+ more
++ [*] more [*]
 @ c
 
 + [*]

--- a/brain/topics.rive
+++ b/brain/topics.rive
@@ -44,7 +44,7 @@
 
 // Asks user to update their subscription status.
 + status
-- Hey it's Freddie from DoSomething.org! Do you want to hear from us A) Weekly B) Monthly C) Need More Info D) STOP {topic=askSubscriptionStatus}
+- Hi it's Freddie at DoSomething! I send texts w updates on news & easy ways to take action. Want texts: A)Weekly B)Monthly C)I need more info D)Text STOP to stop {topic=askSubscriptionStatus}
 
 > topic askSubscriptionStatus includes random
 
@@ -55,7 +55,7 @@
 - subscriptionStatusLess{topic=random}
 
 + c
-- DoSomething is a community of 6 million young people taking action in their community. Read more about what we do: https://www.dosomething.org/us/about/who-we-are. Do you have a question for me? Text QUESTION and I’ll reply within 24 hours!\n\nDo you want to hear from us A) Weekly B) Monthly or STOP
+- Sure! Maybe it's been a while since you signed up for DoSomething.org texts, so I'll give you the run down of what these texts are all about. Once a week, I text over 3 million young people with updates on what's happening in the news and/or easy ways to take action in your community.\n\nWant an example of the news we share? Take 2 mins to catch up on the 5 things you *must* know that happened last week? https://www.dosomething.org/us/5-things-to-know-june-18?user_id={{user.id}},broadcastsource=info
 
 + d
 - subscriptionStatusStop{topic=unsubscribed}

--- a/config/lib/helpers/template.js
+++ b/config/lib/helpers/template.js
@@ -66,11 +66,11 @@ const templatesMap = {
     },
     subscriptionStatusActive: {
       name: 'subscriptionStatusActive',
-      text: 'OK, great! You\'ll receive weekly updates from me. -Freddie, DoSomething.org.',
+      text: 'Okay, great! I\'ll text you once a week with updates on what\'s happening in the news and/or easy ways for you to take action in your community! Wanna take 2 mins to catch up on the 5 things you *must* know that happened last week? I complied some of my fav news here: https://www.dosomething.org/us/5-things-to-know-june-18?user_id={{user.id}},broadcastsource=weekly',
     },
     subscriptionStatusLess: {
       name: 'subscriptionStatusLess',
-      text: 'Great, you\'ll start to receive 1 monthly update from Freddie at DoSomething.org! Things to know: Msg&DataRatesApply. Text HELP for help, text STOP to stop.',
+      text: 'Okay, great! I\'ll text you once a month with updates on what\'s happening in the news and/or easy ways for you to take action in your community! Wanna take 2 mins to catch up on the 5 things you *must* know that happened last week? I complied some of my fav news here: https://www.dosomething.org/us/5-things-to-know-june-18?user_id={{user.id}},broadcastsource=monthly',
     },
     subscriptionStatusResubscribed: {
       name: 'subscriptionStatusResubscribed',


### PR DESCRIPTION
#### What's this PR do?
* Edits the Need More Info reply in `askSubscriptionStatus` topic, and modifies trigger to catch more replies
* Adds `week` and `month` as subscription status triggers, tailors templates to the `askSubscriptionStatus` broadcast going out this week. 

#### How should this be reviewed?
💬 🤖 

#### Checklist
- [x] Tested on staging.
