### PR TITLE
Additional unsubscribe substitutions and triggers

### DIFF
--- a/brain/index.rive
+++ b/brain/index.rive
@@ -89,7 +89,9 @@
 ! array question  = is there|who|what|when|why|how
 ! array send      = send submit text
 ! array social    = social media|facebook|twitter|instagram|social
-! array unsubscribe = sotp|stop|stopp|stopall|quit|end|unsubscribe|cancel|do not|remove
+! array unsubscribe = unsubscribe|cancel
+  ^ leave|remove|quit|end|exit|opt out|optout|do not|discontinue
+  ^ atop|dtop|sotp|srop|stip|stop|stop all|stopp|stopall|stp
 ! array want      = want|am going|am thinking about
 ! array why       = why y how
 ! array yes       = y ya yas yea yeah yep yes yup

--- a/brain/index.rive
+++ b/brain/index.rive
@@ -91,7 +91,7 @@
 ! array send      = send submit text
 ! array social    = social media|facebook|twitter|instagram|social
 ! array unsubscribe = unsubscribe|cancel
-  ^ leave|remove|quit|end|exit|opt out|optout|do not|discontinue|take me off
+  ^ leave|remove|quit|end|exit|opt out|optout|discontinue|take me off
   ^ atop|dtop|sotp|srop|stip|stop|stop all|stopp|stopall|stp
 ! array want      = want|am going|am thinking about
 ! array why       = why y how

--- a/brain/index.rive
+++ b/brain/index.rive
@@ -81,7 +81,8 @@
   ^ rape|raped|rapes|raping
   ^ is violent|gets violent
   ^ suicidal|suicidial|suicide
-! array messaging = text|texts|txt|texting|txting|talking|talkign|messaging|contacting|sending
+! array messaging = text|texts|txt|texting|txting|talking|talkign
+  ^ messaging|contacting|sending|list|this list
 ! array my        = my this
 ! array no        = n no nah nope nay
 ! array photo     = photo photos mms pic pics pix image image img
@@ -90,7 +91,7 @@
 ! array send      = send submit text
 ! array social    = social media|facebook|twitter|instagram|social
 ! array unsubscribe = unsubscribe|cancel
-  ^ leave|remove|quit|end|exit|opt out|optout|do not|discontinue
+  ^ leave|remove|quit|end|exit|opt out|optout|do not|discontinue|take me off
   ^ atop|dtop|sotp|srop|stip|stop|stop all|stopp|stopall|stp
 ! array want      = want|am going|am thinking about
 ! array why       = why y how

--- a/brain/macros.rive
+++ b/brain/macros.rive
@@ -39,7 +39,7 @@
 + @please @unsubscribe [*]
 @ stop
 
-+ @please do not [*]
++ @please do not @messaging [*]
 @ stop
 
 + leave me alone

--- a/brain/macros.rive
+++ b/brain/macros.rive
@@ -42,6 +42,9 @@
 + @please do not @messaging [*]
 @ stop
 
++ i do not want this
+@ stop
+
 + leave me alone
 @ stop
 

--- a/brain/macros.rive
+++ b/brain/macros.rive
@@ -33,7 +33,13 @@
 + [*] @unsubscribe [*] @messaging [*]
 @ stop
 
++ [*] wrong number [*]
+@ stop
+
 + @please @unsubscribe [*]
+@ stop
+
++ @please do not [*]
 @ stop
 
 + leave me alone

--- a/brain/topics.rive
+++ b/brain/topics.rive
@@ -54,10 +54,10 @@
 + b
 - subscriptionStatusLess{topic=random}
 
-+ c
++ c [*]
 - Sure! Maybe it's been a while since you signed up for DoSomething.org texts, so I'll give you the run down of what these texts are all about. Once a week, I text over 3 million young people with updates on what's happening in the news and/or easy ways to take action in your community.\n\nWant an example of the news we share? Take 2 mins to catch up on what's happening in the news this week and learn what you can do about it https://www.dosomething.org/us/family-separations-us-border?user_id={{user.id}},broadcastsource=info
 
-+ d
++ d [*]
 - subscriptionStatusStop{topic=unsubscribed}
 
 + [*] more [*]
@@ -71,7 +71,13 @@
 // The survey_response topic is commonly used by broadcast entries. This will eventually be
 // deprecated by a content type like an AutoReplyBroadcast that sends a generic auto reply message
 // and changes conversation topic back to random so user gets prompted to continue a campaign.
+
+// NOTE: We're currently survey_response follow up broadcasts to users in askSubscriptionStatus, so
+// we'll duplicate the D unsuscribe trigger for now.
 > topic survey_response includes random
+
++ d [*]
+- subscriptionStatusStop{topic=unsubscribed}
 
 + [*]
 - I'm sorry I didn't understand that! Text Q if you have a question.{topic=random}


### PR DESCRIPTION
#### What's this PR do?

Catches more unsubscribe requests per https://www.pivotaltracker.com/n/projects/2092729/stories/158416150

#### How should this be reviewed?
The one word substitutions can be tested at any time, even when unsubscribed (because the conversation topic is set to `unsubscribed`, which has a [single substitution trigger](https://github.com/DoSomething/gambit-conversations/blob/2.11.4/brain/topics.rive#L18)).

For other topics that include our `random` topic, adds additional triggers for 
* includes "wrong number"
* starts with "please don't / do not"
* says "I don't / do not want this"

Also adds `d` as a valid unsubscribe request to the `survey_response` topic, which we've been sending as a follow up to the `askSubscriptionStatus` topic broadcast.


#### Relevant tickets
Fixes https://www.pivotaltracker.com/n/projects/2092729/stories/158416150

#### Checklist
- [x] Tested on staging.
