### PR TITLE
Gambit Campaigns cleanup + moves GET /broadcasts to v2 [pr]

### DIFF
--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -19,14 +19,11 @@ module.exports = function init(app) {
   // v1
   // Restified routes.
   app.use(mongooseRoutes);
-  // GET broadcasts routes are prefixed with v1 to keep consistent with our v1 Mongoose routes.
-  // TODO: Prefix with v2, resolve Express Mongoose Restify conflicts (or build custom GET routes).
-  app.use('/api/v1/broadcasts/:broadcastId',
-    broadcastsSingleRoute);
-  app.use('/api/v1/broadcasts',
-    broadcastsIndexRoute);
-
   // v2
+  app.use('/api/v2/broadcasts/:broadcastId',
+    broadcastsSingleRoute);
+  app.use('/api/v2/broadcasts',
+    broadcastsIndexRoute);
   app.use('/api/v2/messages',
     /**
      * parses Metadata like requestId and retryCount

--- a/config/lib/gambit-campaigns.js
+++ b/config/lib/gambit-campaigns.js
@@ -8,5 +8,6 @@ module.exports = {
   closedStatusValue: 'closed',
   endpoints: {
     broadcasts: 'broadcasts',
+    defaultTopicTriggers: 'defaultTopicTriggers',
   },
 };

--- a/config/lib/gambit-campaigns.js
+++ b/config/lib/gambit-campaigns.js
@@ -8,6 +8,8 @@ module.exports = {
   closedStatusValue: 'closed',
   endpoints: {
     broadcasts: 'broadcasts',
+    campaigns: 'campaigns',
     defaultTopicTriggers: 'defaultTopicTriggers',
+    topics: 'topics',
   },
 };

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -22,10 +22,10 @@ All v1 endpoints are served via the Express Restify Mongoose package. [Docs](htt
 
 Endpoint | Functionality                                           
 -------- | -------------
-`/api/v1/conversations` | Retrieve conversations.
-`/api/v1/conversations/:id` | Retrieve a conversation.
-`/api/v1/messages` | Retrieve messages.
-`/api/v1/messages/:id` | Retrieve a message.
+`GET /api/v1/conversations` | Retrieve conversations.
+`GET /api/v1/conversations/:id` | Retrieve a conversation.
+`GET /api/v1/messages` | Retrieve messages.
+`GET /api/v1/messages/:id` | Retrieve a message.
 
 
 

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -5,30 +5,30 @@ This is __Gambit Conversations__, the DoSomething.org multi-platform chatbot ser
 ## Authentication
 See [Authentication](authentication.md) for details on authorizing your requests.
 
-
 ## Endpoints
-
-### v1
-
-Endpoint | Functionality                                           
--------- | -------------
-`GET /api/v1/broadcasts` | Retrieve all Broadcasts.
-`GET /api/v1/broadcasts/:id` | [Retrieve a Broadcast](endpoints/broadcasts.md).
-`GET /api/v1/conversations` | Retrieve all Conversations.
-`GET /api/v1/conversations/:id` | Retrieve a Conversation.
-`GET /api/v1/messages` | Retrieve all Messages.
-`GET /api/v1/messages/:id` | Retrieve a Message.
 
 ### v2
 
 Endpoint | Functionality                                           
 -------- | -------------
-`POST /api/v2/messages` | [Create a Message](endpoints/messages.md).
-`PATCH /api/v2/messages/:messageId` | [Update a Message](endpoints/messages.md).
+`GET /api/v2/broadcasts` | Retrieves broadcasts (proxies the [Gambit Campaigns `GET /broadcasts` endpoint](https://github.com/DoSomething/gambit-campaigns/tree/master/documentation))
+`GET /api/v2/broadcasts/:id` | [Retrieve a broadcast](endpoints/broadcasts.md).
+`POST /api/v2/messages` | [Create a message](endpoints/messages.md).
+`PATCH /api/v2/messages/:messageId` | [Update a message](endpoints/messages.md).
 
-### Query parameters
+### v1
 
-The GET Conversation and Messages are served via the Express Restify Mongoose package. [Docs](https://florianholzapfel.github.io/express-restify-mongoose/)
+All v1 endpoints are served via the Express Restify Mongoose package. [Docs](https://florianholzapfel.github.io/express-restify-mongoose/)
+
+Endpoint | Functionality                                           
+-------- | -------------
+`/api/v1/conversations` | Retrieve conversations.
+`/api/v1/conversations/:id` | Retrieve a conversation.
+`/api/v1/messages` | Retrieve messages.
+`/api/v1/messages/:id` | Retrieve a message.
+
+
+
 
 ### Filtering
 * https://gambit-conversations-staging.herokuapp.com/api/v1/messages?query={"platform":"slack"}

--- a/documentation/endpoints/broadcasts.md
+++ b/documentation/endpoints/broadcasts.md
@@ -1,9 +1,9 @@
 # Broadcasts
 
 ```
-GET /api/v1/broadcasts/:broadcastId
+GET /api/v2/broadcasts/:broadcastId
 ```
-Retrieves a [Broadcast](https://github.com/DoSomething/gambit-admin/wiki/Broadcasts).
+Fetches a broadcast from [Gambit Campaigns API](https://github.com/DoSomething/gambit-campaigns/tree/master/documentation), and returns additional data properties for send configuration and message stats. 
 
 
 ## Examples
@@ -12,7 +12,7 @@ Retrieves a [Broadcast](https://github.com/DoSomething/gambit-admin/wiki/Broadca
 <summary><strong>Example Request</strong></summary>
 
 ```
-curl -X "GET" "http://localhost:5100/api/v1/broadcasts/1S4pnWcZ3qeK0IyU6u4gYE" \
+curl -X "GET" "http://localhost:5100/api/v2/broadcasts/1S4pnWcZ3qeK0IyU6u4gYE" \
      -H "Authorization: Basic cHVwcGV0OnRvdGFsbHlzZWNyZXQ="
 ```
 </details>
@@ -22,40 +22,46 @@ curl -X "GET" "http://localhost:5100/api/v1/broadcasts/1S4pnWcZ3qeK0IyU6u4gYE" \
 
 ```
 {
-    "data": {
-        "id": "257eBFFXnay6QoUOCuuiS0",
-        "name": "GrabTheMic2018_Jul3_Pending_FINAL",
-        "createdAt": "2018-07-04T13:24:32.793Z",
-        "updatedAt": "2018-07-05T13:34:50.370Z",
-        "message": {
-          "text": "It's Freddie, happy 5th of July! Even though the holiday's over, you can still enjoy this playlist we made you all summer. Enjoy: https://www.dosomething.org/us/fourth-of-july-playlist?user_id={{user.id}}&broadcastid=257eBFFXnay6QoUOCuuiS0",
-          "attachments": [
-            
-          ],
-          "template": "rivescript"
-        },
-        "campaignId": null,
-        "topic": "survey_response",
-        "webhook": {
-            "headers": {
-                "Content-Type": "application/json"
-            },
-            "url": "http://<secret>:<secret>@localhost:5050/api/v1/webhooks/customerio-gambit-broadcast",
-            "body": {
-                "northstarId": "{{customer.id}}",
-                "broadcastId": "1S4pnWcZ3qeK0IyU6u4gYE"
-            }
-        },,
-        "stats": {
-            "outbound": {
-                "total": 2
-            },
-            "inbound": {
-                "total": 2,
-                "macros": {}
-            }
+  "data": {
+    "id": "257eBFFXnay6QoUOCuuiS0",
+    "name": "GrabTheMic2018_Jul3_Pending_FINAL",
+    "createdAt": "2018-07-04T13:24:32.793Z",
+    "updatedAt": "2018-07-05T13:34:50.370Z",
+    "message": {
+      "text": "It's Freddie, happy 5th of July! Even though the holiday's over, you can still enjoy this playlist we made you all summer. Enjoy: https://www.dosomething.org/us/fourth-of-july-playlist?user_id={{user.id}}&broadcastid=257eBFFXnay6QoUOCuuiS0",
+      "attachments": [
+        
+      ],
+      "template": "rivescript"
+    },
+    "campaignId": null,
+    "topic": "survey_response",
+    "webhook": {
+      "headers": {
+        "Content-Type": "application/json"
+      },
+      "url": "http://<secret>:<secret>@localhost:5050/api/v1/webhooks/customerio-gambit-broadcast",
+      "body": {
+        "northstarId": "{{customer.id}}",
+        "broadcastId": "257eBFFXnay6QoUOCuuiS0"
+      }
+    },
+    "stats": {
+      "outbound": {
+        "total": 13059
+      },
+      "inbound": {
+        "total": 460,
+        "macros": {
+          "subscriptionStatusStop": 25,
+          "sendInfoMessage": 1,
+          "declinedTopic": 40,
+          "confirmedTopic": 384,
+          "catchAll": 10
         }
+      }
     }
+  }
 }
 ```
 </details>

--- a/lib/gambit-campaigns.js
+++ b/lib/gambit-campaigns.js
@@ -80,14 +80,6 @@ module.exports.fetchDefaultTopicTriggers = function () {
 };
 
 /**
- * @return {Promise}
- */
-module.exports.fetchTopics = function () {
-  return executeGet('topics')
-    .then(res => res.data);
-};
-
-/**
  * @param {object} campaign
  * @return {boolean}
  */

--- a/lib/gambit-campaigns.js
+++ b/lib/gambit-campaigns.js
@@ -14,12 +14,13 @@ const apiKey = config.clientOptions.apiKey;
  * @param {string} endpoint
  * @return {Promise}
  */
-function executeGet(endpoint) {
+function executeGet(endpoint, query = {}) {
   const url = `${uri}/${endpoint}`;
   logger.debug('gambitCampaigns.get', { url });
 
   return superagent.get(url)
-    .then(res => res.body.data)
+    .query(query)
+    .then(res => res.body)
     .catch(err => Promise.reject(err));
 }
 
@@ -43,14 +44,15 @@ function executePost(endpoint, data) {
  * @return {Promise}
  */
 function fetchBroadcastById(broadcastId) {
-  return module.exports.executeGet(`${config.endpoints.broadcasts}/${broadcastId}`);
+  return module.exports.executeGet(`${config.endpoints.broadcasts}/${broadcastId}`)
+    .then(res => res.data);
 }
 
 /**
  * @return {Promise}
  */
-function fetchBroadcasts() {
-  return module.exports.executeGet(config.endpoints.broadcasts);
+function fetchBroadcasts(query) {
+  return module.exports.executeGet(config.endpoints.broadcasts, query);
 }
 
 module.exports = {
@@ -65,21 +67,24 @@ module.exports = {
  * @return {Promise}
  */
 module.exports.fetchCampaigns = function () {
-  return executeGet('campaigns');
+  return executeGet('campaigns')
+    .then(res => res.data);
 };
 
 /**
  * @return {Promise}
  */
 module.exports.fetchDefaultTopicTriggers = function () {
-  return executeGet('defaultTopicTriggers');
+  return executeGet('defaultTopicTriggers')
+    .then(res => res.data);
 };
 
 /**
  * @return {Promise}
  */
 module.exports.fetchTopics = function () {
-  return executeGet('topics');
+  return executeGet('topics')
+    .then(res => res.data);
 };
 
 /**
@@ -136,7 +141,8 @@ module.exports.postCampaignActivity = function (req) {
  * @return {Promise}
  */
 module.exports.fetchCampaignById = function fetchCampaignById(campaignId) {
-  return executeGet(`campaigns/${campaignId}`);
+  return executeGet(`campaigns/${campaignId}`)
+    .then(res => res.data);
 };
 
 /**
@@ -144,5 +150,6 @@ module.exports.fetchCampaignById = function fetchCampaignById(campaignId) {
  * @return {Promise}
  */
 module.exports.fetchTopicById = function fetchTopicById(topicId) {
-  return executeGet(`topics/${topicId}`);
+  return executeGet(`topics/${topicId}`)
+    .then(res => res.data);
 };

--- a/lib/gambit-campaigns.js
+++ b/lib/gambit-campaigns.js
@@ -49,16 +49,26 @@ function fetchBroadcastById(broadcastId) {
 }
 
 /**
+ * @param {Object} query
  * @return {Promise}
  */
-function fetchBroadcasts(query) {
+function fetchBroadcasts(query = {}) {
   return module.exports.executeGet(config.endpoints.broadcasts, query);
+}
+
+/**
+ * @param {Object} query
+ * @return {Promise}
+ */
+function fetchDefaultTopicTriggers(query = {}) {
+  return module.exports.executeGet(config.endpoints.defaultTopicTriggers, query);
 }
 
 module.exports = {
   executeGet,
   fetchBroadcastById,
   fetchBroadcasts,
+  fetchDefaultTopicTriggers,
 };
 
 // TODO: Refactor/move functions below to use config.endpoints and define via module.exports above.
@@ -68,14 +78,6 @@ module.exports = {
  */
 module.exports.fetchCampaigns = function () {
   return executeGet('campaigns')
-    .then(res => res.data);
-};
-
-/**
- * @return {Promise}
- */
-module.exports.fetchDefaultTopicTriggers = function () {
-  return executeGet('defaultTopicTriggers')
     .then(res => res.data);
 };
 

--- a/lib/gambit-campaigns.js
+++ b/lib/gambit-campaigns.js
@@ -11,7 +11,9 @@ const apiKey = config.clientOptions.apiKey;
 
 /**
  * Executes a GET request to given Gambit Campaigns endpoint.
- * @param {string} endpoint
+ *
+ * @param {String} endpoint
+ * @param {Object} query
  * @return {Promise}
  */
 function executeGet(endpoint, query = {}) {
@@ -26,8 +28,9 @@ function executeGet(endpoint, query = {}) {
 
 /**
  * Executes a POST request to given Gambit Campaigns endpoint with given data.
- * @param {string} endpoint
- * @param {object} data
+ *
+ * @param {String} endpoint
+ * @param {Object} data
  * @return {Promise}
  */
 function executePost(endpoint, data) {

--- a/lib/gambit-campaigns.js
+++ b/lib/gambit-campaigns.js
@@ -60,6 +60,23 @@ function fetchBroadcasts(query = {}) {
 }
 
 /**
+ * @param {Number} campaignId
+ * @return {Promise}
+ */
+function fetchCampaignById(campaignId) {
+  return executeGet(`${config.endpoints.campaigns}/${campaignId}`)
+    .then(res => res.data);
+}
+
+/**
+ * @param {Object} query
+ * @return {Promise}
+ */
+function fetchCampaigns(query = {}) {
+  return module.exports.executeGet(config.endpoints.campaigns, query);
+}
+
+/**
  * @param {Object} query
  * @return {Promise}
  */
@@ -67,22 +84,26 @@ function fetchDefaultTopicTriggers(query = {}) {
   return module.exports.executeGet(config.endpoints.defaultTopicTriggers, query);
 }
 
+/**
+ * @param {String} topicId
+ * @return {Promise}
+ */
+function fetchTopicById(topicId) {
+  return executeGet(`${config.endpoints.topics}/${topicId}`)
+    .then(res => res.data);
+}
+
 module.exports = {
   executeGet,
   fetchBroadcastById,
   fetchBroadcasts,
+  fetchCampaignById,
+  fetchCampaigns,
   fetchDefaultTopicTriggers,
+  fetchTopicById,
 };
 
-// TODO: Refactor/move functions below to use config.endpoints and define via module.exports above.
-
-/**
- * @return {Promise}
- */
-module.exports.fetchCampaigns = function () {
-  return executeGet('campaigns')
-    .then(res => res.data);
-};
+// TODO: move functions below to relevant helpers.
 
 /**
  * TODO: Move this into helpers.campaign
@@ -119,7 +140,7 @@ function getCampaignActivityPayloadFromReq(req) {
 }
 
 /**
- * Posts campaign activity to Gambit Campaigns. 
+ * Posts campaign activity to Gambit Campaigns.
  * TODO: Move this into helpers.request
  */
 module.exports.postCampaignActivity = function (req) {
@@ -135,22 +156,4 @@ module.exports.postCampaignActivity = function (req) {
       })
       .catch(err => reject(err));
   });
-};
-
-/**
- * @param {Number} campaignId
- * @return {Promise}
- */
-module.exports.fetchCampaignById = function fetchCampaignById(campaignId) {
-  return executeGet(`campaigns/${campaignId}`)
-    .then(res => res.data);
-};
-
-/**
- * @param {String} topicId
- * @return {Promise}
- */
-module.exports.fetchTopicById = function fetchTopicById(topicId) {
-  return executeGet(`topics/${topicId}`)
-    .then(res => res.data);
 };

--- a/lib/gambit-campaigns.js
+++ b/lib/gambit-campaigns.js
@@ -85,6 +85,7 @@ module.exports.fetchCampaigns = function () {
 };
 
 /**
+ * TODO: Move this into helpers.campaign
  * @param {object} campaign
  * @return {boolean}
  */
@@ -94,6 +95,8 @@ module.exports.isClosedCampaign = function (campaign) {
 
 /**
  * Parse our incoming Express request for expected Gambit Campaigns format.
+ * TODO: Move this into helpers.request
+ *
  * @param {object} req
  * @return {object}
  */
@@ -116,7 +119,8 @@ function getCampaignActivityPayloadFromReq(req) {
 }
 
 /**
- * Posts campaign activity to Gambit Campaigns.
+ * Posts campaign activity to Gambit Campaigns. 
+ * TODO: Move this into helpers.request
  */
 module.exports.postCampaignActivity = function (req) {
   const data = getCampaignActivityPayloadFromReq(req);

--- a/lib/gambit-campaigns.js
+++ b/lib/gambit-campaigns.js
@@ -64,7 +64,7 @@ function fetchBroadcasts(query = {}) {
  * @return {Promise}
  */
 function fetchCampaignById(campaignId) {
-  return executeGet(`${config.endpoints.campaigns}/${campaignId}`)
+  return module.exports.executeGet(`${config.endpoints.campaigns}/${campaignId}`)
     .then(res => res.data);
 }
 
@@ -89,7 +89,7 @@ function fetchDefaultTopicTriggers(query = {}) {
  * @return {Promise}
  */
 function fetchTopicById(topicId) {
-  return executeGet(`${config.endpoints.topics}/${topicId}`)
+  return module.exports.executeGet(`${config.endpoints.topics}/${topicId}`)
     .then(res => res.data);
 }
 

--- a/lib/helpers/broadcast.js
+++ b/lib/helpers/broadcast.js
@@ -6,10 +6,18 @@ const Message = require('../../app/models/Message');
 
 const config = require('../../config/lib/helpers/broadcast');
 
+/**
+ * @param {Object} query
+ * @return {Promise}
+ */
 function fetchAll(query = {}) {
   return gambitCampaigns.fetchBroadcasts(query);
 }
 
+/**
+ * @param {String} query
+ * @return {Promise}
+ */
 function fetchById(broadcastId) {
   return gambitCampaigns.fetchBroadcastById(broadcastId);
 }

--- a/lib/helpers/broadcast.js
+++ b/lib/helpers/broadcast.js
@@ -6,8 +6,8 @@ const Message = require('../../app/models/Message');
 
 const config = require('../../config/lib/helpers/broadcast');
 
-function fetchAll() {
-  return gambitCampaigns.fetchBroadcasts();
+function fetchAll(query = {}) {
+  return gambitCampaigns.fetchBroadcasts(query);
 }
 
 function fetchById(broadcastId) {

--- a/lib/helpers/broadcast.js
+++ b/lib/helpers/broadcast.js
@@ -10,7 +10,7 @@ const config = require('../../config/lib/helpers/broadcast');
  * @param {Object} query
  * @return {Promise}
  */
-function fetchAll(query = {}) {
+function fetch(query = {}) {
   return gambitCampaigns.fetchBroadcasts(query);
 }
 
@@ -92,7 +92,7 @@ function formatStats(data) {
  * Broadcast helper
  */
 module.exports = {
-  fetchAll,
+  fetch,
   fetchById,
   /**
    * @param {boolean} useApiVersion2

--- a/lib/helpers/campaign.js
+++ b/lib/helpers/campaign.js
@@ -6,7 +6,7 @@ const config = require('../../config/lib/helpers/campaign');
 
 function fetchAllActive() {
   return gambitCampaigns.fetchCampaigns()
-    .then(campaigns => campaigns.filter(campaign => !module.exports.isClosedCampaign(campaign)));
+    .then(res => res.data.filter(campaign => !module.exports.isClosedCampaign(campaign)));
 }
 
 /**

--- a/lib/helpers/rivescript.js
+++ b/lib/helpers/rivescript.js
@@ -133,7 +133,8 @@ function fetchAndWriteRivescript() {
       const triggers = [];
       defaultTopicTriggers.forEach((defaultTopicTrigger) => {
         triggers.push(module.exports.getRivescriptFromDefaultTopicTrigger(defaultTopicTrigger));
-        if (defaultTopicTrigger.reply && defaultTopicTrigger.reply.startsWith('changeTopic')) {
+        const changeTopicMacro = helpers.macro.macros.changeTopic();
+        if (defaultTopicTrigger.reply && defaultTopicTrigger.reply.startsWith(changeTopicMacro)) {
           const topicId = defaultTopicTrigger.topic.id;
           if (!topics[topicId]) {
             topics[topicId] = module.exports.getRivescriptMenuTopicForTopicId(topicId);

--- a/lib/helpers/rivescript.js
+++ b/lib/helpers/rivescript.js
@@ -3,8 +3,35 @@
 const fs = require('fs');
 const helpers = require('../helpers');
 const logger = require('../logger');
+const gambitCampaigns = require('../gambit-campaigns');
 const config = require('../../config/lib/helpers/rivescript');
 const rivescriptBotConfig = require('../../config/lib/rivescript');
+
+/**
+ * @param {Object} query
+ * @return {Promise}
+ */
+function fetchDefaultTopicTriggers(query = {}) {
+  return gambitCampaigns.fetchDefaultTopicTriggers(query)
+    .then(res => res.data.map(module.exports.parseDefaultTopicTrigger));
+}
+
+/**
+ * Modifies the reply property if given defaultTopicTrigger is a changeTopic macro.
+ *
+ * @param {Object} defaultTopicTrigger
+ * @return {Object}
+ */
+function parseDefaultTopicTrigger(defaultTopicTrigger) {
+  if (!defaultTopicTrigger) {
+    throw new Error('parseDefaultTopicTrigger cannot parse falsy defaultTopicTrigger');
+  }
+  const data = Object.assign({}, defaultTopicTrigger);
+  if (data.topic && data.topic.id) {
+    data.reply = helpers.macro.getChangeTopicMacroFromTopicId(data.topic.id);
+  }
+  return data;
+}
 
 /**
  *  Returns a string to be used as a line of Rivescript.
@@ -126,7 +153,9 @@ function joinRivescriptLines(lines) {
  * @return {Promise}
  */
 function fetchAndWriteRivescript() {
-  return helpers.topic.fetchAllDefaultTopicTriggers()
+  // TODO: We may eventually add enough defaultTopicTrigger entries that we need to execute multiple
+  // GET requests fo fetch all content required for our default topic.
+  return module.exports.fetchDefaultTopicTriggers()
     .then((defaultTopicTriggers) => {
       logger.info('fetchAllDefaultTopicTriggers success', { count: defaultTopicTriggers.length });
       const topics = {};
@@ -141,13 +170,16 @@ function fetchAndWriteRivescript() {
           }
         }
       });
+      // Save all Rivescript triggers and topics as a string.
       const data = module.exports.joinRivescriptLines(triggers.concat(Object.values(topics)));
+      // Write it to filesystem to be loaded by the Rivescript bot.
       return module.exports.writeRivescript(data);
     });
 }
 
 module.exports = {
   fetchAndWriteRivescript,
+  fetchDefaultTopicTriggers,
   formatRivescriptLine,
   getRedirectRivescript,
   getReplyRivescript,
@@ -156,5 +188,6 @@ module.exports = {
   getRivescriptFromTriggerTextAndRivescriptLine,
   getRivescriptMenuTopicForTopicId,
   joinRivescriptLines,
+  parseDefaultTopicTrigger,
   writeRivescript,
 };

--- a/lib/helpers/rivescript.js
+++ b/lib/helpers/rivescript.js
@@ -162,9 +162,9 @@ function fetchAndWriteRivescript() {
       const triggers = [];
       defaultTopicTriggers.forEach((defaultTopicTrigger) => {
         triggers.push(module.exports.getRivescriptFromDefaultTopicTrigger(defaultTopicTrigger));
-        const changeTopicMacro = helpers.macro.macros.changeTopic();
-        if (defaultTopicTrigger.reply && defaultTopicTrigger.reply.startsWith(changeTopicMacro)) {
-          const topicId = defaultTopicTrigger.topic.id;
+        const topic = defaultTopicTrigger.topic;
+        if (topic) {
+          const topicId = topic.id;
           if (!topics[topicId]) {
             topics[topicId] = module.exports.getRivescriptMenuTopicForTopicId(topicId);
           }

--- a/lib/helpers/rivescript.js
+++ b/lib/helpers/rivescript.js
@@ -59,13 +59,11 @@ function getReplyRivescript(triggerText, replyText) {
  * @return {String}
  */
 function getRivescriptFromDefaultTopicTrigger(defaultTopicTrigger) {
-  if (!defaultTopicTrigger) {
-    return null;
-  }
   if (defaultTopicTrigger.redirect) {
     return module.exports
       .getRedirectRivescript(defaultTopicTrigger.trigger, defaultTopicTrigger.redirect);
   }
+
   return module.exports
     .getReplyRivescript(defaultTopicTrigger.trigger, defaultTopicTrigger.reply);
 }
@@ -74,12 +72,12 @@ function getRivescriptFromDefaultTopicTrigger(defaultTopicTrigger) {
  * Returns Rivescript defining a topic with the given topic id.
  * Eventually we may add handle topic-specific triggers here once available via Content API.
  *
- * @param {Object} topic
+ * @param {String} topicId
  * @return {String}
  */
-function getRivescriptFromTopic(topic) {
+function getRivescriptMenuTopicForTopicId(topicId) {
   // The menu topic is defined in brain/topics.rive
-  const topicDefinition = `topic ${topic.id} includes menu`;
+  const topicDefinition = `topic ${topicId} includes menu`;
   return module.exports.joinRivescriptLines([
     module.exports.formatRivescriptLine('>', topicDefinition),
     // TODO: catchAll macro value should be set in config.
@@ -87,15 +85,6 @@ function getRivescriptFromTopic(topic) {
     module.exports.getReplyRivescript('[*]', 'catchAll'),
     module.exports.formatRivescriptLine('<', 'topic'),
   ]);
-}
-
-/**
- * @param {Array} topics
- * @return {String}
- */
-function getRivescriptFromTopics(topics) {
-  const topicRivescripts = topics.map(getRivescriptFromTopic);
-  return module.exports.joinRivescriptLines(topicRivescripts);
 }
 
 /**
@@ -137,21 +126,21 @@ function joinRivescriptLines(lines) {
  * @return {Promise}
  */
 function fetchAndWriteRivescript() {
-  const fetchRequests = [
-    helpers.topic.fetchAllDefaultTopicTriggers(),
-    helpers.topic.fetchAllTopics(),
-  ];
-  return Promise.all(fetchRequests)
-    .then((values) => {
-      const defaultTopicTriggers = values[0];
-      logger.info('defaultTopicTriggers', { count: defaultTopicTriggers.length });
-      const topics = values[1];
-      logger.info('topics', { count: topics.length });
-      const output = [
-        module.exports.getRivescriptFromDefaultTopicTriggers(defaultTopicTriggers),
-        module.exports.getRivescriptFromTopics(topics),
-      ];
-      const data = module.exports.joinRivescriptLines(output);
+  return helpers.topic.fetchAllDefaultTopicTriggers()
+    .then((defaultTopicTriggers) => {
+      logger.info('fetchAllDefaultTopicTriggers success', { count: defaultTopicTriggers.length });
+      const topics = {};
+      const triggers = [];
+      defaultTopicTriggers.forEach((defaultTopicTrigger) => {
+        triggers.push(module.exports.getRivescriptFromDefaultTopicTrigger(defaultTopicTrigger));
+        if (defaultTopicTrigger.reply && defaultTopicTrigger.reply.startsWith('changeTopic')) {
+          const topicId = defaultTopicTrigger.topic.id;
+          if (!topics[topicId]) {
+            topics[topicId] = module.exports.getRivescriptMenuTopicForTopicId(topicId);
+          }
+        }
+      });
+      const data = module.exports.joinRivescriptLines(triggers.concat(Object.values(topics)));
       return module.exports.writeRivescript(data);
     });
 }
@@ -163,9 +152,8 @@ module.exports = {
   getReplyRivescript,
   getRivescriptFromDefaultTopicTrigger,
   getRivescriptFromDefaultTopicTriggers,
-  getRivescriptFromTopic,
-  getRivescriptFromTopics,
   getRivescriptFromTriggerTextAndRivescriptLine,
+  getRivescriptMenuTopicForTopicId,
   joinRivescriptLines,
   writeRivescript,
 };

--- a/lib/helpers/topic.js
+++ b/lib/helpers/topic.js
@@ -21,13 +21,6 @@ function fetchAllDefaultTopicTriggers() {
 }
 
 /**
- * @return {Promise}
- */
-function fetchAllTopics() {
-  return gambitCampaigns.fetchTopics();
-}
-
-/**
  * @param {String} topicId
  * @return {Promise}
  */
@@ -95,7 +88,6 @@ function parseDefaultTopicTrigger(defaultTopicTrigger) {
 
 module.exports = {
   fetchAllDefaultTopicTriggers,
-  fetchAllTopics,
   fetchById,
   fetchByCampaignId,
   getRenderedTextFromTopicAndTemplateName,

--- a/lib/helpers/topic.js
+++ b/lib/helpers/topic.js
@@ -6,21 +6,6 @@ const logger = require('../logger');
 const config = require('../../config/lib/helpers/topic');
 
 /**
- * Queries Content API for first page of defaultTopicTriggers and returns as an array of
- * Rivescript triggers to be loaded into the Rivescript bot upon app start.
- *
- * TODO: Iterate through all pages of results instead of only returning first page results.
- * @see https://github.com/DoSomething/gambit-conversations/issues/197
- *
- * @return {Promise}
- */
-function fetchAllDefaultTopicTriggers() {
-  return gambitCampaigns.fetchDefaultTopicTriggers()
-    .then(defaultTopicTriggers => defaultTopicTriggers.map(module.exports
-      .parseDefaultTopicTrigger));
-}
-
-/**
  * @param {String} topicId
  * @return {Promise}
  */
@@ -69,29 +54,11 @@ function isRandomTopicId(topicId) {
   return topicId === config.randomTopicId;
 }
 
-/**
- * Parses a defaultTopicTrigger to set macro reply for topic changes.
- *
- * @param {Object} defaultTopicTrigger
- * @return {String}
- */
-function parseDefaultTopicTrigger(defaultTopicTrigger) {
-  if (!defaultTopicTrigger) {
-    return null;
-  }
-  const data = Object.assign({}, defaultTopicTrigger);
-  if (data.topicId) {
-    data.reply = helpers.macro.getChangeTopicMacroFromTopicId(data.topicId);
-  }
-  return data;
-}
 
 module.exports = {
-  fetchAllDefaultTopicTriggers,
   fetchById,
   fetchByCampaignId,
   getRenderedTextFromTopicAndTemplateName,
   isHardcodedTopicId,
   isRandomTopicId,
-  parseDefaultTopicTrigger,
 };

--- a/lib/middleware/broadcasts/index/index.js
+++ b/lib/middleware/broadcasts/index/index.js
@@ -3,7 +3,7 @@
 const helpers = require('../../../helpers');
 
 module.exports = function getBroadcasts() {
-  return (req, res) => helpers.broadcast.fetchAll()
+  return (req, res) => helpers.broadcast.fetchAll(req.query)
     .then(apiRes => res.send(apiRes))
     .catch(err => helpers.sendErrorResponse(res, err));
 };

--- a/lib/middleware/broadcasts/index/index.js
+++ b/lib/middleware/broadcasts/index/index.js
@@ -4,6 +4,6 @@ const helpers = require('../../../helpers');
 
 module.exports = function getBroadcasts() {
   return (req, res) => helpers.broadcast.fetch(req.query)
-    .then(apiRes => res.send(apiRes))
+    .then(fetchResult => res.send(fetchResult))
     .catch(err => helpers.sendErrorResponse(res, err));
 };

--- a/lib/middleware/broadcasts/index/index.js
+++ b/lib/middleware/broadcasts/index/index.js
@@ -3,7 +3,7 @@
 const helpers = require('../../../helpers');
 
 module.exports = function getBroadcasts() {
-  return (req, res) => helpers.broadcast.fetchAll(req.query)
+  return (req, res) => helpers.broadcast.fetch(req.query)
     .then(apiRes => res.send(apiRes))
     .catch(err => helpers.sendErrorResponse(res, err));
 };

--- a/test/helpers/factories/defaultTopicTrigger.js
+++ b/test/helpers/factories/defaultTopicTrigger.js
@@ -5,7 +5,9 @@ const stubs = require('../stubs');
 function getValidChangeTopicDefaultTopicTrigger() {
   return {
     trigger: stubs.getRandomWord(),
-    topicId: stubs.getContentfulId(),
+    topic: {
+      id: stubs.getContentfulId(),
+    },
   };
 }
 

--- a/test/unit/lib/gambit-campaigns.test.js
+++ b/test/unit/lib/gambit-campaigns.test.js
@@ -32,7 +32,7 @@ test.afterEach(() => {
 // fetchBroadcastById
 test('fetchBroadcastById should return result of a successful GET /broadcasts/:id request', async () => {
   sandbox.stub(gambitCampaigns, 'executeGet')
-    .returns(Promise.resolve(campaignBroadcast));
+    .returns(Promise.resolve({ data: campaignBroadcast }));
   const result = await gambitCampaigns.fetchBroadcastById(campaignBroadcast.id);
   result.should.deep.equal(campaignBroadcast);
   const endpoint = `${config.endpoints.broadcasts}/${campaignBroadcast.id}`;
@@ -48,14 +48,16 @@ test('fetchBroadcastById should return error of failed GET /broadcasts/:id reque
 
 // fetchBroadcasts
 test('fetchBroadcasts should return result of a successful GET /broadcasts request', async () => {
-  const broadcasts = [
-    campaignBroadcast,
-    broadcastFactory.getValidTopicBroadcast(),
-  ];
+  const fetchResponse = {
+    data: [
+      campaignBroadcast,
+      broadcastFactory.getValidTopicBroadcast(),
+    ],
+  };
   sandbox.stub(gambitCampaigns, 'executeGet')
-    .returns(Promise.resolve(broadcasts));
+    .returns(Promise.resolve(fetchResponse));
   const result = await gambitCampaigns.fetchBroadcasts();
-  result.should.deep.equal(broadcasts);
+  result.should.deep.equal(fetchResponse);
   gambitCampaigns.executeGet.should.have.been.calledWith(config.endpoints.broadcasts);
 });
 

--- a/test/unit/lib/gambit-campaigns.test.js
+++ b/test/unit/lib/gambit-campaigns.test.js
@@ -21,7 +21,9 @@ const gambitCampaigns = require('../../../lib/gambit-campaigns');
 const broadcastFactory = require('../../helpers/factories/broadcast');
 const campaignFactory = require('../../helpers/factories/campaign');
 const defaultTopicTriggerFactory = require('../../helpers/factories/defaultTopicTrigger');
+const topicFactory = require('../../helpers/factories/topic');
 
+const campaign = campaignFactory.getValidCampaign();
 const campaignBroadcast = broadcastFactory.getValidCampaignBroadcast();
 const defaultTopicTriggers = [
   defaultTopicTriggerFactory.getValidReplyDefaultTopicTrigger(),
@@ -29,6 +31,7 @@ const defaultTopicTriggers = [
 ];
 const fetchError = new Error({ message: 'Epic fail' });
 const queryParams = { skip: 11 };
+const topic = topicFactory.getValidTopic();
 
 test.afterEach(() => {
   // reset stubs, spies, and mocks
@@ -75,6 +78,30 @@ test('fetchBroadcasts should return error of failed GET /broadcasts request', as
   gambitCampaigns.executeGet.should.have.been.calledWith(config.endpoints.broadcasts);
 });
 
+// fetchCampaignById
+test('fetchCampaignById should return result of a successful GET /campaigns/:id request', async () => {
+  sandbox.stub(gambitCampaigns, 'executeGet')
+    .returns(Promise.resolve({ data: campaign }));
+
+  const result = await gambitCampaigns.fetchCampaignById(campaign.id);
+  result.should.deep.equal(campaign);
+  const endpoint = `${config.endpoints.campaigns}/${campaign.id}`;
+  gambitCampaigns.executeGet.should.have.been.calledWith(endpoint);
+});
+
+// fetchCampaigns
+test('fetchCampaigns should return result of a successful GET /campaigns request', async () => {
+  const campaigns = [campaign, campaign];
+  const fetchResponse = { data: campaigns };
+  sandbox.stub(gambitCampaigns, 'executeGet')
+    .returns(Promise.resolve(fetchResponse));
+
+  const result = await gambitCampaigns.fetchCampaigns();
+  result.should.deep.equal(fetchResponse);
+  gambitCampaigns.executeGet
+    .should.have.been.calledWith(config.endpoints.campaigns);
+});
+
 // fetchDefaultTopicTriggers
 test('fetchDefaultTopicTriggers should return result of a successful GET /fetchDefaultTopicTriggers request', async () => {
   const fetchResponse = { data: defaultTopicTriggers };
@@ -86,16 +113,26 @@ test('fetchDefaultTopicTriggers should return result of a successful GET /fetchD
     .should.have.been.calledWith(config.endpoints.defaultTopicTriggers, queryParams);
 });
 
+// fetchTopicById
+test('fetchTopicById should return result of a successful GET /topics/:id request', async () => {
+  sandbox.stub(gambitCampaigns, 'executeGet')
+    .returns(Promise.resolve({ data: topic }));
+
+  const result = await gambitCampaigns.fetchTopicById(topic.id);
+  result.should.deep.equal(topic);
+  const endpoint = `${config.endpoints.topics}/${topic.id}`;
+  gambitCampaigns.executeGet.should.have.been.calledWith(endpoint);
+});
+
 // isClosedCampaign
 test('isClosedCampaign should return true when campaign is active', (t) => {
-  const campaign = campaignFactory.getValidCampaign();
   const result = gambitCampaigns.isClosedCampaign(campaign);
   t.falsy(result);
 });
 
 test('isClosedCampaign should return false when campaign is closed', (t) => {
-  const campaign = campaignFactory.getValidCampaign();
-  campaign.status = config.closedStatusValue;
-  const result = gambitCampaigns.isClosedCampaign(campaign);
+  const closedCampaign = campaignFactory.getValidCampaign();
+  closedCampaign.status = config.closedStatusValue;
+  const result = gambitCampaigns.isClosedCampaign(closedCampaign);
   t.truthy(result);
 });

--- a/test/unit/lib/gambit-campaigns.test.js
+++ b/test/unit/lib/gambit-campaigns.test.js
@@ -20,9 +20,15 @@ const gambitCampaigns = require('../../../lib/gambit-campaigns');
 // stubs
 const broadcastFactory = require('../../helpers/factories/broadcast');
 const campaignFactory = require('../../helpers/factories/campaign');
+const defaultTopicTriggerFactory = require('../../helpers/factories/defaultTopicTrigger');
 
 const campaignBroadcast = broadcastFactory.getValidCampaignBroadcast();
+const defaultTopicTriggers = [
+  defaultTopicTriggerFactory.getValidReplyDefaultTopicTrigger(),
+  defaultTopicTriggerFactory.getValidReplyDefaultTopicTrigger(),
+];
 const fetchError = new Error({ message: 'Epic fail' });
+const queryParams = { skip: 11 };
 
 test.afterEach(() => {
   // reset stubs, spies, and mocks
@@ -56,9 +62,9 @@ test('fetchBroadcasts should return result of a successful GET /broadcasts reque
   };
   sandbox.stub(gambitCampaigns, 'executeGet')
     .returns(Promise.resolve(fetchResponse));
-  const result = await gambitCampaigns.fetchBroadcasts();
+  const result = await gambitCampaigns.fetchBroadcasts(queryParams);
   result.should.deep.equal(fetchResponse);
-  gambitCampaigns.executeGet.should.have.been.calledWith(config.endpoints.broadcasts);
+  gambitCampaigns.executeGet.should.have.been.calledWith(config.endpoints.broadcasts, queryParams);
 });
 
 test('fetchBroadcasts should return error of failed GET /broadcasts request', async (t) => {
@@ -67,6 +73,17 @@ test('fetchBroadcasts should return error of failed GET /broadcasts request', as
   const result = await t.throws(gambitCampaigns.fetchBroadcasts());
   t.is(result.message, fetchError.message);
   gambitCampaigns.executeGet.should.have.been.calledWith(config.endpoints.broadcasts);
+});
+
+// fetchDefaultTopicTriggers
+test('fetchDefaultTopicTriggers should return result of a successful GET /fetchDefaultTopicTriggers request', async () => {
+  const fetchResponse = { data: defaultTopicTriggers };
+  sandbox.stub(gambitCampaigns, 'executeGet')
+    .returns(Promise.resolve(fetchResponse));
+  const result = await gambitCampaigns.fetchDefaultTopicTriggers(queryParams);
+  result.should.deep.equal(fetchResponse);
+  gambitCampaigns.executeGet
+    .should.have.been.calledWith(config.endpoints.defaultTopicTriggers, queryParams);
 });
 
 // isClosedCampaign

--- a/test/unit/lib/lib-helpers/broadcast.test.js
+++ b/test/unit/lib/lib-helpers/broadcast.test.js
@@ -57,15 +57,16 @@ test('aggregateMessagesForBroadcastId should throw if Messages.aggregate fails',
   await t.throws(broadcastHelper.aggregateMessagesForBroadcastId(broadcastId));
 });
 
-// fetchAll
-test('fetchAll should return gambitCampaigns.fetchBroadcasts', async () => {
+// fetch
+test('fetch should return gambitCampaigns.fetchBroadcasts', async () => {
   const broadcasts = [broadcastFactory.getValidCampaignBroadcast()];
+  const query = { skip: 11 };
   sandbox.stub(gambitCampaigns, 'fetchBroadcasts')
     .returns(Promise.resolve(broadcasts));
 
-  const result = await broadcastHelper.fetchAll();
+  const result = await broadcastHelper.fetch(query);
   result.should.deep.equal(broadcasts);
-  gambitCampaigns.fetchBroadcasts.should.have.been.called;
+  gambitCampaigns.fetchBroadcasts.should.have.been.calledWith(query);
 });
 
 // fetchById

--- a/test/unit/lib/lib-helpers/campaign.test.js
+++ b/test/unit/lib/lib-helpers/campaign.test.js
@@ -29,6 +29,22 @@ test.afterEach(() => {
   sandbox.restore();
 });
 
+// fetchAllActive
+test('fetchAllActive calls gambitCampaigns.fetchCampaigns and filters by isClosedCampaign', async () => {
+  const campaigns = [campaignFactory.getValidCampaign(), campaignFactory.getValidCampaign()];
+  sandbox.stub(gambitCampaigns, 'fetchCampaigns')
+    .returns(Promise.resolve({ data: campaigns }));
+  sandbox.stub(gambitCampaigns, 'isClosedCampaign')
+    .returns(false);
+
+  const result = await campaignHelper.fetchAllActive();
+  gambitCampaigns.fetchCampaigns.should.have.been.called;
+  campaigns.forEach((campaign) => {
+    gambitCampaigns.isClosedCampaign.should.have.been.calledWith(campaign);
+  });
+  result.should.deep.equal(campaigns);
+});
+
 // fetchById
 test('fetchById calls gambitCampaigns.fetchCampaignById', async () => {
   sandbox.stub(gambitCampaigns, 'fetchCampaignById')

--- a/test/unit/lib/lib-helpers/rivescript.test.js
+++ b/test/unit/lib/lib-helpers/rivescript.test.js
@@ -6,6 +6,9 @@ const chai = require('chai');
 const sinon = require('sinon');
 const sinonChai = require('sinon-chai');
 
+
+const gambitCampaigns = require('../../../../lib/gambit-campaigns');
+const helpers = require('../../../../lib/helpers');
 const config = require('../../../../config/lib/helpers/rivescript');
 const stubs = require('../../../helpers/stubs');
 const defaultTopicTriggerFactory = require('../../../helpers/factories/defaultTopicTrigger');
@@ -23,11 +26,43 @@ const mockRivescriptLine = `${mockRivescriptCommand}${lineBreak}`;
 const mockRedirectLine = `${config.commands.redirect}${config.separators.command}${mockWord}${lineBreak}`;
 const mockReplyLine = `${config.commands.reply}${config.separators.command}${mockWord}${lineBreak}`;
 const mockRivescript = [mockRivescriptLine, mockReplyLine].join(lineBreak);
+const replyTrigger = defaultTopicTriggerFactory.getValidReplyDefaultTopicTrigger();
+const redirectTrigger = defaultTopicTriggerFactory.getValidReplyDefaultTopicTrigger();
 
 const sandbox = sinon.sandbox.create();
 
 test.afterEach(() => {
   sandbox.restore();
+});
+
+// fetchDefaultTopicTriggers
+test('fetchDefaultTopicTriggers should call parseDefaultTopicTrigger on gambitCampaigns.fetchDefaultTopicTriggers success', async () => {
+  const data = [replyTrigger, redirectTrigger];
+  const mockParsedTrigger = defaultTopicTriggerFactory.getValidReplyDefaultTopicTrigger();
+  sandbox.stub(gambitCampaigns, 'fetchDefaultTopicTriggers')
+    .returns(Promise.resolve({ data }));
+  sandbox.stub(rivescriptHelper, 'parseDefaultTopicTrigger')
+    .returns(mockParsedTrigger);
+
+  const result = await rivescriptHelper.fetchDefaultTopicTriggers();
+  data.forEach((item) => {
+    rivescriptHelper.parseDefaultTopicTrigger.should.have.been.calledWith(item);
+  });
+  gambitCampaigns.fetchDefaultTopicTriggers.should.have.been.called;
+  result.should.deep.equal([mockParsedTrigger, mockParsedTrigger]);
+});
+
+test('fetchDefaultTopicTriggers should throw on gambitCampaigns.fetchDefaultTopicTriggers fail', async (t) => {
+  const mockError = new Error('epic fail');
+  sandbox.stub(gambitCampaigns, 'fetchDefaultTopicTriggers')
+    .returns(Promise.reject(mockError));
+  sandbox.stub(rivescriptHelper, 'parseDefaultTopicTrigger')
+    .returns(replyTrigger);
+
+  const result = await t.throws(rivescriptHelper.fetchDefaultTopicTriggers());
+  gambitCampaigns.fetchDefaultTopicTriggers.should.have.been.called;
+  rivescriptHelper.parseDefaultTopicTrigger.should.not.have.been.called;
+  result.should.deep.equal(mockError);
 });
 
 // formatRivescriptLine
@@ -142,4 +177,24 @@ test('joinRivescriptLines returns input array joined by the config line separato
   const lines = [mockRivescript, mockRivescript, mockRivescript];
   const result = rivescriptHelper.joinRivescriptLines(lines);
   result.should.equal(lines.join(lineBreak));
+});
+
+// parseDefaultTopicTrigger
+test('parseDefaultTopicTrigger should throw error if defaultTopicTrigger undefined', (t) => {
+  t.throws(() => rivescriptHelper.parseDefaultTopicTrigger());
+});
+
+test('parseDefaultTopicTrigger should return defaultTopicTrigger if defaultTopicTrigger.topicId undefined', () => {
+  const defaultTopicTrigger = defaultTopicTriggerFactory.getValidReplyDefaultTopicTrigger();
+  const result = rivescriptHelper.parseDefaultTopicTrigger(defaultTopicTrigger);
+  result.should.deep.equal(defaultTopicTrigger);
+});
+
+test('parseDefaultTopicTrigger should return object with a changeTopic macro reply if defaultTopicTrigger.topic set', () => {
+  const mockChangeTopicMacro = `changeTopicTo${stubs.getTopicId()}`;
+  sandbox.stub(helpers.macro, 'getChangeTopicMacroFromTopicId')
+    .returns(mockChangeTopicMacro);
+  const defaultTopicTrigger = defaultTopicTriggerFactory.getValidChangeTopicDefaultTopicTrigger();
+  const result = rivescriptHelper.parseDefaultTopicTrigger(defaultTopicTrigger);
+  result.reply.should.equal(mockChangeTopicMacro);
 });

--- a/test/unit/lib/lib-helpers/rivescript.test.js
+++ b/test/unit/lib/lib-helpers/rivescript.test.js
@@ -85,16 +85,6 @@ test('getReplyRivescript should return Rivescript with trigger and reply command
 });
 
 // getRivescriptFromDefaultTopicTrigger
-test('getRivescriptFromDefaultTopicTrigger should return null if no defaultTopicTrigger', (t) => {
-  sandbox.stub(rivescriptHelper, 'formatRivescriptLine')
-    .returns(mockReplyLine);
-  sandbox.stub(rivescriptHelper, 'getRivescriptFromTriggerTextAndRivescriptLine')
-    .returns(mockRivescript);
-
-  const result = rivescriptHelper.getRivescriptFromDefaultTopicTrigger();
-  t.is(result, null);
-});
-
 test('getRivescriptFromDefaultTopicTrigger returns redirectRivescript if defaultTopicTrigger.redirect is set', () => {
   sandbox.stub(rivescriptHelper, 'getRedirectRivescript')
     .returns(mockRivescript);

--- a/test/unit/lib/lib-helpers/topic.test.js
+++ b/test/unit/lib/lib-helpers/topic.test.js
@@ -10,7 +10,6 @@ const gambitCampaigns = require('../../../../lib/gambit-campaigns');
 const helpers = require('../../../../lib/helpers');
 const stubs = require('../../../helpers/stubs');
 const campaignFactory = require('../../../helpers/factories/campaign');
-const defaultTopicTriggerFactory = require('../../../helpers/factories/defaultTopicTrigger');
 const topicFactory = require('../../../helpers/factories/topic');
 const config = require('../../../../config/lib/helpers/topic');
 
@@ -21,42 +20,11 @@ chai.use(sinonChai);
 const topicHelper = require('../../../../lib/helpers/topic');
 
 const hardcodedTopicId = config.hardcodedTopicIds[0];
-const replyTrigger = defaultTopicTriggerFactory.getValidReplyDefaultTopicTrigger();
-const redirectTrigger = defaultTopicTriggerFactory.getValidReplyDefaultTopicTrigger();
 
 const sandbox = sinon.sandbox.create();
 
 test.afterEach(() => {
   sandbox.restore();
-});
-
-// fetchAllDefaultTopicTriggers
-test('fetchAllDefaultTopicTriggers should call parseDefaultTopicTrigger on gambitCampaigns.fetchDefaultTopicTriggers success', async () => {
-  const mockResponse = [replyTrigger, redirectTrigger];
-  sandbox.stub(gambitCampaigns, 'fetchDefaultTopicTriggers')
-    .returns(Promise.resolve(mockResponse));
-  sandbox.stub(topicHelper, 'parseDefaultTopicTrigger')
-    .returns(replyTrigger);
-
-  const result = await topicHelper.fetchAllDefaultTopicTriggers();
-  mockResponse.forEach((item) => {
-    topicHelper.parseDefaultTopicTrigger.should.have.been.calledWith(item);
-  });
-  gambitCampaigns.fetchDefaultTopicTriggers.should.have.been.called;
-  result.should.deep.equal([replyTrigger, replyTrigger]);
-});
-
-test('fetchAllDefaultTopicTriggers should throw on gambitCampaigns.fetchDefaultTopicTriggers fail', async (t) => {
-  const mockError = new Error('epic fail');
-  sandbox.stub(gambitCampaigns, 'fetchDefaultTopicTriggers')
-    .returns(Promise.reject(mockError));
-  sandbox.stub(topicHelper, 'parseDefaultTopicTrigger')
-    .returns(replyTrigger);
-
-  const result = await t.throws(topicHelper.fetchAllDefaultTopicTriggers());
-  gambitCampaigns.fetchDefaultTopicTriggers.should.have.been.called;
-  topicHelper.parseDefaultTopicTrigger.should.not.have.been.called;
-  result.should.deep.equal(mockError);
 });
 
 // fetchById
@@ -125,27 +93,6 @@ test('isHardcodedTopicId should return whether topicId exists in config.hardcode
 test('isRandomTopicId should return whether topicId is config.randomTopicId', (t) => {
   t.truthy(topicHelper.isRandomTopicId(config.randomTopicId));
   t.falsy(topicHelper.isRandomTopicId(stubs.getContentfulId()));
-});
-
-// parseDefaultTopicTrigger
-test('parseDefaultTopicTrigger should return null if defaultTopicTrigger undefined', (t) => {
-  const result = topicHelper.parseDefaultTopicTrigger();
-  t.is(result, null);
-});
-
-test('parseDefaultTopicTrigger should return defaultTopicTrigger if defaultTopicTrigger.topicId undefined', () => {
-  const defaultTopicTrigger = defaultTopicTriggerFactory.getValidReplyDefaultTopicTrigger();
-  const result = topicHelper.parseDefaultTopicTrigger(defaultTopicTrigger);
-  result.should.deep.equal(defaultTopicTrigger);
-});
-
-test('parseDefaultTopicTrigger should return object with a changeTopic macro reply if defaultTopicTrigger.topicId', () => {
-  const mockChangeTopicMacro = `changeTopicTo${stubs.getTopicId()}`;
-  sandbox.stub(helpers.macro, 'getChangeTopicMacroFromTopicId')
-    .returns(mockChangeTopicMacro);
-  const defaultTopicTrigger = defaultTopicTriggerFactory.getValidChangeTopicDefaultTopicTrigger();
-  const result = topicHelper.parseDefaultTopicTrigger(defaultTopicTrigger);
-  result.reply.should.equal(mockChangeTopicMacro);
 });
 
 // getRenderedTextFromTopicAndTemplateName

--- a/test/unit/lib/lib-helpers/topic.test.js
+++ b/test/unit/lib/lib-helpers/topic.test.js
@@ -59,17 +59,6 @@ test('fetchAllDefaultTopicTriggers should throw on gambitCampaigns.fetchDefaultT
   result.should.deep.equal(mockError);
 });
 
-// fetchAllTopics
-test('fetchAllTopics should call gambitCampaigns.fetchTopics', async () => {
-  const mockResponse = [topicFactory.getValidTopic(), topicFactory.getValidTopic()];
-  sandbox.stub(gambitCampaigns, 'fetchTopics')
-    .returns(Promise.resolve(mockResponse));
-
-  const result = await topicHelper.fetchAllTopics();
-  gambitCampaigns.fetchTopics.should.have.been.called;
-  result.should.deep.equal(mockResponse);
-});
-
 // fetchById
 test('fetchById should return 404 error if topicId is the random topicId', async (t) => {
   const mockTopic = topicFactory.getValidTopic();

--- a/test/unit/lib/middleware/broadcasts/index/index.test.js
+++ b/test/unit/lib/middleware/broadcasts/index/index.test.js
@@ -1,0 +1,71 @@
+'use strict';
+
+require('dotenv').config();
+
+const test = require('ava');
+const chai = require('chai');
+const sinon = require('sinon');
+const sinonChai = require('sinon-chai');
+const httpMocks = require('node-mocks-http');
+const underscore = require('underscore');
+
+const helpers = require('../../../../../../lib/helpers');
+const logger = require('../../../../../../lib/logger');
+const stubs = require('../../../../../helpers/stubs');
+const broadcastFactory = require('../../../../../helpers/factories/broadcast');
+
+const broadcasts = [
+  broadcastFactory.getValidCampaignBroadcast(),
+  broadcastFactory.getValidTopicBroadcast(),
+];
+
+chai.should();
+chai.use(sinonChai);
+
+// module to be tested
+const getBroadcasts = require('../../../../../../lib/middleware/broadcasts/index');
+
+const sandbox = sinon.sandbox.create();
+
+test.beforeEach((t) => {
+  stubs.stubLogger(sandbox, logger);
+  sandbox.stub(helpers, 'sendErrorResponse')
+    .returns(underscore.noop);
+  t.context.req = httpMocks.createRequest();
+  t.context.req.query = { skip: 11 };
+  t.context.res = httpMocks.createResponse();
+  sandbox.spy(t.context.res, 'send');
+});
+
+test.afterEach((t) => {
+  // reset stubs, spies, and mocks
+  sandbox.restore();
+  t.context = {};
+});
+
+test('getBroadcasts should return helpers.broadcast.fetch result upon success', async (t) => {
+  const middleware = getBroadcasts();
+  sandbox.stub(helpers.broadcast, 'fetch')
+    .returns(Promise.resolve(broadcasts));
+
+  // test
+  await middleware(t.context.req, t.context.res);
+
+  helpers.broadcast.fetch.should.have.been.calledWith(t.context.req.query);
+  t.context.res.send.should.have.been.calledWith(broadcasts);
+  helpers.sendErrorResponse.should.not.have.been.called;
+});
+
+test('getBroadcasts should return helpers.broadcast.fetch error upon fail', async (t) => {
+  const error = new Error({ message: 'Epic fail' });
+  const middleware = getBroadcasts();
+  sandbox.stub(helpers.broadcast, 'fetch')
+    .returns(Promise.reject(error));
+
+  // test
+  await middleware(t.context.req, t.context.res);
+
+  helpers.broadcast.fetch.should.have.been.calledWith(t.context.req.query);
+  t.context.res.send.should.not.have.been.called;
+  helpers.sendErrorResponse.should.have.been.calledWith(t.context.res, error);
+});


### PR DESCRIPTION
#### What's this PR do?

A small new feature - passing over the `req.query` when proxying the Gambit Campaigns `GET /v1/broadcasts` endpoint. That endpoint doesn't do anything with query string just variables yet, but it will soon... 

Some cleanup along the way:

* Moves the `GET /broadcasts` proxy over to `/api/v2`, reserving `/api/v1` for our restified model routes. Updates docs accordingly, along with additional #368 details

* Removes parsing the `body.data` out of the `executeGet` function, in anticipation of using  additional properties like `meta` for total results of index queries.

* Only writes Rivescript topics that inherit our `menu` topic for topics referenced in a `GET /defaultTopicTriggers` index query, instead of the `GET /topics` index. [The Rivescript defined in the `menu` topic](https://github.com/DoSomething/gambit-conversations/blob/2.14.0/brain/topics.rive#L32) contains is only used when we ask user if they'd like to change the current topic (via either the `menu` macro or an `askSignup` broadcast). Both of these options are limited to topics that have `defaultTopicTriggers` anyway, so we don't have a need for any other topics to inherit the `menu` Rivescript yes/no triggers at this time. Removes 

    * Removes `helpers/topic.fetchAll` and `gambitCampaigns.fetchTopics` functions

   * Moves `fetchDefaultTopicTriggers` and `parseDefaultTopicTrigger` from the topic helper into the Rivescript helper instead, as these functions are used only when writing the Rivescript we load upon app start.


#### How should this be reviewed?
Everything should work as normal, except the `GET broadcasts` endpoints have moved to `api/v2` instead of `api/v1`. Verify fetching campaigns and topics work as expected by texting MENU command to spot check the expected replies are sent for each topic change.

#### Any background context you want to provide?

TODOs for a future PR:

* Integration tests
* Rename `gambit-campaigns` to `gambit-content` ? 

#### Relevant tickets
https://www.pivotaltracker.com/story/show/158080999

#### Checklist
- [x] Documentation added for new features/changed endpoints.
- [x] Tests added for new features/bug fixes.
- [x] Tested on staging.
