### PR TITLE
Adds autoReplyBroadcast support [pr]

### DIFF
--- a/config/lib/helpers/topic.js
+++ b/config/lib/helpers/topic.js
@@ -15,4 +15,7 @@ module.exports = {
     'unsubscribed',
   ],
   randomTopicId: 'random',
+  autoReplyTypes: [
+    'autoReplyBroadcast',
+  ],
 };

--- a/lib/helpers/broadcast.js
+++ b/lib/helpers/broadcast.js
@@ -23,6 +23,14 @@ function fetchById(broadcastId) {
 }
 
 /**
+ * @param {Object} broadcast
+ * @return {Boolean}
+ */
+function isAutoReplyBroadcast(broadcast) {
+  return broadcast.type === 'autoReplyBroadcast';
+}
+
+/**
  * getWebhookBodyForBroadcastId
  *
  * @param {string} broadcastId
@@ -94,6 +102,7 @@ function formatStats(data) {
 module.exports = {
   fetch,
   fetchById,
+  isAutoReplyBroadcast,
   /**
    * @param {boolean} useApiVersion2
    * @return {object}

--- a/lib/helpers/replies.js
+++ b/lib/helpers/replies.js
@@ -116,6 +116,10 @@ module.exports.askSignup = function (req, res) {
   return exports.sendReplyWithTopicTemplate(req, res, 'askSignup');
 };
 
+module.exports.autoReply = function (req, res) {
+  return exports.sendReplyWithTopicTemplate(req, res, 'autoReply');
+};
+
 module.exports.campaignClosed = function (req, res) {
   return exports.sendReplyWithTopicTemplate(req, res, 'campaignClosed');
 };

--- a/lib/helpers/request.js
+++ b/lib/helpers/request.js
@@ -94,6 +94,14 @@ function hasCampaign(req) {
  * @param {Object} req
  * @return {Boolean}
  */
+function isAutoReplyTopic(req) {
+  return req.topic && helpers.topic.isAutoReplyTopic(req.topic);
+}
+
+/**
+ * @param {Object} req
+ * @return {Boolean}
+ */
 function isChangeTopicMacro(req) {
   return req.macro && helpers.macro.isChangeTopic(req.macro);
 }
@@ -227,6 +235,7 @@ module.exports = {
   getCampaignActivityPayloadFromReq,
   getUserIdParamFromReq,
   hasCampaign,
+  isAutoReplyTopic,
   isChangeTopicMacro,
   isClosedCampaign,
   isConfirmedTopicMacro,

--- a/lib/helpers/topic.js
+++ b/lib/helpers/topic.js
@@ -35,7 +35,20 @@ function fetchByCampaignId(campaignId) {
  * @param {String} templateName
  */
 function getRenderedTextFromTopicAndTemplateName(topic, templateName) {
-  return topic.templates[templateName].rendered;
+  const template = topic.templates[templateName];
+  // This rendered property will eventually get phased out, always query by text.
+  if (template.rendered) {
+    return template.rendered;
+  }
+  return template.text;
+}
+
+/**
+ * @param {Object} topic
+ * @return {Boolean}
+ */
+function isAutoReplyTopic(topic) {
+  return config.autoReplyTypes.includes(topic.type);
 }
 
 /**
@@ -59,6 +72,7 @@ module.exports = {
   fetchById,
   fetchByCampaignId,
   getRenderedTextFromTopicAndTemplateName,
+  isAutoReplyTopic,
   isHardcodedTopicId,
   isRandomTopicId,
 };

--- a/lib/helpers/topic.js
+++ b/lib/helpers/topic.js
@@ -37,10 +37,7 @@ function fetchByCampaignId(campaignId) {
 function getRenderedTextFromTopicAndTemplateName(topic, templateName) {
   const template = topic.templates[templateName];
   // This rendered property will eventually get phased out, always query by text.
-  if (template.rendered) {
-    return template.rendered;
-  }
-  return template.text;
+  return template.rendered || template.text;
 }
 
 /**

--- a/lib/middleware/messages/broadcast/broadcast-parse.js
+++ b/lib/middleware/messages/broadcast/broadcast-parse.js
@@ -8,11 +8,15 @@ module.exports = function parseBroadcast() {
       const outboundMessage = req.broadcast.message;
       helpers.request.setOutboundMessageText(req, outboundMessage.text);
       helpers.request.setOutboundMessageTemplate(req, outboundMessage.template);
-      if (req.broadcast.topic) {
+
+      if (helpers.broadcast.isAutoReplyBroadcast(req.broadcast)) {
+        helpers.request.setTopic(req, req.broadcast.id);
+      } else if (req.broadcast.topic) {
         helpers.request.setTopic(req, req.broadcast.topic);
       } else {
         helpers.request.setCampaignId(req, req.broadcast.campaignId);
       }
+
       outboundMessage.attachments.forEach((attachment) => {
         helpers.attachments.add(req, attachment, 'outbound');
       });

--- a/lib/middleware/messages/member/macro-catch-all.js
+++ b/lib/middleware/messages/member/macro-catch-all.js
@@ -4,6 +4,10 @@ const helpers = require('../../../helpers');
 
 module.exports = function catchAllReply() {
   return (req, res) => {
+    if (helpers.request.isAutoReplyTopic(req)) {
+      return helpers.replies.autoReply(req, res);
+    }
+
     if (!helpers.request.hasCampaign(req)) {
       return helpers.replies.noCampaign(req, res);
     }


### PR DESCRIPTION
#### What's this PR do?
Makes the changes outlined in https://github.com/DoSomething/gambit-campaigns/pull/1063#issuecomment-407923816 to support autoReplyBroadcasts.

#### How should this be reviewed?
Testing Conversations against a Campaigns branch running  https://github.com/DoSomething/gambit-campaigns/pull/1063 : 

* Verify that the test `autoReplyBroadcast` 4nwTwvXmfuuYAGYgusGyyW works as expected -- the broadcast message is sent, and all subsequent replies are the `autoReply` template.

* Verify all other existing types of broadcasts work as expected (`survey_response` should still work, as we're not removing any functionality, or that hardcoded Rivescript topic -- yet)

#### Any background context you want to provide?
* We'll need to deploy https://github.com/DoSomething/gambit-campaigns/pull/1063 to production first before we can send `autoReplyBroadcast` messages on production.

* Also skips tests for now as priority is determining level of effort for handling yes/no responses with a new broadcast content type (more to come on that in a future PR)

#### Relevant tickets
https://www.pivotaltracker.com/story/show/157369418

#### Checklist
- [x] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.
