### PR TITLE
Adds askSubscriptionStatus, autoReply, textPost, and photoPost broadcast types [pr]

### DIFF
--- a/config/lib/helpers/broadcast.js
+++ b/config/lib/helpers/broadcast.js
@@ -1,6 +1,12 @@
 'use strict';
 
 module.exports = {
+  types: {
+    askSubscriptionStatus: 'askSubscriptionStatus',
+    askYesNo: 'askYesNo',
+    autoReplyBroadcast: 'autoReplyBroadcast',
+    legacy: 'broadcast',
+  },
   default: {
     templates: {
       campaign: 'askSignup',

--- a/config/lib/helpers/broadcast.js
+++ b/config/lib/helpers/broadcast.js
@@ -5,6 +5,8 @@ module.exports = {
     askSubscriptionStatus: 'askSubscriptionStatus',
     askYesNo: 'askYesNo',
     autoReplyBroadcast: 'autoReplyBroadcast',
+    photoPostBroadcast: 'photoPostBroadcast',
+    textPostBroadcast: 'textPostBroadcast',
     legacy: 'broadcast',
   },
   default: {

--- a/config/lib/helpers/template.js
+++ b/config/lib/helpers/template.js
@@ -25,6 +25,7 @@ const templatesMap = {
     askSignup: 'askSignup',
     invalidAskSignupResponse: 'invalidAskSignupResponse',
   },
+  // TODO: Rename as topicTemplates.
   gambitCampaignsTemplates: {
     askCaption: 'askCaption',
     askPhoto: 'askPhoto',
@@ -39,14 +40,17 @@ const templatesMap = {
     invalidQuantity: 'invalidQuantity',
     invalidText: 'invalidText',
     invalidWhyParticipated: 'invalidWhyParticipated',
+    photoPostBroadcast: 'photoPostBroadcast',
     startExternalPost: 'startExternalPost',
     startExternalPostAutoReply: 'startExternalPostAutoReply',
     startPhotoPost: 'startPhotoPost',
     startPhotoPostAutoReply: 'startPhotoPostAutoReply',
+    textPostBroadcast: 'textPostBroadcast',
     webAskText: 'webAskText',
     webStartExternalPost: 'webStartExternalPost',
     webStartPhotoPost: 'webStartPhotoPost',
   },
+  // TODO: Rename as macroTemplates.
   gambitConversationsTemplates: {
     badWords: {
       name: 'badWords',

--- a/config/lib/helpers/topic.js
+++ b/config/lib/helpers/topic.js
@@ -15,9 +15,14 @@ module.exports = {
     'tmi_completed',
     'unsubscribed',
   ],
-  autoReplyTopics: [
-    'autoReplyBroadcast',
-  ],
+  types: {
+    askYesNo: 'askYesNo',
+    autoReply: 'autoReply',
+    photoPostConfig: 'photoPostConfig',
+    textPostConfig: 'textPostConfig',
+    // To be deprecated by autoReply:
+    externalPostConfig: 'externalPostConfig',
+  },
   rivescriptTopics: {
     askSubscriptionStatus: {
       id: 'ask_subscription_status',

--- a/lib/helpers/broadcast.js
+++ b/lib/helpers/broadcast.js
@@ -30,13 +30,6 @@ function fetchById(broadcastId, query = {}) {
 function isAskSubscriptionStatus(broadcast) {
   return broadcast.type === config.types.askSubscriptionStatus;
 }
-/**
- * @param {Object} broadcast
- * @return {Boolean}
- */
-function isAutoReplyBroadcast(broadcast) {
-  return broadcast.type === config.types.autoReplyBroadcast;
-}
 
 /**
  * @param {Object} broadcast
@@ -119,7 +112,6 @@ module.exports = {
   fetch,
   fetchById,
   isAskSubscriptionStatus,
-  isAutoReplyBroadcast,
   isLegacyBroadcast,
   /**
    * @param {boolean} useApiVersion2

--- a/lib/helpers/broadcast.js
+++ b/lib/helpers/broadcast.js
@@ -27,8 +27,23 @@ function fetchById(broadcastId, query = {}) {
  * @param {Object} broadcast
  * @return {Boolean}
  */
+function isAskSubscriptionStatus(broadcast) {
+  return broadcast.type === 'askSubscriptionStatus';
+}
+/**
+ * @param {Object} broadcast
+ * @return {Boolean}
+ */
 function isAutoReplyBroadcast(broadcast) {
   return broadcast.type === 'autoReplyBroadcast';
+}
+
+/**
+ * @param {Object} broadcast
+ * @return {Boolean}
+ */
+function isLegacyBroadcast(broadcast) {
+  return broadcast.type === 'broadcast';
 }
 
 /**
@@ -103,7 +118,9 @@ function formatStats(data) {
 module.exports = {
   fetch,
   fetchById,
+  isAskSubscriptionStatus,
   isAutoReplyBroadcast,
+  isLegacyBroadcast,
   /**
    * @param {boolean} useApiVersion2
    * @return {object}

--- a/lib/helpers/broadcast.js
+++ b/lib/helpers/broadcast.js
@@ -28,14 +28,14 @@ function fetchById(broadcastId, query = {}) {
  * @return {Boolean}
  */
 function isAskSubscriptionStatus(broadcast) {
-  return broadcast.type === 'askSubscriptionStatus';
+  return broadcast.type === config.types.askSubscriptionStatus;
 }
 /**
  * @param {Object} broadcast
  * @return {Boolean}
  */
 function isAutoReplyBroadcast(broadcast) {
-  return broadcast.type === 'autoReplyBroadcast';
+  return broadcast.type === config.types.autoReplyBroadcast;
 }
 
 /**
@@ -43,7 +43,7 @@ function isAutoReplyBroadcast(broadcast) {
  * @return {Boolean}
  */
 function isLegacyBroadcast(broadcast) {
-  return broadcast.type === 'broadcast';
+  return broadcast.type === config.types.legacy;
 }
 
 /**

--- a/lib/helpers/request.js
+++ b/lib/helpers/request.js
@@ -110,14 +110,6 @@ function hasCampaign(req) {
  * @param {Object} req
  * @return {Boolean}
  */
-function isAutoReplyTopic(req) {
-  return req.topic && helpers.topic.isAutoReplyTopic(req.topic);
-}
-
-/**
- * @param {Object} req
- * @return {Boolean}
- */
 function isChangeTopicMacro(req) {
   return req.macro && helpers.macro.isChangeTopic(req.macro);
 }
@@ -263,6 +255,17 @@ function setTopic(req, topic) {
 }
 
 /**
+ * @param {Object} req
+ * @return {Boolean}
+ */
+function shouldSendAutoReply(req) {
+  const topic = req.topic;
+  // TODO: Currently treating existing in askYesNo topic as a reason to send the autoReply template,
+  // but we'll want to instead only send the autoReply when user has responded with a no.
+  return topic && (helpers.topic.isAutoReply(topic) || helpers.topic.isAskYesNo(topic));
+}
+
+/**
  * getUserIdParamFromReq - Gets the user id from the params sent inside the body of a POST request
  *
  * @param  {Object} req
@@ -288,7 +291,6 @@ module.exports = {
   getRivescriptReply,
   getUserIdParamFromReq,
   hasCampaign,
-  isAutoReplyTopic,
   isChangeTopicMacro,
   isClosedCampaign,
   isLastOutboundAskContinue,
@@ -352,6 +354,7 @@ module.exports = {
     req.userId = userId;
     analytics.addCustomAttributes({ userId });
   },
+  shouldSendAutoReply,
   shouldSuppressOutboundReply: function shouldSuppressOutboundReply(req) {
     return req.headers['x-gambit-outbound-reply-suppress'] === 'true';
   },

--- a/lib/helpers/request.js
+++ b/lib/helpers/request.js
@@ -262,7 +262,7 @@ function shouldSendAutoReply(req) {
   const topic = req.topic;
   // TODO: Currently treating existing in askYesNo topic as a reason to send the autoReply template,
   // but we'll want to instead only send the autoReply when user has responded with a no.
-  return topic && (helpers.topic.isAutoReply(topic) || helpers.topic.isAskYesNo(topic));
+  return !!topic && (helpers.topic.isAutoReply(topic) || helpers.topic.isAskYesNo(topic));
 }
 
 /**

--- a/lib/helpers/topic.js
+++ b/lib/helpers/topic.js
@@ -86,8 +86,16 @@ function isAskSubscriptionStatus(topic) {
  * @param {Object} topic
  * @return {Boolean}
  */
-function isAutoReplyTopic(topic) {
-  return config.autoReplyTopics.includes(topic.type);
+function isAskYesNo(topic) {
+  return topic.type === config.types.askYesNo;
+}
+
+/**
+ * @param {Object} topic
+ * @return {Boolean}
+ */
+function isAutoReply(topic) {
+  return topic.type === config.types.autoReply;
 }
 
 /**
@@ -116,8 +124,9 @@ module.exports = {
   getRenderedTextFromTopicAndTemplateName,
   getRivescriptTopicById,
   getSupportTopic,
-  isAutoReplyTopic,
+  isAskSubscriptionStatus,
+  isAskYesNo,
+  isAutoReply,
   isDefaultTopicId,
   isRivescriptTopicId,
-  isAskSubscriptionStatus,
 };

--- a/lib/helpers/topic.js
+++ b/lib/helpers/topic.js
@@ -25,7 +25,14 @@ function fetchByCampaignId(campaignId) {
 }
 
 /**
- * @return {String}
+ * @return {Object}
+ */
+function getAskSubscriptionStatusTopic() {
+  return config.rivescriptTopics.askSubscriptionStatus;
+}
+
+/**
+ * @return {Object}
  */
 function getDefaultTopic() {
   return config.rivescriptTopics.default;
@@ -61,7 +68,7 @@ function getRenderedTextFromTopicAndTemplateName(topic, templateName) {
 }
 
 /**
- * @return {String}
+ * @return {Object}
  */
 function getSupportTopic() {
   return config.rivescriptTopics.support;
@@ -103,6 +110,7 @@ function isDefaultTopicId(topicId) {
 module.exports = {
   fetchById,
   fetchByCampaignId,
+  getAskSubscriptionStatusTopic,
   getDefaultTopic,
   getDefaultTopicId,
   getRenderedTextFromTopicAndTemplateName,

--- a/lib/middleware/messages/broadcast/broadcast-parse.js
+++ b/lib/middleware/messages/broadcast/broadcast-parse.js
@@ -14,10 +14,14 @@ module.exports = function parseBroadcast() {
       });
 
       // Parse topic that we'll need to update the user's conversation with.
+      // TODO: We'll be able to deprecate the legacy type and remove this check once:
+      // - The askYesNo topic returns its relevant replies
+      // - An autoReply topic has an optional campaign value set, which will deprecate the use of
+      //   the externalPostConfig content type used to create signups and send a single reply.
       if (helpers.broadcast.isLegacyBroadcast(req.broadcast)) {
-        // The legacy type has a topic text field used to user conversation to a Rivescript topic.
+        // The legacy type has a topic text field used to save a Rivescript topic id.
         if (req.broadcast.topic) {
-          helpers.request.setTopic(req, { id: req.broadcast.topic });
+          helpers.request.setTopic(req, helpers.topic.getRivescriptTopicById(req.broadcast.topic));
           return next();
         }
         // Otherwise we save the campaignId to use later to find the topic to set.

--- a/lib/middleware/messages/broadcast/broadcast-parse.js
+++ b/lib/middleware/messages/broadcast/broadcast-parse.js
@@ -32,7 +32,8 @@ module.exports = function parseBroadcast() {
 
       // If the outbound message does not contain a topic, this is a broadcast with templates to use
       // as a topic (e.g. to be used when we get to supporting an askYesNo broadcast)
-      helpers.request.setTopic(req, outboundMessage.topic ? outboundMessage.topic : req.broadcast);
+      helpers.request
+        .setTopic(req, outboundMessage.topic.id ? outboundMessage.topic : req.broadcast);
 
       return next();
     } catch (err) {

--- a/lib/middleware/messages/broadcast/broadcast-parse.js
+++ b/lib/middleware/messages/broadcast/broadcast-parse.js
@@ -5,24 +5,34 @@ const helpers = require('../../../helpers');
 module.exports = function parseBroadcast() {
   return (req, res, next) => {
     try {
+      // Parse message to send to user.
       const outboundMessage = req.broadcast.message;
       helpers.request.setOutboundMessageText(req, outboundMessage.text);
       helpers.request.setOutboundMessageTemplate(req, outboundMessage.template);
-
-      if (helpers.broadcast.isAutoReplyBroadcast(req.broadcast)) {
-        helpers.request.setTopic(req, req.broadcast);
-      // Note: eventually this broadcast.topic property won't be a string but would be a topic
-      // object. For now, the only new broadcast type we're in good shape to support without more
-      // refactoring is the autoReplyBroadcast.
-      } else if (req.broadcast.topic) {
-        helpers.request.setTopic(req, { id: req.broadcast.topic });
-      } else {
-        helpers.request.setCampaignId(req, req.broadcast.campaignId);
-      }
-
       outboundMessage.attachments.forEach((attachment) => {
         helpers.attachments.add(req, attachment, 'outbound');
       });
+
+      // Parse topic that we'll need to update the user's conversation with.
+      if (helpers.broadcast.isLegacyBroadcast(req.broadcast)) {
+        // The legacy type has a topic text field used to user conversation to a Rivescript topic.
+        if (req.broadcast.topic) {
+          helpers.request.setTopic(req, { id: req.broadcast.topic });
+          return next();
+        }
+        // Otherwise we save the campaignId to use later to find the topic to set.
+        helpers.request.setCampaignId(req, req.broadcast.campaignId);
+        return next();
+      }
+
+      if (helpers.broadcast.isAskSubscriptionStatus(req.broadcast)) {
+        helpers.request.setTopic(req, helpers.topic.getAskSubscriptionStatusTopic());
+        return next();
+      }
+
+      // If the outbound message does not contain a topic, this is a broadcast with templates to use
+      // as a topic (e.g. to be used when we get to supporting an askYesNo broadcast)
+      helpers.request.setTopic(req, outboundMessage.topic ? outboundMessage.topic : req.broadcast);
 
       return next();
     } catch (err) {

--- a/lib/middleware/messages/broadcast/conversation-update.js
+++ b/lib/middleware/messages/broadcast/conversation-update.js
@@ -5,12 +5,13 @@ const UnprocessibleEntityError = require('../../../../app/exceptions/Unprocessib
 
 module.exports = function updateConversation() {
   return (req, res, next) => {
-    // Eventually all broadcasts will contain a topic, and all code below will be removed.
-    // @see https://www.pivotaltracker.com/story/show/157369418
     if (req.topic) {
       return helpers.request.changeTopic(req, req.topic).then(() => next());
     }
-    // TODO: this check will turn into an else for when req.topic undefined.
+
+    // TODO: Once we get askYesNo broadcasts in place to deprecate the askSignup legacy broadcast,
+    // we'll throw an error if a req.topic doesn't exist, and no longer to find a topic for a given
+    // campaignId.
     if (!req.campaignId) {
       const error = new UnprocessibleEntityError('Broadcast does not contain topic or campaignId.');
       return helpers.sendErrorResponse(res, error);

--- a/lib/middleware/messages/broadcast/conversation-update.js
+++ b/lib/middleware/messages/broadcast/conversation-update.js
@@ -10,7 +10,7 @@ module.exports = function updateConversation() {
     }
 
     // TODO: Once we get askYesNo broadcasts in place to deprecate the askSignup legacy broadcast,
-    // send error response if req.topic undefined, as we'll no longer to find a topic by campaignId.
+    // send error if req.topic undefined, as we'll no longer need to find a topic by campaignId.
     if (!req.campaignId) {
       const error = new UnprocessibleEntityError('Broadcast does not contain topic or campaignId.');
       return helpers.sendErrorResponse(res, error);

--- a/lib/middleware/messages/broadcast/conversation-update.js
+++ b/lib/middleware/messages/broadcast/conversation-update.js
@@ -10,8 +10,7 @@ module.exports = function updateConversation() {
     }
 
     // TODO: Once we get askYesNo broadcasts in place to deprecate the askSignup legacy broadcast,
-    // we'll throw an error if a req.topic doesn't exist, and no longer to find a topic for a given
-    // campaignId.
+    // send error response if req.topic undefined, as we'll no longer to find a topic by campaignId.
     if (!req.campaignId) {
       const error = new UnprocessibleEntityError('Broadcast does not contain topic or campaignId.');
       return helpers.sendErrorResponse(res, error);

--- a/lib/middleware/messages/member/macro-catch-all.js
+++ b/lib/middleware/messages/member/macro-catch-all.js
@@ -5,7 +5,7 @@ const logger = require('../../../logger');
 
 module.exports = function catchAllMacro() {
   return async (req, res) => {
-    if (helpers.request.isAutoReplyTopic(req)) {
+    if (helpers.request.shouldSendAutoReply(req)) {
       return helpers.replies.autoReply(req, res);
     }
 

--- a/test/helpers/factories/broadcast.js
+++ b/test/helpers/factories/broadcast.js
@@ -38,7 +38,7 @@ function getValidAskYesNo() {
   return module.exports.getBroadcast(config.types.askYesNo);
 }
 
-function getValidCampaignBroadcast() {
+function getValidLegacyCampaignBroadcast() {
   const broadcast = getBroadcast(config.types.legacy);
   broadcast.message.template = 'askSignup';
   broadcast.topic = null;
@@ -49,7 +49,7 @@ function getValidCampaignBroadcast() {
 /**
  * @return {Object}
  */
-function getValidTopicBroadcast() {
+function getValidLegacyRivescriptTopicBroadcast() {
   const broadcast = getBroadcast(config.types.legacy);
   broadcast.message.template = 'rivescript';
   broadcast.topic = stubs.getTopic();
@@ -62,6 +62,6 @@ module.exports = {
   getValidAutoReplyBroadcast,
   getValidAskSubscriptionStatus,
   getValidAskYesNo,
-  getValidCampaignBroadcast,
-  getValidTopicBroadcast,
+  getValidLegacyCampaignBroadcast,
+  getValidLegacyRivescriptTopicBroadcast,
 };

--- a/test/helpers/factories/broadcast.js
+++ b/test/helpers/factories/broadcast.js
@@ -1,13 +1,14 @@
 'use strict';
 
 const stubs = require('../stubs');
+const topicFactory = require('./topic');
 const config = require('../../../config/lib/helpers/broadcast');
 
 /**
  * @see https://github.com/DoSomething/gambit-campaigns/tree/master/documentation
  */
 
-function getBroadcast(type) {
+function getBroadcast(type, topic = {}) {
   const date = Date.now();
   return {
     id: stubs.getBroadcastId(),
@@ -19,9 +20,14 @@ function getBroadcast(type) {
       text: stubs.getBroadcastMessageText(),
       attachments: [stubs.getAttachment()],
       template: type,
+      topic,
     },
     templates: [],
   };
+}
+
+function getValidAutoReplyBroadcast() {
+  return getBroadcast(config.types.autoReplyBroadcast, topicFactory.getValidAutoReply());
 }
 
 function getValidAskSubscriptionStatus() {
@@ -53,6 +59,7 @@ function getValidTopicBroadcast() {
 
 module.exports = {
   getBroadcast,
+  getValidAutoReplyBroadcast,
   getValidAskSubscriptionStatus,
   getValidAskYesNo,
   getValidCampaignBroadcast,

--- a/test/helpers/factories/broadcast.js
+++ b/test/helpers/factories/broadcast.js
@@ -29,7 +29,7 @@ function getValidAskSubscriptionStatus() {
 }
 
 function getValidAskYesNo() {
-  return getBroadcast(config.types.askYesNo);
+  return module.exports.getBroadcast(config.types.askYesNo);
 }
 
 function getValidCampaignBroadcast() {
@@ -52,6 +52,7 @@ function getValidTopicBroadcast() {
 }
 
 module.exports = {
+  getBroadcast,
   getValidAskSubscriptionStatus,
   getValidAskYesNo,
   getValidCampaignBroadcast,

--- a/test/helpers/factories/broadcast.js
+++ b/test/helpers/factories/broadcast.js
@@ -1,35 +1,50 @@
 'use strict';
 
 const stubs = require('../stubs');
+const config = require('../../../config/lib/helpers/broadcast');
 
 /**
  * @see https://github.com/DoSomething/gambit-campaigns/tree/master/documentation
  */
 
-/**
- * @return {Object}
- */
-function getValidCampaignBroadcast(date = Date.now()) {
+function getBroadcast(type) {
+  const date = Date.now();
   return {
     id: stubs.getBroadcastId(),
     name: stubs.getBroadcastName(),
+    type,
     createdAt: date,
     updatedAt: date,
     message: {
       text: stubs.getBroadcastMessageText(),
       attachments: [stubs.getAttachment()],
-      template: 'askSignup',
+      template: type,
     },
-    campaignId: stubs.getCampaignId(),
-    topic: null,
+    templates: [],
   };
+}
+
+function getValidAskSubscriptionStatus() {
+  return getBroadcast(config.types.askSubscriptionStatus);
+}
+
+function getValidAskYesNo() {
+  return getBroadcast(config.types.askYesNo);
+}
+
+function getValidCampaignBroadcast() {
+  const broadcast = getBroadcast(config.types.legacy);
+  broadcast.message.template = 'askSignup';
+  broadcast.topic = null;
+  broadcast.campaignId = stubs.getCampaignId();
+  return broadcast;
 }
 
 /**
  * @return {Object}
  */
-function getValidTopicBroadcast(date = Date.now()) {
-  const broadcast = module.exports.getValidCampaignBroadcast(date);
+function getValidTopicBroadcast() {
+  const broadcast = getBroadcast(config.types.legacy);
   broadcast.message.template = 'rivescript';
   broadcast.topic = stubs.getTopic();
   broadcast.campaignId = null;
@@ -37,6 +52,8 @@ function getValidTopicBroadcast(date = Date.now()) {
 }
 
 module.exports = {
+  getValidAskSubscriptionStatus,
+  getValidAskYesNo,
   getValidCampaignBroadcast,
   getValidTopicBroadcast,
 };

--- a/test/helpers/factories/broadcast.js
+++ b/test/helpers/factories/broadcast.js
@@ -35,7 +35,7 @@ function getValidAskSubscriptionStatus() {
 }
 
 function getValidAskYesNo() {
-  return module.exports.getBroadcast(config.types.askYesNo);
+  return getBroadcast(config.types.askYesNo);
 }
 
 function getValidLegacyCampaignBroadcast() {

--- a/test/helpers/factories/topic.js
+++ b/test/helpers/factories/topic.js
@@ -1,10 +1,15 @@
 'use strict';
 
 const stubs = require('../stubs');
+const broadcastFactory = require('./broadcast');
+const config = require('../../../config/lib/helpers/topic');
 
-function getValidTopic() {
+
+function getValidTopic(type = 'photoPostConfig') {
   const result = {
     id: stubs.getContentfulId(),
+    name: stubs.getRandomName(),
+    type,
     postType: stubs.getPostType(),
     templates: {},
     campaign: {
@@ -15,18 +20,34 @@ function getValidTopic() {
   result.templates[templateName] = {
     raw: stubs.getRandomMessageText(),
     rendered: stubs.getRandomMessageText(),
+    text: stubs.getRandomMessageText(),
     override: true,
   };
   return result;
 }
 
 function getValidTopicWithoutCampaign() {
-  const topic = module.exports.getValidTopic();
+  const topic = getValidTopic();
   topic.campaign = null;
   return topic;
 }
 
+function getValidAskYesNo() {
+  return broadcastFactory.getValidAskYesNo();
+}
+
+function getValidAutoReply() {
+  return getValidTopic(config.types.autoReply);
+}
+
+function getValidTextPostConfig() {
+  return getValidTopic(config.types.textPostConfig);
+}
+
 module.exports = {
+  getValidAskYesNo,
+  getValidAutoReply,
+  getValidTextPostConfig,
   getValidTopic,
   getValidTopicWithoutCampaign,
 };

--- a/test/helpers/stubs.js
+++ b/test/helpers/stubs.js
@@ -182,6 +182,9 @@ module.exports = {
   getRandomMessageText: function getRandomMessageText() {
     return chance.paragraph({ sentences: 2 });
   },
+  getRandomName: function getRandomWord() {
+    return `${chance.animal()} ${chance.animal()} - ${chance.month()} ${chance.year()}`;
+  },
   getRandomWord: function getRandomWord() {
     return chance.word();
   },

--- a/test/unit/lib/gambit-campaigns.test.js
+++ b/test/unit/lib/gambit-campaigns.test.js
@@ -25,7 +25,7 @@ const defaultTopicTriggerFactory = require('../../helpers/factories/defaultTopic
 const topicFactory = require('../../helpers/factories/topic');
 
 const campaign = campaignFactory.getValidCampaign();
-const campaignBroadcast = broadcastFactory.getValidCampaignBroadcast();
+const campaignBroadcast = broadcastFactory.getValidLegacyCampaignBroadcast();
 const defaultTopicTriggers = [
   defaultTopicTriggerFactory.getValidReplyDefaultTopicTrigger(),
   defaultTopicTriggerFactory.getValidReplyDefaultTopicTrigger(),
@@ -114,7 +114,7 @@ test('fetchBroadcasts should return result of a successful GET /broadcasts reque
   const fetchResponse = {
     data: [
       campaignBroadcast,
-      broadcastFactory.getValidTopicBroadcast(),
+      broadcastFactory.getValidLegacyRivescriptTopicBroadcast(),
     ],
   };
   sandbox.stub(gambitCampaigns, 'executeGet')

--- a/test/unit/lib/lib-helpers/broadcast.test.js
+++ b/test/unit/lib/lib-helpers/broadcast.test.js
@@ -30,7 +30,7 @@ const webhookContentTypeHeader = 'application/json';
 
 const askSubscriptionStatusBroadcast = broadcastFactory.getValidAskSubscriptionStatus();
 const askYesNoBroadcast = broadcastFactory.getValidAskYesNo();
-const legacyBroadcast = broadcastFactory.getValidCampaignBroadcast();
+const legacyBroadcast = broadcastFactory.getValidLegacyCampaignBroadcast();
 
 // sinon sandbox object
 const sandbox = sinon.sandbox.create();
@@ -63,7 +63,7 @@ test('aggregateMessagesForBroadcastId should throw if Messages.aggregate fails',
 
 // fetch
 test('fetch should return gambitCampaigns.fetchBroadcasts', async () => {
-  const broadcasts = [broadcastFactory.getValidCampaignBroadcast()];
+  const broadcasts = [broadcastFactory.getValidLegacyCampaignBroadcast()];
   const query = { skip: 11 };
   sandbox.stub(gambitCampaigns, 'fetchBroadcasts')
     .returns(Promise.resolve(broadcasts));
@@ -75,7 +75,7 @@ test('fetch should return gambitCampaigns.fetchBroadcasts', async () => {
 
 // fetchById
 test('fetchById should return gambitCampaigns.fetchBroadcastById', async () => {
-  const broadcast = broadcastFactory.getValidCampaignBroadcast();
+  const broadcast = broadcastFactory.getValidLegacyCampaignBroadcast();
   sandbox.stub(gambitCampaigns, 'fetchBroadcastById')
     .returns(Promise.resolve(broadcast));
 

--- a/test/unit/lib/lib-helpers/broadcast.test.js
+++ b/test/unit/lib/lib-helpers/broadcast.test.js
@@ -28,6 +28,10 @@ const defaultStats = stubs.getBroadcastStats(true);
 const mockAggregateResults = stubs.getBroadcastAggregateMessagesResults();
 const webhookContentTypeHeader = 'application/json';
 
+const askSubscriptionStatusBroadcast = broadcastFactory.getValidAskSubscriptionStatus();
+const askYesNoBroadcast = broadcastFactory.getValidAskYesNo();
+const legacyBroadcast = broadcastFactory.getValidCampaignBroadcast();
+
 // sinon sandbox object
 const sandbox = sinon.sandbox.create();
 
@@ -119,6 +123,18 @@ test('getWebhook should return an object with body of a POST Broadcast Message r
   result.body.northstarId.should.equal(config.customerIo.userIdField);
   result.body.broadcastId.should.equal(broadcastId);
   result.should.have.property('url');
+});
+
+// isAskSubscriptionStatus
+test('isAskSubscriptionStatus returns whether broadcast type is askSubscriptionStatus', (t) => {
+  t.truthy(broadcastHelper.isAskSubscriptionStatus(askSubscriptionStatusBroadcast));
+  t.falsy(broadcastHelper.isAskSubscriptionStatus(askYesNoBroadcast));
+});
+
+// isLegacyBroadcast
+test('isLegacyBroadcast returns whether broadcast type is legacy', (t) => {
+  t.truthy(broadcastHelper.isLegacyBroadcast(legacyBroadcast));
+  t.falsy(broadcastHelper.isLegacyBroadcast(askYesNoBroadcast));
 });
 
 // parseMessageDirection

--- a/test/unit/lib/lib-helpers/request.test.js
+++ b/test/unit/lib/lib-helpers/request.test.js
@@ -495,3 +495,31 @@ test('setUserId should inject a userId property to req', (t) => {
   t.context.req.userId.should.equal(userId);
   helpers.analytics.addCustomAttributes.should.have.been.calledWith({ userId });
 });
+
+// shouldSendAutoReply
+test('shouldSendAutoReply returns false if req.topic undefined', (t) => {
+  t.falsy(requestHelper.shouldSendAutoReply(t.context.req));
+});
+
+test('shouldSendAutoReply return true if req.topic isAskYesNo (for now)', (t) => {
+  sandbox.stub(helpers.topic, 'isAskYesNo')
+    .returns(true);
+  t.context.req.topic = topic;
+  t.truthy(requestHelper.shouldSendAutoReply(t.context.req));
+});
+
+test('shouldSendAutoReply return true if req.topic isAutoReply', (t) => {
+  sandbox.stub(helpers.topic, 'isAutoReply')
+    .returns(true);
+  t.context.req.topic = topic;
+  t.truthy(requestHelper.shouldSendAutoReply(t.context.req));
+});
+
+test('shouldSendAutoReply return false if req.topic is neither isAutoReply or isAskYesNo', (t) => {
+  sandbox.stub(helpers.topic, 'isAskYesNo')
+    .returns(false);
+  sandbox.stub(helpers.topic, 'isAutoReply')
+    .returns(false);
+  t.context.req.topic = topic;
+  t.falsy(requestHelper.shouldSendAutoReply(t.context.req));
+});

--- a/test/unit/lib/lib-helpers/topic.test.js
+++ b/test/unit/lib/lib-helpers/topic.test.js
@@ -54,6 +54,12 @@ test('fetchByCampaignId should call helpers.campaign.fetchById and inject campai
   });
 });
 
+// getAskSubscriptionStatusTopic
+test('getAskSubscriptionStatusTopic should return config.rivescriptTopics.askSubscriptionStatus', () => {
+  const result = topicHelper.getAskSubscriptionStatusTopic();
+  result.should.deep.equal(config.rivescriptTopics.askSubscriptionStatus);
+});
+
 // getDefaultTopic
 test('getDefaultTopic should return config.rivescriptTopics.default', () => {
   const result = topicHelper.getDefaultTopic();
@@ -86,6 +92,18 @@ test('isAskSubscriptionStatus returns whether topic is rivescriptTopics.isAskSub
   const mockTopic = topicFactory.getValidTopic();
   t.truthy(topicHelper.isAskSubscriptionStatus(config.rivescriptTopics.askSubscriptionStatus));
   t.falsy(topicHelper.isAskSubscriptionStatus(mockTopic));
+});
+
+// isAskYesNo
+test('isAskYesNo returns whether topic type is askYesNo', (t) => {
+  t.truthy(topicHelper.isAskYesNo(topicFactory.getValidAskYesNo()));
+  t.falsy(topicHelper.isAskYesNo(topicFactory.getValidAutoReply()));
+});
+
+// isAutoReply
+test('isAutoReply returns whether topic type is autoReply', (t) => {
+  t.truthy(topicHelper.isAutoReply(topicFactory.getValidAutoReply()));
+  t.falsy(topicHelper.isAutoReply(topicFactory.getValidTextPostConfig()));
 });
 
 // isRivescriptTopicId

--- a/test/unit/lib/middleware/broadcasts/index/index.test.js
+++ b/test/unit/lib/middleware/broadcasts/index/index.test.js
@@ -15,8 +15,8 @@ const stubs = require('../../../../../helpers/stubs');
 const broadcastFactory = require('../../../../../helpers/factories/broadcast');
 
 const broadcasts = [
-  broadcastFactory.getValidCampaignBroadcast(),
-  broadcastFactory.getValidTopicBroadcast(),
+  broadcastFactory.getValidLegacyCampaignBroadcast(),
+  broadcastFactory.getValidLegacyRivescriptTopicBroadcast(),
 ];
 
 chai.should();

--- a/test/unit/lib/middleware/messages/broadcast/broadcast-get.test.js
+++ b/test/unit/lib/middleware/messages/broadcast/broadcast-get.test.js
@@ -17,7 +17,7 @@ const broadcastFactory = require('../../../../../helpers/factories/broadcast');
 
 // stubs
 const broadcastId = stubs.getBroadcastId();
-const mockBroadcast = broadcastFactory.getValidCampaignBroadcast();
+const mockBroadcast = broadcastFactory.getValidLegacyCampaignBroadcast();
 
 // setup "x.should.y" assertion style
 chai.should();

--- a/test/unit/lib/middleware/messages/broadcast/broadcast-parse.test.js
+++ b/test/unit/lib/middleware/messages/broadcast/broadcast-parse.test.js
@@ -25,6 +25,9 @@ const sandbox = sinon.sandbox.create();
 test.beforeEach((t) => {
   sandbox.stub(helpers.attachments, 'add')
     .returns(underscore.noop);
+  // TODO: Remove me and add tests for non legacy parsing.
+  sandbox.stub(helpers.broadcast, 'isLegacyBroadcast')
+    .returns(true);
   sandbox.stub(helpers.request, 'setCampaignId')
     .returns(underscore.noop);
   sandbox.stub(helpers.request, 'setOutboundMessageTemplate')

--- a/test/unit/lib/middleware/messages/broadcast/broadcast-parse.test.js
+++ b/test/unit/lib/middleware/messages/broadcast/broadcast-parse.test.js
@@ -45,7 +45,7 @@ test.afterEach((t) => {
 test('parseBroadcast should inject campaignId into req if legacy campaign broadcast', async (t) => {
   const next = sinon.stub();
   const middleware = parseBroadcast();
-  const broadcast = broadcastFactory.getValidCampaignBroadcast();
+  const broadcast = broadcastFactory.getValidLegacyCampaignBroadcast();
   t.context.req.broadcast = broadcast;
   sandbox.stub(helpers.request, 'setOutboundMessageText')
     .returns(underscore.noop);
@@ -66,15 +66,19 @@ test('parseBroadcast should inject campaignId into req if legacy campaign broadc
 test('parseBroadcast should inject topic into req if legacy rivescript topic broadcast', async (t) => {
   const next = sinon.stub();
   const middleware = parseBroadcast();
-  const broadcast = broadcastFactory.getValidTopicBroadcast();
+  const broadcast = broadcastFactory.getValidLegacyRivescriptTopicBroadcast();
   t.context.req.broadcast = broadcast;
+  const mockRivescriptTopic = { id: broadcast.topic };
+  sandbox.stub(helpers.topic, 'getRivescriptTopicById')
+    .returns(mockRivescriptTopic);
+
   sandbox.stub(helpers.request, 'setOutboundMessageText')
     .returns(underscore.noop);
 
   // test
   await middleware(t.context.req, t.context.res, next);
   helpers.request.setCampaignId.should.not.have.been.called;
-  helpers.request.setTopic.should.have.been.calledWith(t.context.req, { id: broadcast.topic });
+  helpers.request.setTopic.should.have.been.calledWith(t.context.req, mockRivescriptTopic);
   helpers.request.setOutboundMessageText
     .should.have.been.calledWith(t.context.req, broadcast.message.text);
   helpers.request.setOutboundMessageTemplate

--- a/test/unit/lib/middleware/messages/member/macro-catch-all.test.js
+++ b/test/unit/lib/middleware/messages/member/macro-catch-all.test.js
@@ -44,10 +44,10 @@ test.afterEach((t) => {
   t.context = {};
 });
 
-test('catchAllMacro should call replies.autoReply if request.isAutoReplyTopic', async (t) => {
+test('catchAllMacro should call replies.autoReply if request.shouldSendAutoReply', async (t) => {
   const next = sinon.stub();
   const middleware = catchAllMacro();
-  sandbox.stub(helpers.request, 'isAutoReplyTopic')
+  sandbox.stub(helpers.request, 'shouldSendAutoReply')
     .returns(true);
   sandbox.stub(helpers.replies, 'autoReply')
     .returns(underscore.noop);
@@ -55,7 +55,7 @@ test('catchAllMacro should call replies.autoReply if request.isAutoReplyTopic', 
   // test
   await middleware(t.context.req, t.context.res, next);
 
-  helpers.request.isAutoReplyTopic.should.have.been.calledWith(t.context.req);
+  helpers.request.shouldSendAutoReply.should.have.been.calledWith(t.context.req);
   next.should.not.have.been.called;
   helpers.replies.autoReply.should.have.been.calledWith(t.context.req, t.context.res);
 });


### PR DESCRIPTION
#### What's this PR do?

Modifies the broadcast parsing in a `POST /messages?origin=request` to support the new broadcast types added in https://github.com/DoSomething/gambit-campaigns/pull/1072, https://github.com/DoSomething/gambit-campaigns/pull/1073, https://github.com/DoSomething/gambit-campaigns/pull/1074 

If the broadcast is not considered legacy (type is `broadcast`), we check:

* If type is `askSubscriptionStatus`, change topic to our hardcoded `ask_subscription_status` Rivescript topic.

* If the broadcast `message.topic` is not empty (e.g. an `autoReply`, `photoPostConfig`, or `textPostConfig`), change topic to this topic

* Otherwise, change the topic to the broadcast (e.g. an `askYesNo`)

This deprecates using our legacy `broadcast` type to update the conversation with a Rivescript topic (e.g. `survey_response` or `ask_subscription_status`) as well as the campaign askText or startPhotoPost templates.

#### How should this be reviewed?

I've created entries for each new type to test each type:

* askSubscriptionStatus - 4qLXWRSqY0ommayY2iWCwU
    * Should update topic to `ask_subscription_status`. This deprecates our use of the `ask_subscription_status` legacy Rivescript topic broadcast 

* autoReplyBroadcast - 6zj3wladnGyWuMWAUYyg8c`
    * Should update topic to autoReply 61RPZx8atiGyeoeaqsckOE. This deprecates our use of the `survey_response` legacy Rivescript topic broadcast 

* photoPostBroadcast - `5t2fmKd2iQgaCCy8Kgg0CI`
    * Should update topic to photoPostConfig 4xXe9sQqmIeiWauSUu6kAY. - Replying to this broadcast should begin a photo post (assuming no other triggers/quick replies are caught)
    * This deprecates our legacy  `startPhotoPost` campaign broadcast

* textPostBroadcast - `1pGaGNh8fCyIeqAukYkUwM`
    * Should update topic to textPostConfig `2Aq6ZrB5Y4gucmSYasq4O4`. Replying to this broadcast should create a text post (assuming no other triggers/ quick replies are caught, text over 3 chars sent)
    * This deprecates our legacy  `askText` campaign broadcast

* isAskYesNo - `2X4r3fZrTGA2mGemowgiEI`
    * Should update topic to the broadcast, 2X4r3fZrTGA2mGemowgiEI. This isn't parsing yes and no responses yet, but instead sends the `autoReply` template defined on the broadcast.
    * This will eventually deprecate the legacy  `askSignup` campaign broadcast, 

For good measure, sanity check that legacy types still result in expected behavior:

* `survey_response` - `6pNPkaCeaceSem4OQIyqIE` should set topic to `survey_response`

* `askSignup` - `5xvQes9UJyMowO8kisEwss` should set topic to `4xXe9sQqmIeiWauSUu6kAY`

#### Any background context you want to provide?
I'll be tackling the next TODOs into 2 parts:

1 - Add an optional `campaign` property to the `autoReply` topic, to deprecate the `externalPostConfig` type. If it exists, create a signup when user joins the `autoReply` topic via posting message to the gambit-campaigns `campaignActivity` endpoint

2 - Add support for the `askYesNo` templates (and `saidYes` topic change) to deprecate the using legacy braodcast for the `askSignup` campaign template.

#### Relevant tickets
https://www.pivotaltracker.com/story/show/157369418

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [x] Tests added for new features/bug fixes.
- [x] Tested on staging.
