### PR TITLE
Throw error if Rivescript replies are not sorted

### DIFF
--- a/lib/rivescript.js
+++ b/lib/rivescript.js
@@ -70,6 +70,9 @@ module.exports.getReply = function (conversation, inboundMessageText) {
 
   return bot.replyAsync(conversationId, inboundMessageText)
     .then((text) => {
+      if (!bot.ready) {
+        throw new Error('Still sorting Rivescript replies.');
+      }
       const res = { text };
       // The inbound message may have triggered a topic change, check bot.uservars to return topic.
       const updatedUservars = bot.getUservars(conversationId);
@@ -77,6 +80,5 @@ module.exports.getReply = function (conversation, inboundMessageText) {
       res.match = updatedUservars.__initialmatch__; // eslint-disable-line no-underscore-dangle
 
       return res;
-    })
-    .catch(err => err);
+    });
 };

--- a/lib/rivescript.js
+++ b/lib/rivescript.js
@@ -5,12 +5,17 @@ const logger = require('heroku-logger');
 const config = require('../config/lib/rivescript');
 
 let brain;
+// If our Rivescript bot receives a user message before the replies are sorted, it sends an reply
+// with a hardcoded error message, 'ERR: Replies Not Sorted'.
+// @see https://github.com/aichaos/rivescript-js/blob/v1.17.2/src/brain.coffee#L265
+// We'll set this hasSortedReplies flag to true once replies have been sorted and the bot is able to
+// respond to user messages.
+let hasSortedReplies = false;
 
 function loadingDone(batchNumber) {
   logger.debug('rivescript.loadingDone', { batchNumber });
-
   brain.sortReplies();
-  brain.ready = true;
+  hasSortedReplies = true;
 }
 
 function loadingError(error) {
@@ -33,7 +38,6 @@ module.exports.createNewBot = function createNewBot() {
       debug: config.debug,
       concat: config.concat,
     });
-    brain.ready = false;
     brain.loadDirectory(config.directory, loadingDone, loadingError);
   } catch (err) {
     logger.error('bot.createNewBot', err);
@@ -70,7 +74,12 @@ module.exports.getReply = function (conversation, inboundMessageText) {
 
   return bot.replyAsync(conversationId, inboundMessageText)
     .then((text) => {
-      if (!bot.ready) {
+      // Throw an error if replies haven't been sorted yet. For SMS member messages, Blink will
+      // retry the request and will eventually send user the correct reply when hasSortedReplies.
+      /* eslint-disable max-len */
+      // @see https://github.com/aichaos/rivescript-js/wiki/Asynchronous-Support#what-happens-in-reply
+      /* eslint-enable max-len */
+      if (!hasSortedReplies) {
         throw new Error('Still sorting Rivescript replies.');
       }
       const res = { text };

--- a/server.js
+++ b/server.js
@@ -24,6 +24,9 @@ helpers.rivescript.fetchAndWriteRivescript()
     logger.info('fetchAndWriteRivescript success', { opts });
     rivescript.getBot();
   })
+  // TODO: If fetchAndWriteRivescript fails, we need to retry it, not carry on as normal, as all
+  // member messages will return errors because the Rivescript bot has not finished sorting replies.
+  // @see lib/rivescript
   .catch(error => logger.error('fetchAndWriteRivescript', { error }));
 
 const db = mongoose.connection;


### PR DESCRIPTION
#### What's this PR do?

Fixes up `lib/rivescript` to throw an error if  a member message is received before `sortReplies()` function has finished on app start. This way, Blink will retry the message upon errors and the user won't receive a rather unhelpful ["ERR: Replies Not Sorted" reply.](https://github.com/aichaos/rivescript-js/blob/v1.17.2/src/brain.coffee#L265)


#### How should this be reviewed?
It's not pretty but the easiest way to replicate the error is delaying setting the `ready` property in `loadingDone(batchNumber)`, e.g.:
```
function loadingDone(batchNumber) {
  logger.debug('rivescript.loadingDone', { batchNumber });

  brain.sortReplies();
  setTimeout(() => brain.ready = true, 5000);
}
```


#### Any background context you want to provide?
Another cleanup TODO to avoid long loading times is that we don't need to fetch all topics to write the `menu` topic children, we can just use topics that have `defaultTopicTrigger` entries referencing them.

#### Relevant tickets
Fixes https://gambit-admin-staging.herokuapp.com/requests/9685d106-8a1c-445e-a388-6eb2a19d6f29
<img width="402" alt="screen shot 2018-07-03 at 11 02 04 am" src="https://user-images.githubusercontent.com/1236811/42236742-9d31e500-7eb0-11e8-9cfb-71d1781bb331.png">



#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tested on staging.
