### PR TITLE
Enforces HTTPS in production [pr]

### DIFF
--- a/app.js
+++ b/app.js
@@ -2,8 +2,15 @@
 
 const express = require('express');
 const bodyParser = require('body-parser');
+const config = require('./config');
 
 const app = express();
+/**
+ * Set app locals
+ * @see https://expressjs.com/en/4x/api.html#app.locals
+ */
+app.locals.forceHttps = config.forceHttps;
+
 // parse application/json Content-Type
 app.use(bodyParser.json());
 // parse application/x-www-form-urlencoded Content-Type

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -6,10 +6,14 @@ const mongooseRoutes = require('./mongoose');
 const v2MessagesRoute = require('./messages');
 
 // middleware
+const enforceHttpsMiddleware = require('../../lib/middleware/enforce-https');
 const authenticateMiddleware = require('../../lib/middleware/authenticate');
 const parseMessageMetadataMiddleware = require('../../lib/middleware/messages/metadata-parse');
 
 module.exports = function init(app) {
+  // Enforce https
+  app.use(enforceHttpsMiddleware(app.locals.forceHttps));
+
   app.get('/', (req, res) => res.send('hi'));
   app.get('/favicon.ico', (req, res) => res.sendStatus(204));
 

--- a/config/env/override-production.js
+++ b/config/env/override-production.js
@@ -1,0 +1,13 @@
+'use strict';
+
+/**
+ * Production environment overrides.
+ *
+ * Ignoring no-param-reassign eslint rule because it's exactly what we want here.
+ */
+
+/* eslint-disable no-param-reassign */
+
+module.exports = (config) => {
+  config.forceHttps = true;
+};

--- a/config/index.js
+++ b/config/index.js
@@ -7,6 +7,8 @@ const config = {
   dbUri: process.env.MONGODB_URI || 'mongodb://localhost/gambit-conversations',
   port: process.env.PORT || 5100,
   env: process.env.NODE_ENV || 'development',
+  // overridden in production to true
+  forceHttps: false,
 };
 
 // Require env-dependent configs

--- a/config/mongoose.js
+++ b/config/mongoose.js
@@ -4,7 +4,10 @@ const mongoose = require('mongoose');
 const Promise = require('bluebird');
 
 mongoose.Promise = Promise;
-
+/**
+ * @see http://mongoosejs.com/docs/4.x/docs/index.html
+ * @see http://mongoosejs.com/docs/4.x/docs/api.html#index_Mongoose-connect
+ */
 module.exports = url => mongoose.connect(url, {
   // http://mongoosejs.com/docs/connections.html#use-mongo-client
   useMongoClient: true,

--- a/lib/middleware/enforce-https.js
+++ b/lib/middleware/enforce-https.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const enforce = require('express-sslify');
+const logger = require('../logger');
+
+module.exports = function enforceHttps(forceHttps) {
+  logger.info(`Enforcing https connections=${forceHttps}`);
+  if (!forceHttps) {
+    return (req, res, next) => next();
+  }
+  return enforce.HTTPS({
+    /**
+     * Required for Heroku deployed apps
+     * @see https://www.npmjs.com/package/express-sslify#reverse-proxies-heroku-nodejitsu-and-others
+     */
+    trustProtoHeader: true,
+  });
+};

--- a/lib/middleware/enforce-https.js
+++ b/lib/middleware/enforce-https.js
@@ -4,7 +4,7 @@ const enforce = require('express-sslify');
 const logger = require('../logger');
 
 module.exports = function enforceHttps(forceHttps) {
-  logger.info(`Enforcing https connections=${forceHttps}`);
+  logger.info(`Enforcing HTTPS connections=${forceHttps}`);
   if (!forceHttps) {
     return (req, res, next) => next();
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gambit-conversations",
-  "version": "2.12.3",
+  "version": "2.14.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2516,6 +2516,11 @@
           }
         }
       }
+    },
+    "express-sslify": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/express-sslify/-/express-sslify-1.2.0.tgz",
+      "integrity": "sha1-MOhLzu0VV+sYdnK74UMKCioQDZw="
     },
     "extend": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "dotenv": "^4.0.0",
     "express": "^4.16.3",
     "express-restify-mongoose": "^4.1.3",
+    "express-sslify": "^1.2.0",
     "google-libphonenumber": "^3.0.5",
     "heroku-logger": "^0.1.1",
     "linkify-it": "^2.0.3",

--- a/test/unit/lib/middleware/enforce-https.test.js
+++ b/test/unit/lib/middleware/enforce-https.test.js
@@ -1,0 +1,53 @@
+'use strict';
+
+require('dotenv').config();
+
+const test = require('ava');
+const chai = require('chai');
+const sinon = require('sinon');
+const rewire = require('rewire');
+const enforce = require('express-sslify');
+const sinonChai = require('sinon-chai');
+const httpMocks = require('node-mocks-http');
+
+const logger = require('../../../../lib/logger');
+const stubs = require('../../../helpers/stubs');
+
+chai.should();
+chai.use(sinonChai);
+
+// module to be tested
+const enforceHttpsMiddleware = rewire('../../../../lib/middleware/enforce-https');
+
+const sandbox = sinon.sandbox.create();
+
+test.beforeEach((t) => {
+  stubs.stubLogger(sandbox, logger);
+  t.context.req = httpMocks.createRequest();
+  t.context.res = httpMocks.createResponse();
+});
+
+test.afterEach((t) => {
+  // reset stubs, spies, and mocks
+  sandbox.restore();
+  t.context = {};
+  enforceHttpsMiddleware.__set__('enforce', enforce);
+});
+
+test('enforceHttpsMiddleware should return dummy function that always calls next if forceHttps is false', (t) => {
+  const forceHttps = false;
+  const middleware = enforceHttpsMiddleware(forceHttps);
+  const next = sinon.stub();
+
+  middleware(t.context.req, t.context.res, next);
+  next.should.have.been.called;
+});
+
+test('enforceHttpsMiddleware should return a function that enforces HTTPS if forceHttps is true', () => {
+  const forceHttps = true;
+  const enforceStub = { HTTPS: sinon.stub() };
+  enforceHttpsMiddleware.__set__('enforce', enforceStub);
+  enforceHttpsMiddleware(forceHttps);
+
+  enforceStub.HTTPS.should.have.been.calledWith({ trustProtoHeader: true });
+});


### PR DESCRIPTION
#### What's this PR do?
It adds a middleware that will redirect any GET and HEAD requests to `https://`. Other requests like POSTs will return a `403`. Only while in the **production** environment. Local development will not be impacted.

NOTES:
There is a chance that this update will break other apps that are sending requests to G-Conversations not using the HTTPS protocol. ~~If that is the case a rollback in Staging would be in order and the update of those services would have to happen first.~~ I have to check if it's just a matter of updating the ENV variable in that service first!

#### How should this be reviewed?
- 👀 
- Run all tests

#### Relevant tickets
G-Conversations item in [Pivotal#159114978](https://www.pivotaltracker.com/story/show/159114978)

#### Checklist
- [x] Tests added for new features/bug fixes.
- [x] Tested on staging.
