### PR TITLE
remove 30008 as an undeliverable error

### DIFF
--- a/config/lib/helpers/twilio.js
+++ b/config/lib/helpers/twilio.js
@@ -11,7 +11,7 @@ module.exports = {
   //        Example: https://www.twilio.com/console/sms/logs/SM4367f21c9cfb40e2b87216227a20a109
   undeliverableErrorCodes: {
     30006: 'Landline or unreachable carrier',
-    30008: 'Unknown error',
+    // 30008: 'Unknown error',
     // TODO: Not sure about these ones yet
     // 30004: 'Message blocked',
     // 30003: 'Unreachable destination handset',


### PR DESCRIPTION
#### What's this PR do?
It removes the `30008` error from the array of errors that set an user's `sms_status` as `undeliverable`.

We need this in place before we turn the `twilio-sms-outbound-error-relay` workers back on.

#### How should this be reviewed?
- 👀 

#### Relevant Issues
Fixes [Pivotal#158556247](https://www.pivotaltracker.com/n/projects/2092729/stories/158556247)