### PR TITLE
Fixes replies when conversation topic is set to 'random'

### DIFF
--- a/config/app/models/conversation.js
+++ b/config/app/models/conversation.js
@@ -1,9 +1,11 @@
 'use strict';
 
+const topicHelperConfig = require('../../lib/helpers/topic');
+
 module.exports = {
   topics: {
     askSubscriptionStatus: 'askSubscriptionStatus',
-    default: 'random',
+    default: topicHelperConfig.randomTopicId,
     campaign: 'campaign',
     support: 'support',
   },

--- a/config/lib/helpers/topic.js
+++ b/config/lib/helpers/topic.js
@@ -14,4 +14,5 @@ module.exports = {
     'tmi_completed',
     'unsubscribed',
   ],
+  randomTopicId: 'random',
 };

--- a/lib/helpers/topic.js
+++ b/lib/helpers/topic.js
@@ -33,6 +33,9 @@ function fetchAllTopics() {
  */
 function fetchById(topicId) {
   logger.debug('helpers.topic.fetchById', { topicId });
+  if (module.exports.isRandomTopicId(topicId)) {
+    return Promise.reject({ status: 404 });
+  }
   if (module.exports.isHardcodedTopicId(topicId)) {
     return Promise.resolve(topicId);
   }
@@ -66,6 +69,14 @@ function isHardcodedTopicId(topicId) {
 }
 
 /**
+ * @param {String} topicId
+ * @return {Boolean}
+ */
+function isRandomTopicId(topicId) {
+  return topicId === config.randomTopicId;
+}
+
+/**
  * Parses a defaultTopicTrigger to set macro reply for topic changes.
  *
  * @param {Object} defaultTopicTrigger
@@ -89,5 +100,6 @@ module.exports = {
   fetchByCampaignId,
   getRenderedTextFromTopicAndTemplateName,
   isHardcodedTopicId,
+  isRandomTopicId,
   parseDefaultTopicTrigger,
 };

--- a/lib/middleware/messages/member/topic-get.js
+++ b/lib/middleware/messages/member/topic-get.js
@@ -22,18 +22,24 @@ module.exports = function getCurrentTopic() {
 
         return helpers.topic.fetchByCampaignId(req.conversation.campaignId)
           .then((topics) => {
-            if (!topics.length) {
+            // Each campaign currently only has one topic, which is why this will work for now.
+            // If a campaign had multiple topics and we're switching to a Content API topic from a
+            // hardcoded topic here, we may want to track the lastCampaignTopicId a user was in to
+            // ensure we ask continue for last specific campaign topic they participated in.
+            const firstTopic = topics[0];
+            if (!firstTopic) {
+              // Technically this should be a closed campaign message, because user's in a campaign
+              // that exists but no longer has topics. We'd need to make a separate request to find
+              // the campaign title, or create a new hardcoded generic topicUnavailable template.
               return helpers.replies.noCampaign(req, res);
             }
-            // Each campaign currently only has one topic, which is why this will work for now.
-            // Ideally all topics should be findable via topics API this may be deprecated.
-            const topic = topics[0];
-            helpers.request.setTopic(req, topic);
-            // Update the topic so we won't have to fetch by campaign upon next request.
-            return req.conversation.changeTopic(topic).then(() => next());
+
+            helpers.request.setTopic(req, firstTopic);
+            // Save the topic so we won't have to fetch by campaignId upon next request.
+            return req.conversation.changeTopic(firstTopic).then(() => next());
           })
           .catch((err) => {
-            // Sanity check for edge-case where campaign may not exist anymore.
+            // Safety check for edge-case where conversation.campaignId no longer exists.
             if (err.status === 404) {
               return helpers.replies.noCampaign(req, res);
             }

--- a/test/unit/lib/lib-helpers/topic.test.js
+++ b/test/unit/lib/lib-helpers/topic.test.js
@@ -71,8 +71,22 @@ test('fetchAllTopics should call gambitCampaigns.fetchTopics', async () => {
 });
 
 // fetchById
+test('fetchById should return 404 error if topicId is the random topicId', async (t) => {
+  const mockTopic = topicFactory.getValidTopic();
+  sandbox.stub(topicHelper, 'isRandomTopicId')
+    .returns(true);
+  sandbox.stub(gambitCampaigns, 'fetchTopicById')
+    .returns(Promise.resolve(mockTopic));
+
+  const result = await t.throws(topicHelper.fetchById());
+  gambitCampaigns.fetchTopicById.should.not.have.been.called;
+  result.status.should.equal(404);
+});
+
 test('fetchById should call gambitCampaigns.fetchTopicById and return object if topicId is not hardcoded', async () => {
   const mockTopic = topicFactory.getValidTopic();
+  sandbox.stub(topicHelper, 'isRandomTopicId')
+    .returns(false);
   sandbox.stub(topicHelper, 'isHardcodedTopicId')
     .returns(false);
   sandbox.stub(gambitCampaigns, 'fetchTopicById')
@@ -85,6 +99,8 @@ test('fetchById should call gambitCampaigns.fetchTopicById and return object if 
 
 test('fetchById should return a string if topicId is hardcoded', async () => {
   const mockTopic = topicFactory.getValidTopic();
+  sandbox.stub(topicHelper, 'isRandomTopicId')
+    .returns(false);
   sandbox.stub(topicHelper, 'isHardcodedTopicId')
     .returns(true);
   sandbox.stub(gambitCampaigns, 'fetchTopicById')
@@ -114,6 +130,12 @@ test('fetchByCampaignId should call helpers.campaign.fetchById and inject campai
 test('isHardcodedTopicId should return whether topicId exists in config.hardcodedTopicIds', (t) => {
   t.truthy(topicHelper.isHardcodedTopicId(hardcodedTopicId));
   t.falsy(topicHelper.isHardcodedTopicId(stubs.getContentfulId()));
+});
+
+// isRandomTopicId
+test('isRandomTopicId should return whether topicId is config.randomTopicId', (t) => {
+  t.truthy(topicHelper.isRandomTopicId(config.randomTopicId));
+  t.falsy(topicHelper.isRandomTopicId(stubs.getContentfulId()));
 });
 
 // parseDefaultTopicTrigger


### PR DESCRIPTION
#### What's this PR do?
Fixes a bug introduced by #346 to restore expected behavior when Gambit receives a member message from a user in the `random` topic:

* If the user's conversation has a `campaignId` set, check if the campaign has any topics available. If so, set the conversation topic to it and ask user whether they wish to continue the campaign (sending the `askContinue` template)

* If it is not set -- return the `noCampaign` template, prompting user to send `menu` to find a campaign to participate in

#### How should this be reviewed?
* Make sure your conversation has a `campaignId` set -- you can do this by texting a keyword for an active campaign (or by sending `menu`)

* Next, opt yourself into a hardcoded topic that eventually changes the topic to `random`, e.g. send `status`, and then respond with a `A` `B` or `C` -- which changes topic to random, or send yourself a `survey_response` broadcast like https://gambit-admin.herokuapp.com/broadcasts/3wl5MyjiS4a4AgQC22E4ES. 

* Once your topic is set to `random`, send Gambit a non-trigger (e.g. "france") and verify the reply sent is an `askContinue` template.

#### Any background context you want to provide?
Returning a 404 error from `helpers.topic.fetchById` didn't seem like the most graceful solution, but it sure seemed easy enough to implement and review. I aim to add a breakdown of each hardcoded topic either into the Gambit Admin wiki or somewhere within the Gambit Admin front-end to document what each hardcoded topic is used for and when to use.

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [x] Tests added for new features/bug fixes.
- [x] Tested on staging.
