### PR TITLE
Upgrades vulnerable dependency https-proxy-agent

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gambit-conversations",
-  "version": "2.14.2",
+  "version": "2.14.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -164,10 +164,18 @@
         }
       }
     },
+    "@newrelic/koa": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@newrelic/koa/-/koa-1.0.5.tgz",
+      "integrity": "sha512-1zTojq9gW2mi0YblGrS86gCyL56+gbCn6o2+1UJJL3pFmBgp8IAMzZ93PkHHtdrbL3BnVMBrD2Q2WR32FbhIAg==",
+      "requires": {
+        "methods": "1.1.2"
+      }
+    },
     "@newrelic/native-metrics": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@newrelic/native-metrics/-/native-metrics-2.2.0.tgz",
-      "integrity": "sha512-mMRj6sp6eV7iXZZFQcpdcD9JIixeMuj0bRneK1Jyes3xL7NT7ig/OVKQZk4iP//Uexrr0OttRF395kYb08NUXw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@newrelic/native-metrics/-/native-metrics-3.1.0.tgz",
+      "integrity": "sha512-45OhFKiRT5L+hBzAkDkR5UTuHWIUNMjwlMlu65Y8HmyrTPtgUMKoqMmHERRX4aRqb/EEaW3oWYYLOpLnB6fiHg==",
       "optional": true,
       "requires": {
         "nan": "2.10.0"
@@ -181,6 +189,11 @@
       "requires": {
         "samsam": "1.3.0"
       }
+    },
+    "@tyriar/fibonacci-heap": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@tyriar/fibonacci-heap/-/fibonacci-heap-2.0.7.tgz",
+      "integrity": "sha512-DANf9u0VN5oWrRk31B+xCy9mMNx1H9YhWUaTzCzU0uBruj/zg8u9JSw5qpArntvfJxaW/gWGWbQtzpAkYO6VBg=="
     },
     "accepts": {
       "version": "1.3.5",
@@ -215,9 +228,12 @@
       }
     },
     "agent-base": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-1.0.2.tgz",
-      "integrity": "sha1-aJDT+yFwBLYrcPiSjg+uX4lSpwY="
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
+      "integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
+      "requires": {
+        "es6-promisify": "5.0.0"
+      }
     },
     "ajv": {
       "version": "5.5.2",
@@ -2073,6 +2089,21 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.2.1.tgz",
       "integrity": "sha1-7FYjOGgDKQkgcXDDlEjiREndH8Q="
+    },
+    "es6-promisify": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+      "requires": {
+        "es6-promise": "4.2.4"
+      },
+      "dependencies": {
+        "es6-promise": {
+          "version": "4.2.4",
+          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.4.tgz",
+          "integrity": "sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ=="
+        }
+      }
     },
     "escape-html": {
       "version": "1.0.3",
@@ -4056,13 +4087,22 @@
       }
     },
     "https-proxy-agent": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-0.3.6.tgz",
-      "integrity": "sha1-cT+jjl01P1DrFKNC/r4pAz7RYZs=",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
+      "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
       "requires": {
-        "agent-base": "1.0.2",
-        "debug": "2.6.9",
-        "extend": "3.0.1"
+        "agent-base": "4.2.1",
+        "debug": "3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "hullabaloo-config-manager": {
@@ -5365,23 +5405,25 @@
       "dev": true
     },
     "newrelic": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/newrelic/-/newrelic-2.8.0.tgz",
-      "integrity": "sha1-S3LR/dVkQJKyySPvXeRTbiB71T8=",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/newrelic/-/newrelic-4.7.0.tgz",
+      "integrity": "sha512-p8nOFgyPlShhk3MK4EZVE5GumxSubaUdQFzOCmu+zmbDOrZuYFmmLGUccjezfODpnC6K/htxZKAzPoZtrn98+g==",
       "requires": {
-        "@newrelic/native-metrics": "2.2.0",
-        "async": "2.6.0",
+        "@newrelic/koa": "1.0.5",
+        "@newrelic/native-metrics": "3.1.0",
+        "@tyriar/fibonacci-heap": "2.0.7",
+        "async": "2.6.1",
         "concat-stream": "1.6.2",
-        "https-proxy-agent": "0.3.6",
+        "https-proxy-agent": "2.2.1",
         "json-stringify-safe": "5.0.1",
         "readable-stream": "2.3.5",
         "semver": "5.5.0"
       },
       "dependencies": {
         "async": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
-          "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+          "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
           "requires": {
             "lodash": "4.17.10"
           }

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "moment": "^2.21.0",
     "mongoose": "^4.10.6",
     "mustache": "^2.3.0",
-    "newrelic": "2.8.x",
+    "newrelic": "4.7.0",
     "request": "^2.81.0",
     "request-promise": "^4.2.1",
     "rivescript": "^1.17.2",


### PR DESCRIPTION
#### What's this PR do?
Upgrades `newrelic` to `4.7.0` to upgrade vulnerable dependency `https-proxy-agent`

#### How should this be reviewed?
- 👀 

#### Relevant tickets
- Fixes [Pivotal-#159594740](https://www.pivotaltracker.com/story/show/159594740)
- G-Campaigns is patched in PR https://github.com/DoSomething/gambit-campaigns/pull/1067