### PR TITLE
Adds helpers.template.getSubscriptionStatusActive

### DIFF
--- a/lib/helpers/template.js
+++ b/lib/helpers/template.js
@@ -3,7 +3,15 @@
 const logger = require('../../lib/logger');
 const config = require('../../config/lib/helpers/template');
 
+/**
+ * @return {Object}
+ */
+function getSubscriptionStatusActive() {
+  return config.templatesMap.gambitConversationsTemplates.subscriptionStatusActive;
+}
+
 module.exports = {
+  getSubscriptionStatusActive,
   getTextForTemplate: function getTextForTemplate(templateName) {
     return config.conversationsTemplatesText[templateName];
   },

--- a/test/unit/lib/lib-helpers/template.test.js
+++ b/test/unit/lib/lib-helpers/template.test.js
@@ -28,6 +28,14 @@ test.afterEach(() => {
   sandbox.restore();
 });
 
+// getSubscriptionStatusActive
+test('getSubscriptionStatusActive should return subscriptionStatusActive config object', () => {
+  const result = templateHelper.getSubscriptionStatusActive();
+  result.should.deep.equal(config.templatesMap
+    .gambitConversationsTemplates.subscriptionStatusActive);
+});
+
+// getTextForTemplate
 test('getTextForTemplate should return text for given template', () => {
   const template = 'badWords';
   const templateText = config.conversationsTemplatesText[template];
@@ -39,16 +47,19 @@ test('getTextForTemplate should return falsy for undefined template', (t) => {
   t.falsy(templateHelper.getTextForTemplate(undefinedTemplateName));
 });
 
+// isAskContinueTemplate
 test('isAskContinueTemplate should return boolean', (t) => {
   t.true(templateHelper.isAskContinueTemplate('askContinue'));
   t.falsy(templateHelper.isAskContinueTemplate(undefinedTemplateName));
 });
 
+// isAskSignupTemplate
 test('isAskSignupTemplate should return boolean', (t) => {
   t.true(templateHelper.isAskSignupTemplate('askSignup'));
   t.falsy(templateHelper.isAskSignupTemplate(undefinedTemplateName));
 });
 
+// isGambitCampaignsTemplate
 test('isGambitCampaignsTemplate should return boolean', (t) => {
   t.true(templateHelper.isGambitCampaignsTemplate('askQuantity'));
   t.falsy(templateHelper.isGambitCampaignsTemplate(undefinedTemplateName));


### PR DESCRIPTION
#### What's this PR do?
Adds a `helpers.template` function to return the message template name and text for an outbound  `subscriptionStatusActive` message.

#### How should this be reviewed?
Run tests. We're not calling this anywhere in code yet, but aims to be useful for sending one-off welcome messages via web or SMS.

#### Checklist
- [x] Tests added for new features/bug fixes.
- [ ] Tested on staging.