### PR TITLE
Pass query params to GET /broadcasts/:id

### DIFF
--- a/lib/gambit-campaigns.js
+++ b/lib/gambit-campaigns.js
@@ -48,10 +48,11 @@ function executePost(endpoint, data) {
 
 /**
  * @param {String} broadcastId
+ * @param {Object} query
  * @return {Promise}
  */
-function fetchBroadcastById(broadcastId) {
-  return module.exports.executeGet(`${config.endpoints.broadcasts}/${broadcastId}`)
+function fetchBroadcastById(broadcastId, query = {}) {
+  return module.exports.executeGet(`${config.endpoints.broadcasts}/${broadcastId}`, query)
     .then(res => res.data);
 }
 

--- a/lib/helpers/broadcast.js
+++ b/lib/helpers/broadcast.js
@@ -15,11 +15,12 @@ function fetch(query = {}) {
 }
 
 /**
- * @param {String} query
+ * @param {String} broadcastId
+ * @param {Object} query
  * @return {Promise}
  */
-function fetchById(broadcastId) {
-  return gambitCampaigns.fetchBroadcastById(broadcastId);
+function fetchById(broadcastId, query = {}) {
+  return gambitCampaigns.fetchBroadcastById(broadcastId, query);
 }
 
 /**

--- a/lib/middleware/broadcasts/single/broadcast.js
+++ b/lib/middleware/broadcasts/single/broadcast.js
@@ -16,7 +16,7 @@ module.exports = function getBroadcast() {
   return (req, res, next) => {
     logger.info('Searching for Broadcast', { broadcastId: req.broadcastId }, req);
 
-    return helpers.broadcast.fetchById(req.broadcastId)
+    return helpers.broadcast.fetchById(req.broadcastId, req.query)
       .then((broadcast) => {
         // We should never be able to send an empty message to users.
         if (isMessageEmpty(broadcast)) {


### PR DESCRIPTION
#### What's this PR do?
Includes query parameters in the proxy to the Gambit Campaigns endpoint.

#### How should this be reviewed?
Can be tested in tandem with https://github.com/DoSomething/gambit-campaigns/pull/1064 to verify `cache` parameter is passed.

#### Checklist
- [ ] Tests added for new features/bug fixes.
- [ ] Tested on staging.
