### PR TITLE
Send message instead of noReply for unsubscribed wildcard

### DIFF
--- a/brain/topics.rive
+++ b/brain/topics.rive
@@ -19,7 +19,7 @@
 - subscriptionStatusStop
 
 + [*]
-- noReply
+- These are DoSomething.org Alerts. Reply HELP for help. Text JOIN to receive 4-8 msgs/mth or LESS for 1msg/mth.
 
 < topic
 

--- a/config/lib/helpers/template.js
+++ b/config/lib/helpers/template.js
@@ -2,7 +2,7 @@
 
 const underscore = require('underscore');
 
-const activeStatusText = 'Hi I\'m Freddie from DoSomething.org! Welcome to my weekly updates (up to 8msg/week). Things to know: Msg&DataRatesApply. Text HELP for help, text STOP to stop.';
+const activeStatusText = 'Hi I\'m Freddie from DoSomething.org! Welcome to my weekly updates (up to 8msg/month). Things to know: Msg&DataRatesApply. Text HELP for help, text STOP to stop.';
 const helpCenterUrl = 'http://doso.me/1jf4/291kep';
 // Note: This url may also appear in hardcoded askSubscriptionStatus topic.
 // @see brain/topics.rive


### PR DESCRIPTION
#### What's this PR do?

* Sends an info style message to an unsubscribed user instead of radio silence per https://www.pivotaltracker.com/story/show/158855005. This way, if a user unsubscribes but wants to resubscribe later via keyword -- they'll be prompted with the message to JOIN 

* Fixes copy in the `subscriptionStatusActive` template per https://dosomething.slack.com/archives/C2C8NLNAY/p1531159393000502

#### How should this be reviewed?
Unsubscribe, and text back something other than a JOIN or LESS keyword. Confirm the reply informs what the service is and how to subscribe.

#### Relevant tickets
Fixes https://www.pivotaltracker.com/story/show/158855005

#### Checklist
- [x] Tested on staging.
