### PR TITLE
Adds join trigger and updates subscriptonStatusActive template

### DIFF
--- a/brain/macros.rive
+++ b/brain/macros.rive
@@ -6,6 +6,18 @@
 + help
 @ info
 
++ subscribe
+- subscriptionStatusActive
+
+// Join currently gets overridden in Contentful: once it's unpublished, this trigger will catch.
+// @see https://app.contentful.com/spaces/owik07lyerdj/entries/2OSVbOpFGEyGOYqqcgsyqM
++ join
+@ subscribe
+
++ menu
+- menu
+
+
 + menu
 - menu
 

--- a/config/lib/helpers/template.js
+++ b/config/lib/helpers/template.js
@@ -2,6 +2,7 @@
 
 const underscore = require('underscore');
 
+const createdUserText = 'Hi I\'m Freddie from DoSomething.org! Welcome to my weekly updates (up to 8msg/week). Things to know: Msg&DataRatesApply. Text HELP for help, text STOP to stop.';
 const helpCenterUrl = 'http://doso.me/1jf4/291kep';
 // Note: This url may also appear in hardcoded askSubscriptionStatus topic.
 // @see brain/topics.rive
@@ -69,7 +70,7 @@ const templatesMap = {
     },
     subscriptionStatusActive: {
       name: 'subscriptionStatusActive',
-      text: `Okay, great! I'll text you once a week with updates on what's happening in the news and/or easy ways for you to take action in your community! Wanna take 2 mins to catch up on what's happening in the news this week and what you can do about it? ${newsUrl}?user_id={{user.id}},broadcastsource=weekly`,
+      text: createdUserText,
     },
     subscriptionStatusLess: {
       name: 'subscriptionStatusLess',
@@ -77,7 +78,7 @@ const templatesMap = {
     },
     subscriptionStatusResubscribed: {
       name: 'subscriptionStatusResubscribed',
-      text: 'Hi I\'m Freddie from DoSomething.org! Welcome to my weekly updates (up to 8msg/week). Things to know: Msg&DataRatesApply. Text HELP for help, text STOP to stop.',
+      text: createdUserText,
     },
     subscriptionStatusStop: {
       name: 'subscriptionStatusStop',

--- a/config/lib/helpers/template.js
+++ b/config/lib/helpers/template.js
@@ -2,7 +2,7 @@
 
 const underscore = require('underscore');
 
-const createdUserText = 'Hi I\'m Freddie from DoSomething.org! Welcome to my weekly updates (up to 8msg/week). Things to know: Msg&DataRatesApply. Text HELP for help, text STOP to stop.';
+const activeStatusText = 'Hi I\'m Freddie from DoSomething.org! Welcome to my weekly updates (up to 8msg/week). Things to know: Msg&DataRatesApply. Text HELP for help, text STOP to stop.';
 const helpCenterUrl = 'http://doso.me/1jf4/291kep';
 // Note: This url may also appear in hardcoded askSubscriptionStatus topic.
 // @see brain/topics.rive
@@ -70,7 +70,7 @@ const templatesMap = {
     },
     subscriptionStatusActive: {
       name: 'subscriptionStatusActive',
-      text: createdUserText,
+      text: activeStatusText,
     },
     subscriptionStatusLess: {
       name: 'subscriptionStatusLess',
@@ -78,7 +78,7 @@ const templatesMap = {
     },
     subscriptionStatusResubscribed: {
       name: 'subscriptionStatusResubscribed',
-      text: createdUserText,
+      text: activeStatusText,
     },
     subscriptionStatusStop: {
       name: 'subscriptionStatusStop',

--- a/test/unit/lib/lib-helpers/replies.test.js
+++ b/test/unit/lib/lib-helpers/replies.test.js
@@ -32,6 +32,7 @@ const sandbox = sinon.sandbox.create();
 // misc helper vars
 const gCampResponse = stubs.gambitCampaigns.getReceiveMessageResponse();
 const templates = templatesConfig.templatesMap;
+const gambitConversationsTemplates = templates.gambitConversationsTemplates;
 const resolvedPromise = Promise.resolve({});
 const rejectedPromise = Promise.reject({});
 
@@ -261,44 +262,44 @@ test('invalidAskSignupResponse(): should call sendReplyWithTopicTemplate', async
 });
 
 test('badWords(): should call sendGambitConversationsTemplate', async (t) => {
-  const template = templates.gambitConversationsTemplates.badWords.name;
+  const template = gambitConversationsTemplates.badWords.name;
   await assertSendingGambitConversationsTemplate(t.context.req, t.context.res, template);
 });
 
 test('crisis(): should call sendGambitConversationsTemplate', async (t) => {
-  const template = templates.gambitConversationsTemplates.crisis.name;
+  const template = gambitConversationsTemplates.crisis.name;
   await assertSendingGambitConversationsTemplate(t.context.req, t.context.res, template, 'crisisMessage');
 });
 
 test('info(): should call sendGambitConversationsTemplate', async (t) => {
-  const template = templates.gambitConversationsTemplates.info.name;
+  const template = gambitConversationsTemplates.info.name;
   await assertSendingGambitConversationsTemplate(t.context.req, t.context.res, template, 'infoMessage');
 });
 
 test('noCampaign(): should call sendGambitConversationsTemplate', async (t) => {
-  const template = templates.gambitConversationsTemplates.noCampaign.name;
+  const template = gambitConversationsTemplates.noCampaign.name;
   await assertSendingGambitConversationsTemplate(t.context.req, t.context.res, template);
 });
 
 test('noReply(): should call sendGambitConversationsTemplate', async (t) => {
-  const template = templates.gambitConversationsTemplates.noReply.name;
+  const template = gambitConversationsTemplates.noReply.name;
   await assertSendingGambitConversationsTemplate(t.context.req, t.context.res, template);
 });
 
 test('subscriptionStatusLess(): should call sendGambitConversationsTemplate', async (t) => {
-  const template = templates.gambitConversationsTemplates.subscriptionStatusLess.name;
+  const template = gambitConversationsTemplates.subscriptionStatusLess.name;
   await assertSendingGambitConversationsTemplate(t.context.req, t.context.res, template);
 });
 
 test('subscriptionStatusStop(): should call sendGambitConversationsTemplate', async (t) => {
-  const template = templates.gambitConversationsTemplates.subscriptionStatusStop.name;
+  const template = gambitConversationsTemplates.subscriptionStatusStop.name;
   await assertSendingGambitConversationsTemplate(t.context.req, t.context.res, template);
 });
 
 test('supportRequested(): should call sendGambitConversationsTemplate if no campaign is found', async (t) => {
   // Campaign is being set beforeEach test, so we need to unset it here
   t.context.req.campaign = undefined;
-  const template = templates.gambitConversationsTemplates.supportRequested.name;
+  const template = gambitConversationsTemplates.supportRequested.name;
   await assertSendingGambitConversationsTemplate(t.context.req, t.context.res, template);
 });
 


### PR DESCRIPTION
#### What's this PR do?

Implements the idea here https://github.com/DoSomething/gambit-conversations/pull/361#issuecomment-401954870 --it could make sense to avoid creating a new `createdUser` template and instead just set the `subscriptionStatusActive` template text to be used globally now that it doesn't seem we'd be asking users to respond with subscription status for a while. Ideally each broadcast should have customizable Weekly messages, vs editing our hardcoded `subscriptionStatusActive` macro reply.

#### How should this be reviewed?
Same as #361 


#### Relevant tickets
https://www.pivotaltracker.com/story/show/158416129/comments/191210520

#### Checklist
- [x] Documentation added for new features/changed endpoints.
- [x] Tested on staging.
