### PR TITLE
Backfill conversation.userId upon finding existing conversation

### DIFF
--- a/app/models/Conversation.js
+++ b/app/models/Conversation.js
@@ -101,9 +101,7 @@ conversationSchema.statics.findOneAndPopulateLastOutboundMessage = function (que
         conversationId: conversation.id,
       }, req);
 
-      return conversation.save()
-        .then(updatedDoc => updatedDoc.populate('lastOutboundMessage'))
-        .catch(err => Promise.reject(err));
+      return conversation.save().then(updatedDoc => updatedDoc.populate('lastOutboundMessage'));
     });
 };
 

--- a/lib/helpers/user.js
+++ b/lib/helpers/user.js
@@ -3,6 +3,7 @@
 const crypto = require('crypto');
 const underscore = require('underscore');
 
+const logger = require('../logger');
 const northstar = require('../northstar');
 const macro = require('./macro');
 const statuses = require('./subscription').statuses;
@@ -13,6 +14,7 @@ const config = require('../../config/lib/helpers/user');
  * @return {Promise}
  */
 function setPendingSubscriptionStatusForUserId(userId) {
+  logger.debug('setPendingSubscriptionStatusForUserId', { userId });
   return northstar.updateUser(userId, { sms_status: statuses.pending() });
 }
 


### PR DESCRIPTION
#### What's this PR do?

Moves the backfilling of a `conversation.userId` property out of the `Conversation.createAndSetLastOutboundMessage` instance method, and instead into the `Conversation.findOneAndPopulateLastOutboundMessage` static method instead.

#351 fixed a bug in #347, stopping errors from being thrown when a conversation didn't have a `userId` set upon receiving a `askSubscriptionStatus` broadcast by skipping the user update completely. This PR moves the backfill into the `conversation-get` middleware, which means we'll have a backfilled `userId` property available by the time we're ready to set the conversation topic (and update user accordingly if our topic change is to `askSubscriptionStatus`)

This bug occurred because it's the first time we've had to make an update to the user when sending a broadcast message (and because we're sending to our full list, where some users who haven't sent or received messages in a long time may not have conversations with userId's).

#### How should this be reviewed?

Test sending yourself an `askSubscriptionStatus` broadcast  with the following steps:

* Make sure your `sms_status` is set to `'active'` or `'less`' (or null could work too). Also make sure your conversation topic is not set to `askSubscriptionStatus`, as the update won't be triggered if topic is not changed)
* Manually delete your conversation `userId` property 
* Send yourself an `askSubscriptionStatus` broadcast, e.g. `5547be89469c64ec7d8b518d`
* Verify your user status is set to `pending` and your conversation now contains a `userId` property

#### Any background context you want to provide?
This for sure could use some unit tests but it'd be best to get to this production asap per our full list broadcast currently sending. This will ensure users receiving the broadcast have their status set to `pending` -- as currently the status of users with non-backfilled conversations is not changing. It's not a critical bug, but it's a false positive on our counts of valid `'active'` and `'less'` subscribers as we send this full list broadcast.

#### Relevant tickets
#342 
#351 

#### Checklist
- [ ] Tests added for new features/bug fixes.
- [ ] Tested on staging.
