### PR TITLE
patch to stop trying to send a sms_status update to users we dont have userId for.

### DIFF
--- a/app/models/Conversation.js
+++ b/app/models/Conversation.js
@@ -110,9 +110,10 @@ conversationSchema.methods.setTopic = function (topic) {
   }
 
   if (topic === config.topics.askSubscriptionStatus) {
-    promise = helpers.user.setPendingSubscriptionStatusForUserId(this.userId);
+    if (this.userId) {
+      promise = helpers.user.setPendingSubscriptionStatusForUserId(this.userId);
+    }
   }
-
   this.topic = topic;
   return promise.then(() => this.save());
 };


### PR DESCRIPTION
#### What's this PR do?
Quick patch to stop the pile up of retried during the re-permissioning broadcast due to user who we have no `userId` in our G-Conversations DB.

[Slack convo where this bug is discussed](https://dosomething.slack.com/archives/C2C8NLNAY/p1529506973000763)
