### PR TITLE
Cleanup lib/gambit-campaigns [pr]

### DIFF
--- a/config/lib/gambit-campaigns.js
+++ b/config/lib/gambit-campaigns.js
@@ -5,6 +5,7 @@ module.exports = {
     baseUri: process.env.DS_GAMBIT_CAMPAIGNS_API_BASEURI,
     apiKey: process.env.DS_GAMBIT_CAMPAIGNS_API_KEY,
   },
+  authHeader: 'x-gambit-api-key',
   closedStatusValue: 'closed',
   endpoints: {
     broadcasts: 'broadcasts',

--- a/config/lib/gambit-campaigns.js
+++ b/config/lib/gambit-campaigns.js
@@ -8,6 +8,7 @@ module.exports = {
   authHeader: 'x-gambit-api-key',
   endpoints: {
     broadcasts: 'broadcasts',
+    campaignActivity: 'campaignActivity',
     campaigns: 'campaigns',
     defaultTopicTriggers: 'defaultTopicTriggers',
     topics: 'topics',

--- a/config/lib/gambit-campaigns.js
+++ b/config/lib/gambit-campaigns.js
@@ -6,7 +6,6 @@ module.exports = {
     apiKey: process.env.DS_GAMBIT_CAMPAIGNS_API_KEY,
   },
   authHeader: 'x-gambit-api-key',
-  closedStatusValue: 'closed',
   endpoints: {
     broadcasts: 'broadcasts',
     campaigns: 'campaigns',

--- a/config/lib/helpers/campaign.js
+++ b/config/lib/helpers/campaign.js
@@ -6,4 +6,8 @@ module.exports = {
     photo: 'webStartPhotoPost',
     text: 'webAskText',
   },
+  statuses: {
+    active: 'active',
+    closed: 'closed',
+  },
 };

--- a/lib/gambit-campaigns.js
+++ b/lib/gambit-campaigns.js
@@ -102,7 +102,7 @@ function fetchTopicById(topicId) {
  * @return {Promise}
  */
 function postCampaignActivity(data) {
-  return module.exports.executePost('campaignActivity', data)
+  return module.exports.executePost(config.endpoints.campaignActivity, data)
     .then(res => res.data);
 }
 

--- a/lib/gambit-campaigns.js
+++ b/lib/gambit-campaigns.js
@@ -1,13 +1,18 @@
 'use strict';
 
 const superagent = require('superagent');
-const Promise = require('bluebird');
-
 const logger = require('./logger');
 const config = require('../config/lib/gambit-campaigns');
 
-const uri = config.clientOptions.baseUri;
 const apiKey = config.clientOptions.apiKey;
+
+/**
+ * @param {String} endpoint
+ * @return {String}
+ */
+function apiUrl(endpoint) {
+  return `${config.clientOptions.baseUri}/${endpoint}`;
+}
 
 /**
  * Executes a GET request to given endpoint with given query.
@@ -17,12 +22,12 @@ const apiKey = config.clientOptions.apiKey;
  * @return {Promise}
  */
 function executeGet(endpoint, query = {}) {
-  const url = `${uri}/${endpoint}`;
-  logger.debug('gambitCampaigns.get', { url, query: JSON.stringify(query) });
+  logger.debug('gambitCampaigns.get', { endpoint, query: JSON.stringify(query) });
 
-  return superagent.get(url)
-    .query(query)
+  return superagent
+    .get(module.exports.apiUrl(endpoint))
     .set(config.authHeader, apiKey)
+    .query(query)
     .then(res => res.body);
 }
 
@@ -35,7 +40,7 @@ function executeGet(endpoint, query = {}) {
  */
 function executePost(endpoint, data) {
   return superagent
-    .post(`${uri}/${endpoint}`)
+    .post(module.exports.apiUrl(endpoint))
     .set(config.authHeader, apiKey)
     .send(data)
     .then(res => res.body);
@@ -92,14 +97,26 @@ function fetchTopicById(topicId) {
     .then(res => res.data);
 }
 
+/**
+ * @param {Object} data
+ * @return {Promise}
+ */
+function postCampaignActivity(data) {
+  return module.exports.executePost('campaignActivity', data)
+    .then(res => res.data);
+}
+
 module.exports = {
+  apiUrl,
   executeGet,
+  executePost,
   fetchBroadcastById,
   fetchBroadcasts,
   fetchCampaignById,
   fetchCampaigns,
   fetchDefaultTopicTriggers,
   fetchTopicById,
+  postCampaignActivity,
 };
 
 // TODO: move functions below to relevant helpers.
@@ -111,48 +128,4 @@ module.exports = {
  */
 module.exports.isClosedCampaign = function (campaign) {
   return campaign.status === config.closedStatusValue;
-};
-
-/**
- * Parse our incoming Express request for expected Gambit Campaigns format.
- * TODO: Move this into helpers.request
- *
- * @param {object} req
- * @return {object}
- */
-function getCampaignActivityPayloadFromReq(req) {
-  const data = {
-    userId: req.userId,
-    campaignId: req.campaign.id,
-    campaignRunId: req.campaign.currentCampaignRun.id,
-    postType: req.topic.postType,
-    text: req.inboundMessageText,
-    mediaUrl: req.mediaUrl,
-    broadcastId: req.broadcastId,
-    platform: req.platform,
-  };
-  if (req.keyword) {
-    data.keyword = req.keyword.toLowerCase();
-  }
-
-  return data;
-}
-
-/**
- * Posts campaign activity to Gambit Campaigns.
- * TODO: Move this into helpers.request
- */
-module.exports.postCampaignActivity = function (req) {
-  const data = getCampaignActivityPayloadFromReq(req);
-  const loggerMessage = 'gambitCampaigns.postCampaignActivity';
-  logger.debug(loggerMessage, data, req);
-
-  return new Promise((resolve, reject) => {
-    executePost('campaignActivity', data)
-      .then((res) => {
-        logger.debug(`${loggerMessage} response`, res.data, req);
-        return resolve(res.data);
-      })
-      .catch(err => reject(err));
-  });
 };

--- a/lib/gambit-campaigns.js
+++ b/lib/gambit-campaigns.js
@@ -118,14 +118,3 @@ module.exports = {
   fetchTopicById,
   postCampaignActivity,
 };
-
-// TODO: move functions below to relevant helpers.
-
-/**
- * TODO: Move this into helpers.campaign
- * @param {object} campaign
- * @return {boolean}
- */
-module.exports.isClosedCampaign = function (campaign) {
-  return campaign.status === config.closedStatusValue;
-};

--- a/lib/gambit-campaigns.js
+++ b/lib/gambit-campaigns.js
@@ -10,7 +10,7 @@ const uri = config.clientOptions.baseUri;
 const apiKey = config.clientOptions.apiKey;
 
 /**
- * Executes a GET request to given Gambit Campaigns endpoint.
+ * Executes a GET request to given endpoint with given query.
  *
  * @param {String} endpoint
  * @param {Object} query
@@ -18,16 +18,16 @@ const apiKey = config.clientOptions.apiKey;
  */
 function executeGet(endpoint, query = {}) {
   const url = `${uri}/${endpoint}`;
-  logger.debug('gambitCampaigns.get', { url });
+  logger.debug('gambitCampaigns.get', { url, query: JSON.stringify(query) });
 
   return superagent.get(url)
     .query(query)
-    .then(res => res.body)
-    .catch(err => Promise.reject(err));
+    .set(config.authHeader, apiKey)
+    .then(res => res.body);
 }
 
 /**
- * Executes a POST request to given Gambit Campaigns endpoint with given data.
+ * Executes a POST request to given endpoint with given data.
  *
  * @param {String} endpoint
  * @param {Object} data
@@ -36,10 +36,9 @@ function executeGet(endpoint, query = {}) {
 function executePost(endpoint, data) {
   return superagent
     .post(`${uri}/${endpoint}`)
-    .set('x-gambit-api-key', apiKey)
+    .set(config.authHeader, apiKey)
     .send(data)
-    .then(res => res.body)
-    .catch(err => Promise.reject(err));
+    .then(res => res.body);
 }
 
 /**

--- a/lib/helpers/campaign.js
+++ b/lib/helpers/campaign.js
@@ -39,8 +39,7 @@ function fetchRandomCampaignExcludingCampaignId(campaignId) {
  * @return {Boolean}
  */
 function isClosedCampaign(campaign) {
-  // TODO: Move isClosedCampaign config out of gambitCampaigns and into this helper.
-  return gambitCampaigns.isClosedCampaign(campaign);
+  return campaign.status === config.statuses.closed;
 }
 
 /**

--- a/lib/helpers/replies.js
+++ b/lib/helpers/replies.js
@@ -101,10 +101,9 @@ module.exports.continueTopic = function (req, res) {
     return module.exports.campaignClosed(req, res);
   }
 
-  return gambitCampaigns.postCampaignActivity(req)
+  return helpers.request.postCampaignActivityFromReq(req)
     .then((gambitCampaignsRes) => {
-      req.signup = gambitCampaignsRes.signup;
-      logger.debug('continueTopic', { signupId: req.signup.id }, req);
+      logger.debug('postCampaignActivityFromReq success', gambitCampaignsRes, req);
       return exports.sendReplyWithTopicTemplate(req, res, gambitCampaignsRes.replyTemplate);
     })
     .catch(err => helpers.sendErrorResponse(res, err));

--- a/lib/helpers/replies.js
+++ b/lib/helpers/replies.js
@@ -3,7 +3,6 @@
 const Promise = require('bluebird');
 const helpers = require('../helpers');
 const logger = require('../logger');
-const gambitCampaigns = require('../gambit-campaigns');
 
 /**
  * Creates and sends outbound-reply Message with given messageText and messageTemplate.
@@ -97,7 +96,7 @@ module.exports.continueTopic = function (req, res) {
     return module.exports.noCampaign(req, res);
   }
 
-  if (gambitCampaigns.isClosedCampaign(req.campaign)) {
+  if (helpers.request.isClosedCampaign(req)) {
     return module.exports.campaignClosed(req, res);
   }
 

--- a/lib/helpers/request.js
+++ b/lib/helpers/request.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const helpers = require('../helpers');
+const gambitCampaigns = require('../gambit-campaigns');
 const logger = require('../logger');
 const analytics = require('./analytics');
 
@@ -48,6 +49,37 @@ function executeChangeTopicMacro(req) {
       logger.debug('helpers.topic.fetchById success', { topicId }, req);
       return module.exports.changeTopic(req, topic);
     });
+}
+
+/**
+ * @param {Object}
+ * @return {Object}
+ */
+function getCampaignActivityPayloadFromReq(req) {
+  const data = {
+    userId: req.userId,
+    campaignId: req.campaign.id,
+    campaignRunId: req.campaign.currentCampaignRun.id,
+    postType: req.topic.postType,
+    text: req.inboundMessageText,
+    mediaUrl: req.mediaUrl,
+    broadcastId: req.broadcastId,
+    platform: req.platform,
+  };
+  if (req.keyword) {
+    data.keyword = req.keyword.toLowerCase();
+  }
+
+  return data;
+}
+
+/**
+ * @param {Object}
+ * @return {Promise}
+ */
+function postCampaignActivityFromReq(req) {
+  return gambitCampaigns
+    .postCampaignActivity(module.exports.getCampaignActivityPayloadFromReq(req));
 }
 
 /**
@@ -192,6 +224,7 @@ module.exports = {
   changeTopic,
   changeTopicByCampaign,
   executeChangeTopicMacro,
+  getCampaignActivityPayloadFromReq,
   getUserIdParamFromReq,
   hasCampaign,
   isChangeTopicMacro,
@@ -206,6 +239,7 @@ module.exports = {
   isTwilio: function isTwilio(req) {
     return req.query.origin === 'twilio';
   },
+  postCampaignActivityFromReq,
   setBroadcastId: function setBroadcastId(req, broadcastId) {
     req.broadcastId = broadcastId;
     analytics.addCustomAttributes({ broadcastId });

--- a/test/unit/lib/gambit-campaigns.test.js
+++ b/test/unit/lib/gambit-campaigns.test.js
@@ -40,6 +40,13 @@ test.afterEach(() => {
   sandbox.restore();
 });
 
+// apiUrl
+test('apiUrl return given endpoint param with prefixed with config.clientOptions.baseUri ', () => {
+  const endpoint = 'dragons';
+  const result = gambitCampaigns.apiUrl(endpoint);
+  result.should.equal(`${config.clientOptions.baseUri}/${endpoint}`);
+});
+
 // executeGet
 test('executeGet should call superagent.get with apiUrl and parse body', async () => {
   const endpoint = 'dragons';

--- a/test/unit/lib/gambit-campaigns.test.js
+++ b/test/unit/lib/gambit-campaigns.test.js
@@ -6,8 +6,8 @@ const test = require('ava');
 const chai = require('chai');
 const sinon = require('sinon');
 const sinonChai = require('sinon-chai');
+const superagent = require('superagent');
 const config = require('../../../config/lib/gambit-campaigns');
-
 
 chai.should();
 chai.use(sinonChai);
@@ -30,6 +30,7 @@ const defaultTopicTriggers = [
   defaultTopicTriggerFactory.getValidReplyDefaultTopicTrigger(),
 ];
 const fetchError = new Error({ message: 'Epic fail' });
+const fetchSuccess = { data: defaultTopicTriggers };
 const queryParams = { skip: 11 };
 const topic = topicFactory.getValidTopic();
 
@@ -37,6 +38,51 @@ test.afterEach(() => {
   // reset stubs, spies, and mocks
   sandbox.restore();
 });
+
+// executeGet
+test('executeGet should call superagent.get with apiUrl and parse body', async () => {
+  const endpoint = 'dragons';
+  const apiUrl = `${config.clientOptions.apiUrl}/${endpoint}`;
+  sandbox.stub(gambitCampaigns, 'apiUrl')
+    .returns(apiUrl);
+  sandbox.stub(superagent, 'get')
+    .callsFake(() => ({
+      // TODO: These nested functions should be stubbed to verify args passed.
+      set: () => { // eslint-disable-line arrow-body-style
+        return {
+          query: () => Promise.resolve({ body: fetchSuccess }),
+        };
+      },
+    }));
+
+  const result = await gambitCampaigns.executeGet(endpoint, queryParams);
+  result.should.equal(fetchSuccess);
+  gambitCampaigns.apiUrl.should.have.been.calledWith(endpoint);
+  superagent.get.should.have.been.calledWith(apiUrl);
+});
+
+// executePost
+test('executePost should call superagent.post with apiUrl and parse body', async () => {
+  const endpoint = 'dragons';
+  const apiUrl = `${config.clientOptions.apiUrl}/${endpoint}`;
+  sandbox.stub(gambitCampaigns, 'apiUrl')
+    .returns(apiUrl);
+  sandbox.stub(superagent, 'post')
+    .callsFake(() => ({
+      // TODO: These nested functions should be stubbed to verify args passed.
+      set: () => { // eslint-disable-line arrow-body-style
+        return {
+          send: () => Promise.resolve({ body: fetchSuccess }),
+        };
+      },
+    }));
+
+  const result = await gambitCampaigns.executePost(endpoint, queryParams);
+  result.should.equal(fetchSuccess);
+  gambitCampaigns.apiUrl.should.have.been.calledWith(endpoint);
+  superagent.post.should.have.been.calledWith(apiUrl);
+});
+
 
 // fetchBroadcastById
 test('fetchBroadcastById should return result of a successful GET /broadcasts/:id request', async () => {

--- a/test/unit/lib/gambit-campaigns.test.js
+++ b/test/unit/lib/gambit-campaigns.test.js
@@ -18,6 +18,7 @@ const sandbox = sinon.sandbox.create();
 const gambitCampaigns = require('../../../lib/gambit-campaigns');
 
 // stubs
+const stubs = require('../../helpers/stubs');
 const broadcastFactory = require('../../helpers/factories/broadcast');
 const campaignFactory = require('../../helpers/factories/campaign');
 const defaultTopicTriggerFactory = require('../../helpers/factories/defaultTopicTrigger');
@@ -168,4 +169,17 @@ test('fetchTopicById should return result of a successful GET /topics/:id reques
   result.should.deep.equal(topic);
   const endpoint = `${config.endpoints.topics}/${topic.id}`;
   gambitCampaigns.executeGet.should.have.been.calledWith(endpoint);
+});
+
+// postCampaignActivity
+test('postCampaignActivity should return result of a successful POST /campaignActivity request', async () => {
+  const requestData = { text: stubs.getRandomMessageText() };
+  const responseData = { abc: 123 };
+  sandbox.stub(gambitCampaigns, 'executePost')
+    .returns(Promise.resolve({ data: responseData }));
+
+  const result = await gambitCampaigns.postCampaignActivity(requestData);
+  result.should.deep.equal(responseData);
+  const endpoint = config.endpoints.campaignActivity;
+  gambitCampaigns.executePost.should.have.been.calledWith(endpoint, requestData);
 });

--- a/test/unit/lib/gambit-campaigns.test.js
+++ b/test/unit/lib/gambit-campaigns.test.js
@@ -169,16 +169,3 @@ test('fetchTopicById should return result of a successful GET /topics/:id reques
   const endpoint = `${config.endpoints.topics}/${topic.id}`;
   gambitCampaigns.executeGet.should.have.been.calledWith(endpoint);
 });
-
-// isClosedCampaign
-test('isClosedCampaign should return true when campaign is active', (t) => {
-  const result = gambitCampaigns.isClosedCampaign(campaign);
-  t.falsy(result);
-});
-
-test('isClosedCampaign should return false when campaign is closed', (t) => {
-  const closedCampaign = campaignFactory.getValidCampaign();
-  closedCampaign.status = config.closedStatusValue;
-  const result = gambitCampaigns.isClosedCampaign(closedCampaign);
-  t.truthy(result);
-});

--- a/test/unit/lib/lib-helpers/campaign.test.js
+++ b/test/unit/lib/lib-helpers/campaign.test.js
@@ -75,7 +75,6 @@ test('getWebSignupMessageTemplateNameFromCampaign returns string from config.sig
   result.should.equal(templateName);
 });
 
-
 // isClosedCampaign
 test('isClosedCampaign should return true when campaign is active', (t) => {
   const result = campaignHelper.isClosedCampaign(campaignFactory.getValidCampaign());

--- a/test/unit/lib/lib-helpers/campaign.test.js
+++ b/test/unit/lib/lib-helpers/campaign.test.js
@@ -34,13 +34,13 @@ test('fetchAllActive calls gambitCampaigns.fetchCampaigns and filters by isClose
   const campaigns = [campaignFactory.getValidCampaign(), campaignFactory.getValidCampaign()];
   sandbox.stub(gambitCampaigns, 'fetchCampaigns')
     .returns(Promise.resolve({ data: campaigns }));
-  sandbox.stub(gambitCampaigns, 'isClosedCampaign')
+  sandbox.stub(campaignHelper, 'isClosedCampaign')
     .returns(false);
 
   const result = await campaignHelper.fetchAllActive();
   gambitCampaigns.fetchCampaigns.should.have.been.called;
   campaigns.forEach((campaign) => {
-    gambitCampaigns.isClosedCampaign.should.have.been.calledWith(campaign);
+    campaignHelper.isClosedCampaign.should.have.been.calledWith(campaign);
   });
   result.should.deep.equal(campaigns);
 });
@@ -77,10 +77,14 @@ test('getWebSignupMessageTemplateNameFromCampaign returns string from config.sig
 
 
 // isClosedCampaign
-test('isClosedCampaign calls gambitCampaigns.isClosedCampaign', (t) => {
-  sandbox.stub(gambitCampaigns, 'isClosedCampaign')
-    .returns(true);
-  const result = campaignHelper.isClosedCampaign(campaignStub);
+test('isClosedCampaign should return true when campaign is active', (t) => {
+  const result = campaignHelper.isClosedCampaign(campaignFactory.getValidCampaign());
+  t.falsy(result);
+});
+
+test('isClosedCampaign should return false when campaign is closed', (t) => {
+  const closedCampaign = campaignFactory.getValidCampaign();
+  closedCampaign.status = campaignHelperConfig.statuses.closed;
+  const result = campaignHelper.isClosedCampaign(closedCampaign);
   t.truthy(result);
-  gambitCampaigns.isClosedCampaign.should.have.been.calledWith(campaignStub);
 });

--- a/test/unit/lib/lib-helpers/replies.test.js
+++ b/test/unit/lib/lib-helpers/replies.test.js
@@ -11,7 +11,6 @@ const Promise = require('bluebird');
 
 const stubs = require('../../../helpers/stubs');
 const logger = require('../../../../lib/logger');
-const gambitCampaigns = require('../../../../lib/gambit-campaigns');
 const helpers = require('../../../../lib/helpers');
 const templatesConfig = require('../../../../config/lib/helpers/template');
 const Message = require('../../../../app/models/Message');
@@ -176,7 +175,7 @@ test('sendReply(): should call sendErrorResponse on failure', async (t) => {
 });
 
 test('continueTopic(): sendReplyWithTopicTemplate should be called', async (t) => {
-  sandbox.stub(gambitCampaigns, 'postCampaignActivity')
+  sandbox.stub(helpers.request, 'postCampaignActivityFromReq')
     .returns(Promise.resolve(gCampResponse.data));
   sandbox.stub(repliesHelper, 'sendReplyWithTopicTemplate')
     .returns(resolvedPromise);
@@ -186,7 +185,7 @@ test('continueTopic(): sendReplyWithTopicTemplate should be called', async (t) =
 });
 
 test('continueTopic(): helpers.sendErrorResponse should be called if postCampaignActivity fails', async (t) => {
-  sandbox.stub(gambitCampaigns, 'postCampaignActivity')
+  sandbox.stub(helpers.request, 'postCampaignActivityFromReq')
     .returns(Promise.reject(gCampResponse.data));
   sandbox.stub(repliesHelper, 'sendReplyWithTopicTemplate')
     .returns(resolvedPromise);

--- a/test/unit/lib/lib-helpers/request.test.js
+++ b/test/unit/lib/lib-helpers/request.test.js
@@ -9,6 +9,7 @@ const httpMocks = require('node-mocks-http');
 const underscore = require('underscore');
 
 const helpers = require('../../../../lib/helpers');
+const gambitCampaigns = require('../../../../lib/gambit-campaigns');
 const stubs = require('../../../helpers/stubs');
 const campaignFactory = require('../../../helpers/factories/campaign');
 const conversationFactory = require('../../../helpers/factories/conversation');
@@ -221,6 +222,20 @@ test('isMenuMacro should return false if req.macro is not menu', (t) => {
     .returns(false);
   t.context.req.macro = macro;
   t.falsy(requestHelper.isMenuMacro(t.context.req));
+});
+
+// postCampaignActivityFromReq
+test('postCampaignActivityFromReq should post getCampaignActivityPayloadFromReq as campaignActivity', async (t) => {
+  const postData = { text: stubs.getRandomMessageText() };
+  const postResult = { data: 123 };
+  sandbox.stub(requestHelper, 'getCampaignActivityPayloadFromReq')
+    .returns(postData);
+  sandbox.stub(gambitCampaigns, 'postCampaignActivity')
+    .returns(Promise.resolve(postResult));
+
+  const result = await requestHelper.postCampaignActivityFromReq();
+  gambitCampaigns.postCampaignActivity.should.have.been.calledWith(postData);
+  result.should.deep.equal(postResult);
 });
 
 // setCampaign

--- a/test/unit/lib/lib-helpers/request.test.js
+++ b/test/unit/lib/lib-helpers/request.test.js
@@ -225,7 +225,7 @@ test('isMenuMacro should return false if req.macro is not menu', (t) => {
 });
 
 // postCampaignActivityFromReq
-test('postCampaignActivityFromReq should post getCampaignActivityPayloadFromReq as campaignActivity', async (t) => {
+test('postCampaignActivityFromReq should post getCampaignActivityPayloadFromReq as campaignActivity', async () => {
   const postData = { text: stubs.getRandomMessageText() };
   const postResult = { data: 123 };
   sandbox.stub(requestHelper, 'getCampaignActivityPayloadFromReq')


### PR DESCRIPTION
#### What's this PR do?

* Sets the authHeader for `GET` requests to the Gambit Campaigns API, as we need to authenticate index requests that query Contentful (refs https://github.com/DoSomething/gambit-campaigns/pull/1062)

* Completes TODO's of refactoring functions so `lib/gambit-campaigns` is solely responsible for executing get and post requests
    * Deprecates `gambitCampaigns.isClosedCampaign` per `helpers.campaign.isClosedCampaign`
    * Moves `getCampaignActivityFromReq` into `helpers.request.getCampaignActivityFromReq`
    * Refactors `postCampaignActivity`, adds `helpers.request.postCampaignActivityFromReq` 
 
#### How should this be reviewed?

Verify menu command, signup and reportback work as expected.

#### Any background context you want to provide?

Will also need to update Gambit Admin to send an API key for GET requests before we can require authentication on all Gambit Campaigns GET endpoints.

#### Relevant tickets

https://www.pivotaltracker.com/story/show/159117166

#### Checklist
- [x] Tests added for new features/bug fixes.
- [x] Tested on staging.
