### PR TITLE
Fixes error in POST /messages?origin=signup requests for campaigns without topics

### DIFF
--- a/lib/middleware/messages/signup/topic-get.js
+++ b/lib/middleware/messages/signup/topic-get.js
@@ -5,14 +5,15 @@ const helpers = require('../../../helpers');
 module.exports = function getTopicByCampaignId() {
   return (req, res, next) => helpers.topic.fetchByCampaignId(req.campaignId)
     .then((topics) => {
-      if (!topics) {
+      // Each campaign currently only has one topic, which is why this will work for now.
+      // We may add a new field like isWebSignupTopic to determine which topic to save.
+      // @see https://www.pivotaltracker.com/story/show/157981231
+      const firstTopic = topics[0];
+      if (!firstTopic) {
         helpers.addBlinkSuppressHeaders(res);
         return helpers.sendResponseWithStatusCode(res, 204, 'Campaign does not have any topics.');
       }
-      // Each campaign currently only has one topic, which is why this will work for now.
-      // We may need to find the topic that has a isWebSignupTopic propery set.
-      // @see https://www.pivotaltracker.com/story/show/157981231
-      helpers.request.setTopic(req, topics[0]);
+      helpers.request.setTopic(req, firstTopic);
       return next();
     })
     .catch(err => helpers.sendErrorResponse(res, err));

--- a/test/unit/lib/middleware/messages/signup/topic-get.test.js
+++ b/test/unit/lib/middleware/messages/signup/topic-get.test.js
@@ -67,7 +67,7 @@ test('getTopic should send 204 status if no topics found for campaignId', async 
   const next = sinon.stub();
   const middleware = getTopic();
   sandbox.stub(helpers.topic, 'fetchByCampaignId')
-    .returns(Promise.resolve(null));
+    .returns(Promise.resolve([]));
   // TODO: Move this hardcoded message into config to DRY.
   const apiResponseMessage = 'Campaign does not have any topics.';
 


### PR DESCRIPTION
#### What's this PR do?
Fixes `lib/middleware/messages/signup/topic-get` to return a 204 response if a campaign does not have any active topics (currently returns a 500 error ) 

#### How should this be reviewed?
Post a signup message request for [campaign 4044](http://ds-mdata-responder-staging.herokuapp.com/v1/campaigns/4044), which is the campaign id a Runscope test has been posting with and triggering 500 errors with api response `Cannot read property 'id' of undefined`. Verify a 204 response is returned.

#### Relevant tickets
Fixes bug introduced in https://github.com/DoSomething/gambit-conversations/pull/341

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.
