### PR TITLE
Not merged: createdUser macro template [pr]

### DIFF
--- a/brain/macros.rive
+++ b/brain/macros.rive
@@ -6,6 +6,14 @@
 + help
 @ info
 
++ subscribe
+- createdUser
+
+// Join currently gets overridden in Contentful: once it's unpublished, this trigger will catch.
+// @see https://app.contentful.com/spaces/owik07lyerdj/entries/2OSVbOpFGEyGOYqqcgsyqM
++ join
+@ subscribe
+
 + menu
 - menu
 
@@ -16,7 +24,7 @@
 @ q
 
 /**
- * Subscription update triggers.
+ * Profile update triggers.
  */
 + (week|weekly)
 - subscriptionStatusActive{topic=random}

--- a/config/lib/helpers/macro.js
+++ b/config/lib/helpers/macro.js
@@ -5,6 +5,7 @@ module.exports = {
     catchAll: 'catchAll',
     changeTopic: 'changeTopic',
     confirmedTopic: 'confirmedTopic',
+    createdUser: 'createdUser',
     declinedTopic: 'declinedTopic',
     menu: 'menu',
     noReply: 'noReply',
@@ -17,6 +18,7 @@ module.exports = {
     supportRequested: 'supportRequested',
   },
   replies: {
+    createdUser: 'createdUser',
     noReply: 'noReply',
     sendCrisisMessage: 'crisisMessage',
     sendInfoMessage: 'infoMessage',

--- a/config/lib/helpers/template.js
+++ b/config/lib/helpers/template.js
@@ -2,6 +2,7 @@
 
 const underscore = require('underscore');
 
+const createdUserText = 'Hi I\'m Freddie from DoSomething.org! Welcome to my weekly updates (up to 8msg/week). Things to know: Msg&DataRatesApply. Text HELP for help, text STOP to stop.';
 const helpCenterUrl = 'http://doso.me/1jf4/291kep';
 // Note: This url may also appear in hardcoded askSubscriptionStatus topic.
 // @see brain/topics.rive
@@ -51,6 +52,10 @@ const templatesMap = {
       name: 'badWords',
       text: 'Not cool. I\'m a real person & that offends me. I send out these texts to help young ppl take action. If you don\'t want my texts, text STOP or LESS to get less.',
     },
+    createdUser: {
+      name: 'createdUser',
+      text: createdUserText,
+    },
     crisis: {
       name: 'crisis',
       text: 'Thanks for being brave and sharing that. If you want to talk to someone, our friends at CTL are here for you 24/7. Just send a text to 741741. Theyll listen!',
@@ -77,7 +82,7 @@ const templatesMap = {
     },
     subscriptionStatusResubscribed: {
       name: 'subscriptionStatusResubscribed',
-      text: 'Hi I\'m Freddie from DoSomething.org! Welcome to my weekly updates (up to 8msg/week). Things to know: Msg&DataRatesApply. Text HELP for help, text STOP to stop.',
+      text: createdUserText,
     },
     subscriptionStatusStop: {
       name: 'subscriptionStatusStop',

--- a/lib/helpers/macro.js
+++ b/lib/helpers/macro.js
@@ -65,6 +65,7 @@ module.exports = {
     catchAll: () => getMacroForKey('catchAll'),
     changeTopic: () => getMacroForKey('changeTopic'),
     confirmedTopic: () => getMacroForKey('confirmedTopic'),
+    createdUser: () => getMacroForKey('createdUser'),
     declinedTopic: () => getMacroForKey('declinedTopic'),
     menu: () => getMacroForKey('menu'),
     noReply: () => getMacroForKey('noReply'),

--- a/lib/helpers/replies.js
+++ b/lib/helpers/replies.js
@@ -169,6 +169,10 @@ module.exports.badWords = function (req, res) {
   return exports.sendGambitConversationsTemplate(req, res, 'badWords');
 };
 
+module.exports.createdUser = function (req, res) {
+  return exports.sendGambitConversationsTemplate(req, res, 'createdUser');
+};
+
 module.exports.crisisMessage = function (req, res) {
   return exports.sendGambitConversationsTemplate(req, res, 'crisis');
 };

--- a/test/unit/lib/lib-helpers/replies.test.js
+++ b/test/unit/lib/lib-helpers/replies.test.js
@@ -32,6 +32,7 @@ const sandbox = sinon.sandbox.create();
 // misc helper vars
 const gCampResponse = stubs.gambitCampaigns.getReceiveMessageResponse();
 const templates = templatesConfig.templatesMap;
+const gambitConversationsTemplates = templates.gambitConversationsTemplates;
 const resolvedPromise = Promise.resolve({});
 const rejectedPromise = Promise.reject({});
 
@@ -261,49 +262,49 @@ test('invalidAskSignupResponse(): should call sendReplyWithTopicTemplate', async
 });
 
 test('badWords(): should call sendGambitConversationsTemplate', async (t) => {
-  const template = templates.gambitConversationsTemplates.badWords.name;
+  const template = gambitConversationsTemplates.badWords.name;
   await assertSendingGambitConversationsTemplate(t.context.req, t.context.res, template);
 });
 
 test('createdUser(): should call sendGambitConversationsTemplate', async (t) => {
-  const template = templates.gambitConversationsTemplates.createdUser.name;
+  const template = gambitConversationsTemplates.createdUser.name;
   await assertSendingGambitConversationsTemplate(t.context.req, t.context.res, template);
 });
 
 test('crisis(): should call sendGambitConversationsTemplate', async (t) => {
-  const template = templates.gambitConversationsTemplates.crisis.name;
+  const template = gambitConversationsTemplates.crisis.name;
   await assertSendingGambitConversationsTemplate(t.context.req, t.context.res, template, 'crisisMessage');
 });
 
 test('info(): should call sendGambitConversationsTemplate', async (t) => {
-  const template = templates.gambitConversationsTemplates.info.name;
+  const template = gambitConversationsTemplates.info.name;
   await assertSendingGambitConversationsTemplate(t.context.req, t.context.res, template, 'infoMessage');
 });
 
 test('noCampaign(): should call sendGambitConversationsTemplate', async (t) => {
-  const template = templates.gambitConversationsTemplates.noCampaign.name;
+  const template = gambitConversationsTemplates.noCampaign.name;
   await assertSendingGambitConversationsTemplate(t.context.req, t.context.res, template);
 });
 
 test('noReply(): should call sendGambitConversationsTemplate', async (t) => {
-  const template = templates.gambitConversationsTemplates.noReply.name;
+  const template = gambitConversationsTemplates.noReply.name;
   await assertSendingGambitConversationsTemplate(t.context.req, t.context.res, template);
 });
 
 test('subscriptionStatusLess(): should call sendGambitConversationsTemplate', async (t) => {
-  const template = templates.gambitConversationsTemplates.subscriptionStatusLess.name;
+  const template = gambitConversationsTemplates.subscriptionStatusLess.name;
   await assertSendingGambitConversationsTemplate(t.context.req, t.context.res, template);
 });
 
 test('subscriptionStatusStop(): should call sendGambitConversationsTemplate', async (t) => {
-  const template = templates.gambitConversationsTemplates.subscriptionStatusStop.name;
+  const template = gambitConversationsTemplates.subscriptionStatusStop.name;
   await assertSendingGambitConversationsTemplate(t.context.req, t.context.res, template);
 });
 
 test('supportRequested(): should call sendGambitConversationsTemplate if no campaign is found', async (t) => {
   // Campaign is being set beforeEach test, so we need to unset it here
   t.context.req.campaign = undefined;
-  const template = templates.gambitConversationsTemplates.supportRequested.name;
+  const template = gambitConversationsTemplates.supportRequested.name;
   await assertSendingGambitConversationsTemplate(t.context.req, t.context.res, template);
 });
 

--- a/test/unit/lib/lib-helpers/replies.test.js
+++ b/test/unit/lib/lib-helpers/replies.test.js
@@ -265,6 +265,11 @@ test('badWords(): should call sendGambitConversationsTemplate', async (t) => {
   await assertSendingGambitConversationsTemplate(t.context.req, t.context.res, template);
 });
 
+test('createdUser(): should call sendGambitConversationsTemplate', async (t) => {
+  const template = templates.gambitConversationsTemplates.createdUser.name;
+  await assertSendingGambitConversationsTemplate(t.context.req, t.context.res, template);
+});
+
 test('crisis(): should call sendGambitConversationsTemplate', async (t) => {
   const template = templates.gambitConversationsTemplates.crisis.name;
   await assertSendingGambitConversationsTemplate(t.context.req, t.context.res, template, 'crisisMessage');


### PR DESCRIPTION
#### What's this PR do?

Adds a `createdUser` macro that sends a new corresponding `createdUser` template, welcoming new user as a subscriber.

* Hardcodes `join` trigger in `brain/macros.rive` to eventually deprecate the Contentful `join` trigger once this goes live

#### How should this be reviewed?

* Send Gambit `subscribe` and verify reply is a `createdUser` template.

* Send Gambit `join` and verify reply is a `rivescript` template with the Boom! copy


#### Any background context you want to provide?

Once this is deployed to production live, we'll change the `join` trigger with the following steps:

* Unpublish the `join` defaultTopicTrigger (https://gambit-admin.herokuapp.com/triggers#join) in Contentful, flush the G-Campaigns redis cache

* Restart G-Conversations to fetch latest Rivescript triggers

* Send Gambit `join` and verify reply is a `createdUser` template.


#### Relevant tickets
https://www.pivotaltracker.com/story/show/158416129/comments/191210520

#### Checklist
- [x] Documentation added for new features/changed endpoints - Gambit Admin is preemptively indicating that the [JOIN message is hardcoded](https://gambit-admin.herokuapp.com/triggers)
- [x] Tests added for new features/bug fixes.
- [x] Tested on staging.
