### PR TITLE
Remove deprecated campaign topic functions

### DIFF
--- a/app/models/Conversation.js
+++ b/app/models/Conversation.js
@@ -28,7 +28,6 @@ const conversationSchema = new mongoose.Schema({
   },
   topic: String,
   campaignId: Number,
-  signupStatus: String,
   lastOutboundMessage: {
     type: mongoose.Schema.Types.ObjectId,
     ref: 'Message',
@@ -148,62 +147,8 @@ conversationSchema.methods.setDefaultTopic = function () {
 /**
  * @return {Promise}
  */
-conversationSchema.methods.setCampaignTopic = function () {
-  return this.setTopic(config.topics.campaign);
-};
-
-/**
- * @return {Promise}
- */
 conversationSchema.methods.setSupportTopic = function () {
   return this.setTopic(config.topics.support);
-};
-
-/**
- * Returns save of User for updating given Campaign and its topic.
- * TODO: Refactor to just pass a campaignId. We were initially passing a campaign
- * model to set Conversation.topic (if Campaign had its own Rivescript topic defined).
- *
- * @param {Campaign} campaign
- * @return {Promise}
- */
-conversationSchema.methods.setCampaignWithSignupStatus = function (campaign, signupStatus) {
-  this.campaignId = campaign.id;
-  this.signupStatus = signupStatus;
-  logger.debug('setCampaignWithSignupStatus', { campaign: this.campaignId, signupStatus });
-
-  return this.setCampaignTopic();
-};
-
-/**
- * Post signup for current campaign and set it as the topic.
- * @param {Campaign} campaign
- * @param {string} source
- * @param {string} keyword
- */
-conversationSchema.methods.setCampaign = function (campaign) {
-  return this.setCampaignWithSignupStatus(campaign, 'doing');
-};
-
-/**
- * Prompt signup for current campaign.
- * @param {Campaign} campaign
- * @param {string} source
- * @param {string} keyword
- */
-conversationSchema.methods.promptSignupForCampaign = function (campaign) {
-  return this.setCampaignWithSignupStatus(campaign, 'prompt');
-};
-
-/**
- * Decline signup for current campaign.
- * @param {Campaign} campaign
- * @param {string} source
- * @param {string} keyword
- */
-conversationSchema.methods.declineSignup = function () {
-  this.signupStatus = 'declined';
-  return this.save();
 };
 
 /**

--- a/test/unit/app/models/conversation.test.js
+++ b/test/unit/app/models/conversation.test.js
@@ -220,16 +220,6 @@ test('setDefaultTopic calls setTopic with config.topics.default', async () => {
   mockConversation.setTopic.should.have.been.calledWith(topics.default);
 });
 
-// setCampaignTopic
-test('setCampaignTopic calls setTopic with config.topics.campaign', async () => {
-  const mockConversation = conversationFactory.getValidConversation();
-  sandbox.stub(mockConversation, 'setTopic')
-    .returns(Promise.resolve(mockConversation));
-
-  await mockConversation.setCampaignTopic();
-  mockConversation.setTopic.should.have.been.calledWith(topics.campaign);
-});
-
 // setSupportTopic
 test('setSupportTopic calls setTopic with config.topics.support', async () => {
   const mockConversation = conversationFactory.getValidConversation();

--- a/test/unit/lib/middleware/messages/broadcast/conversation-update.test.js
+++ b/test/unit/lib/middleware/messages/broadcast/conversation-update.test.js
@@ -65,15 +65,12 @@ test('updateConversation should call conversation.setTopic if req.topic is set',
   t.context.req.topic = topic;
   sandbox.stub(conversation, 'setTopic')
     .returns(conversationSaveStub);
-  sandbox.stub(conversation, 'promptSignupForCampaign')
-    .returns(conversationSaveStub);
 
   // test
   await middleware(t.context.req, t.context.res, next);
 
   t.context.req.conversation.setTopic.should.have.been.called;
   next.should.have.been.called;
-  t.context.req.conversation.promptSignupForCampaign.should.not.have.been.called;
   helpers.sendErrorResponse.should.not.have.been.called;
 });
 


### PR DESCRIPTION
#### What's this PR do?
More cleaning house, we no longer use these `app/Conversation` instance functions that set a conversation topic to `campaign`, nor do we ever make use of the `signupStatus` property.

#### How should this be reviewed?
Text `menu` and test yes and no responses, verify replies work as expected (nothing breaks).

#### Any background context you want to provide?
* The `signupStatus` property was an idea back from when this was an MVP called `slothie` -- with the intent of avoiding constantly asking the user whether they want to continue a campaign they've declined, but for the sake of simplicity / let's-just-kill-this-as-it's-never-come-up-before-and-would-be-less-code.

* Opening this separate from #359 to make it easier for each PR to review. I need to remember to edit this PR to merge to `master` once #359 is merged.

#### Relevant tickets
#339 cleanup

#### Checklist
- [ ] Tests added for new features/bug fixes.
- [ ] Tested on staging.
