### PR TITLE
URL change in More Info, Monthly, Less replies

### DIFF
--- a/brain/topics.rive
+++ b/brain/topics.rive
@@ -55,7 +55,7 @@
 - subscriptionStatusLess{topic=random}
 
 + c
-- Sure! Maybe it's been a while since you signed up for DoSomething.org texts, so I'll give you the run down of what these texts are all about. Once a week, I text over 3 million young people with updates on what's happening in the news and/or easy ways to take action in your community.\n\nWant an example of the news we share? Take 2 mins to catch up on the 5 things you *must* know that happened last week? https://www.dosomething.org/us/5-things-to-know-june-18?user_id={{user.id}},broadcastsource=info
+- Sure! Maybe it's been a while since you signed up for DoSomething.org texts, so I'll give you the run down of what these texts are all about. Once a week, I text over 3 million young people with updates on what's happening in the news and/or easy ways to take action in your community.\n\nWant an example of the news we share? Take 2 mins to catch up on the 5 things you *must* know that happened last week? https://www.dosomething.org/us/family-separations-us-border?user_id={{user.id}},broadcastsource=info
 
 + d
 - subscriptionStatusStop{topic=unsubscribed}

--- a/brain/topics.rive
+++ b/brain/topics.rive
@@ -55,7 +55,7 @@
 - subscriptionStatusLess{topic=random}
 
 + c
-- Sure! Maybe it's been a while since you signed up for DoSomething.org texts, so I'll give you the run down of what these texts are all about. Once a week, I text over 3 million young people with updates on what's happening in the news and/or easy ways to take action in your community.\n\nWant an example of the news we share? Take 2 mins to catch up on the 5 things you *must* know that happened last week? https://www.dosomething.org/us/family-separations-us-border?user_id={{user.id}},broadcastsource=info
+- Sure! Maybe it's been a while since you signed up for DoSomething.org texts, so I'll give you the run down of what these texts are all about. Once a week, I text over 3 million young people with updates on what's happening in the news and/or easy ways to take action in your community.\n\nWant an example of the news we share? Take 2 mins to catch up on what's happening in the news this week and learn what you can do about it https://www.dosomething.org/us/family-separations-us-border?user_id={{user.id}},broadcastsource=info
 
 + d
 - subscriptionStatusStop{topic=unsubscribed}

--- a/config/lib/helpers/template.js
+++ b/config/lib/helpers/template.js
@@ -3,6 +3,9 @@
 const underscore = require('underscore');
 
 const helpCenterUrl = 'http://doso.me/1jf4/291kep';
+// Note: This url may also appear in hardcoded askSubscriptionStatus topic.
+// @see brain/topics.rive
+const dsNewsUrl = 'https://www.dosomething.org/us/family-separations-us-border';
 // TODO: DRY menuCommand definition.
 // @see lib/helpers.js
 const menuCommand = 'menu';
@@ -66,11 +69,11 @@ const templatesMap = {
     },
     subscriptionStatusActive: {
       name: 'subscriptionStatusActive',
-      text: 'Okay, great! I\'ll text you once a week with updates on what\'s happening in the news and/or easy ways for you to take action in your community! Wanna take 2 mins to catch up on the 5 things you *must* know that happened last week? I complied some of my fav news here: https://www.dosomething.org/us/5-things-to-know-june-18?user_id={{user.id}},broadcastsource=weekly',
+      text: `Okay, great! I'll text you once a week with updates on what's happening in the news and/or easy ways for you to take action in your community! ${dsNewsUrl}?user_id={{user.id}},broadcastsource=weekly`,
     },
     subscriptionStatusLess: {
       name: 'subscriptionStatusLess',
-      text: 'Okay, great! I\'ll text you once a month with updates on what\'s happening in the news and/or easy ways for you to take action in your community! Wanna take 2 mins to catch up on the 5 things you *must* know that happened last week? I complied some of my fav news here: https://www.dosomething.org/us/5-things-to-know-june-18?user_id={{user.id}},broadcastsource=monthly',
+      text: `Okay, great! I'll text you once a month with updates on what's happening in the news and/or easy ways for you to take action in your community! Wanna take 2 mins to catch up on the 5 things you *must* know that happened last week? I complied some of my fav news here: ${dsNewsUrl}?user_id={{user.id}},broadcastsource=monthly`,
     },
     subscriptionStatusResubscribed: {
       name: 'subscriptionStatusResubscribed',

--- a/config/lib/helpers/template.js
+++ b/config/lib/helpers/template.js
@@ -5,7 +5,7 @@ const underscore = require('underscore');
 const helpCenterUrl = 'http://doso.me/1jf4/291kep';
 // Note: This url may also appear in hardcoded askSubscriptionStatus topic.
 // @see brain/topics.rive
-const dsNewsUrl = 'https://www.dosomething.org/us/family-separations-us-border';
+const newsUrl = 'https://www.dosomething.org/us/family-separations-us-border';
 // TODO: DRY menuCommand definition.
 // @see lib/helpers.js
 const menuCommand = 'menu';
@@ -69,11 +69,11 @@ const templatesMap = {
     },
     subscriptionStatusActive: {
       name: 'subscriptionStatusActive',
-      text: `Okay, great! I'll text you once a week with updates on what's happening in the news and/or easy ways for you to take action in your community! ${dsNewsUrl}?user_id={{user.id}},broadcastsource=weekly`,
+      text: `Okay, great! I'll text you once a week with updates on what's happening in the news and/or easy ways for you to take action in your community! Wanna take 2 mins to catch up on what's happening in the news this week and what you can do about it? ${newsUrl}?user_id={{user.id}},broadcastsource=weekly`,
     },
     subscriptionStatusLess: {
       name: 'subscriptionStatusLess',
-      text: `Okay, great! I'll text you once a month with updates on what's happening in the news and/or easy ways for you to take action in your community! Wanna take 2 mins to catch up on the 5 things you *must* know that happened last week? I complied some of my fav news here: ${dsNewsUrl}?user_id={{user.id}},broadcastsource=monthly`,
+      text: `Okay, great! I'll text you once a month with updates on what's happening in the news and/or easy ways for you to take action in your community! Wanna take 2 mins to catch up on what's happening in the news this week and what you can do about it? ${newsUrl}?user_id={{user.id}},broadcastsource=monthly`,
     },
     subscriptionStatusResubscribed: {
       name: 'subscriptionStatusResubscribed',


### PR DESCRIPTION
#### What's this PR do? 

Edits hardcoded subscription status replies per Slack request https://dosomething.slack.com/archives/C2C8NLNAY/p1529594329000694?thread_ts=1529591443.000657&cid=C2C8NLNAY

#### How should this be reviewed?
* Send STATUS to Gambit. After receiving the Ask Subscription Status reply, send `More Info` to Gambit and verify the reply contains new link
* Text WEEKLY and verify reply contains the new link
* Text MONTHLY and verify reply contains the new link

#### Any background context you want to provide?
We could add a config to avoid hardcoding on the Less/Active replies, but we'd still be stuck with manually updating the Rivescript content for now (More Info) -- so keeping things as-is to get this on production asap.


#### Checklist
- [x] Tested on staging.
- [x] Pinged a PM if this is a larger PR that would benefit from some additional testing love.
