### PR TITLE
Post campaign activity if autoReply topic has campaign [pr]

### DIFF
--- a/app/routes/messages/member.js
+++ b/app/routes/messages/member.js
@@ -27,7 +27,8 @@ const changeTopicMacroMiddleware = require('../../../lib/middleware/messages/mem
 const menuMacroMiddleware = require('../../../lib/middleware/messages/member/macro-menu');
 const replyMacroMiddleware = require('../../../lib/middleware/messages/member/macro-reply');
 const getTopicMiddleware = require('../../../lib/middleware/messages/member/topic-get');
-const catchAllMacroMiddleware = require('../../../lib/middleware/messages/member/macro-catch-all');
+const catchAllAutoReplyMiddleware = require('../../../lib/middleware/messages/member/catchAll-autoReply');
+const catchAllDefaultMiddleware = require('../../../lib/middleware/messages/member/catchAll');
 
 router.use(paramsMiddleware());
 
@@ -81,7 +82,10 @@ router.use(getTopicMiddleware());
 // TODO: Move this into catchall.
 router.use(supportRequestedMiddleware());
 
+// Checks whether to send an autoReply template.
+router.use(catchAllAutoReplyMiddleware());
+
 // Determines whether to start or continue conversation for the current topic.
-router.use(catchAllMacroMiddleware());
+router.use(catchAllDefaultMiddleware());
 
 module.exports = router;

--- a/config/lib/helpers/template.js
+++ b/config/lib/helpers/template.js
@@ -32,6 +32,7 @@ const templatesMap = {
     askQuantity: 'askQuantity',
     askText: 'askText',
     askWhyParticipated: 'askWhyParticipated',
+    autoReply: 'autoReply',
     completedPhotoPost: 'completedPhotoPost',
     completedPhotoPostAutoReply: 'completedPhotoPostAutoReply',
     completedTextPost: 'completedTextPost',

--- a/lib/consolebot.js
+++ b/lib/consolebot.js
@@ -84,7 +84,7 @@ class Consolebot {
       .set(suppressSendHeader, this.options.request.headers.suppressReply)
       .send(payload)
       .then(res => this.handleSuccess(res))
-      .catch(err => this.reply(err.message));
+      .catch(error => this.handleError(error));
   }
   prompt() {
     this.readline.prompt();
@@ -97,19 +97,20 @@ class Consolebot {
       .on('line', line => console.log(line[this.replyColor])) // eslint-disable-line no-console
       .on('close', () => this.prompt());
   }
-  reply(outboundMessageText) {
-    const prefix = this.options.replyPrefix.bold[this.replyColor];
-    const replyText = outboundMessageText[this.replyColor];
+  reply(outboundMessageText, color = this.replyColor) {
+    const prefix = this.options.replyPrefix.bold[color];
+    const replyText = outboundMessageText[color];
     Consolebot.print(prefix, replyText);
     this.prompt();
   }
+  handleError(res) {
+    const text = `An error occurred.\nstatus: ${res.status}\nmessage: ${res.response.body.message}`;
+    this.reply(text, 'red');
+  }
   handleSuccess(res) {
-    const messages = res.body.data.messages;
-    if (messages.outbound) {
-      return this.reply(messages.outbound[0].text);
-    }
-
-    return this.reply('');
+    const outboundMessages = res.body.data.messages.outbound;
+    const text = outboundMessages.length ? outboundMessages[0].text : '';
+    this.reply(text);
   }
   static print(prefix, messageText) {
     /* eslint-disable no-console */

--- a/lib/consolebot.js
+++ b/lib/consolebot.js
@@ -104,9 +104,9 @@ class Consolebot {
     Consolebot.print(prefix, replyText);
     this.prompt();
   }
-  handleError(error) {
-    const errorMessage = helpers.parseMessageFromError(error);
-    const text = `An error occurred.\nstatus: ${error.status}\nmessage: ${errorMessage}`;
+  handleError(err) {
+    const error = helpers.util.parseStatusAndMessageFromError(err);
+    const text = `An error occurred.\nstatus: ${error.status}\nmessage: ${error.message}`;
     this.reply(text, 'red');
   }
   handleSuccess(res) {

--- a/lib/consolebot.js
+++ b/lib/consolebot.js
@@ -7,6 +7,7 @@ const superagent = require('superagent');
 const underscore = require('underscore');
 const uuidv4 = require('uuid/v4');
 
+const helpers = require('./helpers');
 const defaultConfig = require('../config/lib/consolebot');
 
 const retryHeader = 'x-blink-retry-count';
@@ -103,8 +104,9 @@ class Consolebot {
     Consolebot.print(prefix, replyText);
     this.prompt();
   }
-  handleError(res) {
-    const text = `An error occurred.\nstatus: ${res.status}\nmessage: ${res.response.body.message}`;
+  handleError(error) {
+    const errorMessage = helpers.parseMessageFromError(error);
+    const text = `An error occurred.\nstatus: ${error.status}\nmessage: ${errorMessage}`;
     this.reply(text, 'red');
   }
   handleSuccess(res) {

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -5,7 +5,6 @@ const { STATUS_CODES } = require('http');
 const logger = require('./logger');
 const config = require('../config/lib/helpers');
 const helpers = require('./helpers/index');
-const InternalServerError = require('../app/exceptions/InternalServerError');
 
 // TODO: Move contents of this helper.js file into lib/helpers/index.js or to modular helpers
 
@@ -15,22 +14,6 @@ Object.keys(helpers).forEach((helperName) => {
 });
 
 /**
- * @param {Object|Error}
- * @return {String}
- */
-module.exports.parseMessageFromError = function (error) {
-  // Check for a response body with an error message.
-  if (error.response && error.response.body && error.response.body.error) {
-    return error.response.body.error.message;
-  }
-  // Check for a response body with a message.
-  if (error.response && error.response.body) {
-    return error.response.body.message;
-  }
-  return error.message ? error.message : error.toString();
-};
-
-/**
  * Sends response with err code and message.
  *
  * @param  {Object} res
@@ -38,8 +21,8 @@ module.exports.parseMessageFromError = function (error) {
  * @param  {Boolean} sendSuppressHeader
  */
 module.exports.sendErrorResponse = function (res, err, sendSuppressHeader = false) {
-  const error = err || new InternalServerError();
-  const status = error.status || 500;
+  const error = helpers.util.parseStatusAndMessageFromError(err);
+
   /**
    * If the error has a response and the response contain the Blink Suppress headers,
    * this error is being relayed to Blink from Campaigns through Conversations.
@@ -52,7 +35,7 @@ module.exports.sendErrorResponse = function (res, err, sendSuppressHeader = fals
     exports.addBlinkSuppressHeaders(res);
   }
 
-  return this.sendResponseWithStatusCode(res, status, module.exports.parseMessageFromError(error));
+  return this.sendResponseWithStatusCode(res, error.status, error.message);
 };
 
 module.exports.sendErrorResponseWithSuppressHeaders = function (res, err) {

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -23,9 +23,15 @@ Object.keys(helpers).forEach((helperName) => {
  */
 module.exports.sendErrorResponse = function (res, err, sendSuppressHeader = false) {
   const error = err || new InternalServerError();
-
   const status = error.status || 500;
-  const message = error.message || error.toString();
+  let message = error.message || error.toString();
+
+  if (err) {
+    const errRes = err.response;
+    if (errRes && errRes.body && errRes.body.error && errRes.body.error.message) {
+      message = errRes.body.error.message;
+    }
+  }
 
   /**
    * If the error has a response and the response contain the Blink Suppress headers,

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -24,13 +24,11 @@ Object.keys(helpers).forEach((helperName) => {
 module.exports.sendErrorResponse = function (res, err, sendSuppressHeader = false) {
   const error = err || new InternalServerError();
   const status = error.status || 500;
-  let message = error.message || error.toString();
-
-  if (err) {
-    const errRes = err.response;
-    if (errRes && errRes.body && errRes.body.error && errRes.body.error.message) {
-      message = errRes.body.error.message;
-    }
+  let message = error.toString();
+  if (error.response && err.response.body && err.response.body.error) {
+    message = error.response.body.error.message;
+  } else if (error.message) {
+    message = error.message;
   }
 
   /**

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -14,13 +14,16 @@ Object.keys(helpers).forEach((helperName) => {
   module.exports[helperName] = helpers[helperName];
 });
 
+/**
+ * @param {Object|Error}
+ * @return {String}
+ */
 module.exports.parseMessageFromError = function (error) {
-  // Check for a response with an error message.
+  // Check for a response body with an error message.
   if (error.response && error.response.body && error.response.body.error) {
     return error.response.body.error.message;
   }
-  // Check for a resonse with a message
-  // Check for a response with an error message.
+  // Check for a response body with a message.
   if (error.response && error.response.body) {
     return error.response.body.message;
   }

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -14,6 +14,19 @@ Object.keys(helpers).forEach((helperName) => {
   module.exports[helperName] = helpers[helperName];
 });
 
+module.exports.parseMessageFromError = function (error) {
+  // Check for a response with an error message.
+  if (error.response && error.response.body && error.response.body.error) {
+    return error.response.body.error.message;
+  }
+  // Check for a resonse with a message
+  // Check for a response with an error message.
+  if (error.response && error.response.body) {
+    return error.response.body.message;
+  }
+  return error.message ? error.message : error.toString();
+};
+
 /**
  * Sends response with err code and message.
  *
@@ -24,13 +37,6 @@ Object.keys(helpers).forEach((helperName) => {
 module.exports.sendErrorResponse = function (res, err, sendSuppressHeader = false) {
   const error = err || new InternalServerError();
   const status = error.status || 500;
-  let message = error.toString();
-  if (error.response && err.response.body && err.response.body.error) {
-    message = error.response.body.error.message;
-  } else if (error.message) {
-    message = error.message;
-  }
-
   /**
    * If the error has a response and the response contain the Blink Suppress headers,
    * this error is being relayed to Blink from Campaigns through Conversations.
@@ -43,7 +49,7 @@ module.exports.sendErrorResponse = function (res, err, sendSuppressHeader = fals
     exports.addBlinkSuppressHeaders(res);
   }
 
-  return this.sendResponseWithStatusCode(res, status, message);
+  return this.sendResponseWithStatusCode(res, status, module.exports.parseMessageFromError(error));
 };
 
 module.exports.sendErrorResponseWithSuppressHeaders = function (res, err) {

--- a/lib/helpers/replies.js
+++ b/lib/helpers/replies.js
@@ -116,11 +116,6 @@ module.exports.askSignup = function (req, res) {
   return exports.sendReplyWithTopicTemplate(req, res, 'askSignup');
 };
 
-/**
- * @param {Object} req
- * @param {Object} res
- * @return {Promise}
- */
 module.exports.autoReply = function (req, res) {
   return exports.sendReplyWithTopicTemplate(req, res, 'autoReply');
 };

--- a/lib/helpers/replies.js
+++ b/lib/helpers/replies.js
@@ -116,8 +116,19 @@ module.exports.askSignup = function (req, res) {
   return exports.sendReplyWithTopicTemplate(req, res, 'askSignup');
 };
 
+/**
+ * @param {Object} req
+ * @param {Object} res
+ * @return {Promise}
+ */
 module.exports.autoReply = function (req, res) {
-  return exports.sendReplyWithTopicTemplate(req, res, 'autoReply');
+  // If current topic has a campaign, post this inbound message as campaign activity, and reply with
+  // the topic's autoReply template.
+  const campaign = req.topic.campaign;
+  const promise = campaign ? helpers.request.postCampaignActivityFromReq(req) : Promise.resolve();
+  return promise
+    .then(() => exports.sendReplyWithTopicTemplate(req, res, 'autoReply'))
+    .catch(err => helpers.sendErrorResponse(res, err));
 };
 
 module.exports.campaignClosed = function (req, res) {

--- a/lib/helpers/replies.js
+++ b/lib/helpers/replies.js
@@ -122,13 +122,7 @@ module.exports.askSignup = function (req, res) {
  * @return {Promise}
  */
 module.exports.autoReply = function (req, res) {
-  // If current topic has a campaign, post this inbound message as campaign activity, and reply with
-  // the topic's autoReply template.
-  const campaign = req.topic.campaign;
-  const promise = campaign ? helpers.request.postCampaignActivityFromReq(req) : Promise.resolve();
-  return promise
-    .then(() => exports.sendReplyWithTopicTemplate(req, res, 'autoReply'))
-    .catch(err => helpers.sendErrorResponse(res, err));
+  return exports.sendReplyWithTopicTemplate(req, res, 'autoReply');
 };
 
 module.exports.campaignClosed = function (req, res) {

--- a/lib/helpers/util.js
+++ b/lib/helpers/util.js
@@ -5,9 +5,33 @@ const underscore = require('underscore');
 const Promise = require('bluebird');
 
 const logger = require('../logger');
+const InternalServerError = require('../../app/exceptions/InternalServerError');
 const UnprocessibleEntityError = require('../../app/exceptions/UnprocessibleEntityError');
 
 const phoneUtil = PhoneNumberUtil.getInstance();
+
+/**
+ * @param {Object|Error}
+ * @return {Object}
+ */
+function parseStatusAndMessageFromError(error = new InternalServerError()) {
+  const result = {
+    status: error.status || 500,
+  };
+  const hasResponseBody = error.response && error.response.body;
+  // Check for a response body for an error object.
+  if (hasResponseBody && error.response.body.error) {
+    result.message = error.response.body.error.message;
+    return result;
+  }
+  // Check for a response body for a message property.
+  if (hasResponseBody) {
+    result.message = error.response.body.message;
+    return result;
+  }
+  result.message = error.message ? error.message : error.toString();
+  return result;
+}
 
 module.exports = {
   /**
@@ -67,4 +91,5 @@ module.exports = {
     logger.debug('formatMobileNumber return', { result });
     return result;
   },
+  parseStatusAndMessageFromError,
 };

--- a/lib/middleware/messages/member/catchAll-autoReply.js
+++ b/lib/middleware/messages/member/catchAll-autoReply.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const helpers = require('../../../helpers');
+
+module.exports = function catchAllAutoReply() {
+  return async (req, res, next) => {
+    try {
+      if (!helpers.request.shouldSendAutoReply(req)) {
+        return next();
+      }
+
+      if (helpers.request.hasCampaign(req)) {
+        await helpers.request.postCampaignActivityFromReq(req);
+      }
+
+      return helpers.replies.autoReply(req, res);
+    } catch (err) {
+      return helpers.sendErrorResponse(res, err);
+    }
+  };
+};

--- a/lib/middleware/messages/member/catchAll.js
+++ b/lib/middleware/messages/member/catchAll.js
@@ -5,10 +5,6 @@ const logger = require('../../../logger');
 
 module.exports = function catchAllMacro() {
   return async (req, res) => {
-    if (helpers.request.shouldSendAutoReply(req)) {
-      return helpers.replies.autoReply(req, res);
-    }
-
     if (!helpers.request.hasCampaign(req)) {
       return helpers.replies.noCampaign(req, res);
     }

--- a/test/unit/lib/helpers.test.js
+++ b/test/unit/lib/helpers.test.js
@@ -8,7 +8,6 @@ const sinon = require('sinon');
 const sinonChai = require('sinon-chai');
 const httpMocks = require('node-mocks-http');
 
-const InternalServerError = require('../../../app/exceptions/InternalServerError');
 const UnprocessibleEntityError = require('../../../app/exceptions/UnprocessibleEntityError.js');
 
 chai.should();
@@ -31,44 +30,20 @@ test.afterEach(() => {
 // Tests
 
 // sendErrorResponse
-
-test('helpers.sendErrorResponse(res, anyString): should respond with error status 500 and anyString\'s value as message', () => {
-  const res = httpMocks.createResponse();
-  const errorString = 'omgError';
-  sandbox.stub(helpers, 'sendResponseWithStatusCode').returns(true);
-
-  helpers.sendErrorResponse(res, errorString);
-
-  const callArgs = helpers.sendResponseWithStatusCode.getCall(0).args;
-  helpers.sendResponseWithStatusCode.should.have.been.called;
-  callArgs[1].should.be.equal(500);
-  callArgs[2].should.be.equal(errorString);
-});
-
 test('helpers.sendErrorResponse(res, error): should respond with error status and error message', () => {
   const res = httpMocks.createResponse();
-  const genericError = new UnprocessibleEntityError();
+  const error = new UnprocessibleEntityError();
+  sandbox.stub(helpers.util, 'parseStatusAndMessageFromError')
+    .returns({ status: error.status, message: error.message });
   sandbox.stub(helpers, 'sendResponseWithStatusCode').returns(true);
 
-  helpers.sendErrorResponse(res, genericError);
+  helpers.sendErrorResponse(res, error);
 
   const callArgs = helpers.sendResponseWithStatusCode.getCall(0).args;
+  helpers.util.parseStatusAndMessageFromError.should.have.been.called;
   helpers.sendResponseWithStatusCode.should.have.been.called;
-  callArgs[1].should.be.equal(genericError.status);
-  callArgs[2].should.be.equal(genericError.message);
-});
-
-test('helpers.sendErrorResponse(res): not sending an error should use a Generic Internal Server Error response', () => {
-  const res = httpMocks.createResponse();
-  const genericError = new InternalServerError();
-  sandbox.stub(helpers, 'sendResponseWithStatusCode').returns(true);
-
-  helpers.sendErrorResponse(res);
-
-  const callArgs = helpers.sendResponseWithStatusCode.getCall(0).args;
-  helpers.sendResponseWithStatusCode.should.have.been.called;
-  callArgs[1].should.be.equal(genericError.status);
-  callArgs[2].should.be.equal(genericError.message);
+  callArgs[1].should.be.equal(error.status);
+  callArgs[2].should.be.equal(error.message);
 });
 
 // sendResponseWithStatusCode

--- a/test/unit/lib/lib-helpers/replies.test.js
+++ b/test/unit/lib/lib-helpers/replies.test.js
@@ -175,7 +175,7 @@ test('sendReply(): should call sendErrorResponse on failure', async (t) => {
 });
 
 test('autoReply(): should call sendReplyWithTopicTemplate', async (t) => {
-  const template = templates.autoReply;
+  const template = templates.gambitCampaignsTemplates.autoReply;
   await assertSendingReplyWithTopicTemplate(t.context.req, t.context.res, template);
 });
 

--- a/test/unit/lib/lib-helpers/replies.test.js
+++ b/test/unit/lib/lib-helpers/replies.test.js
@@ -17,6 +17,7 @@ const Message = require('../../../../app/models/Message');
 const campaignFactory = require('../../../helpers/factories/campaign');
 const conversationFactory = require('../../../helpers/factories/conversation');
 const messageFactory = require('../../../helpers/factories/message');
+const topicFactory = require('../../../helpers/factories/topic');
 
 // setup "x.should.y" assertion style
 chai.should();
@@ -215,6 +216,57 @@ test('askSignup(): should call sendReplyWithTopicTemplate', async (t) => {
   await assertSendingReplyWithTopicTemplate(t.context.req, t.context.res, template);
 });
 
+// autoReply
+test('autoReply should call postCampaignActivityFromReq if topic has a campaign', async (t) => {
+  t.context.req.topic = topicFactory.getValidTextPostConfig();
+  sandbox.stub(helpers.request, 'postCampaignActivityFromReq')
+    .returns(Promise.resolve(gCampResponse.data));
+  sandbox.stub(repliesHelper, 'sendReplyWithTopicTemplate')
+    .returns(true);
+
+  await repliesHelper.autoReply(t.context.req, t.context.res);
+  helpers.request.postCampaignActivityFromReq.should.have.been.called;
+  repliesHelper.sendReplyWithTopicTemplate.should.have.been.called;
+});
+
+test('autoReply does not call postCampaignActivityFromReq if topic does not have campaign', async (t) => {
+  t.context.req.topic = topicFactory.getValidTopicWithoutCampaign();
+  sandbox.stub(helpers.request, 'postCampaignActivityFromReq')
+    .returns(Promise.resolve(gCampResponse.data));
+  sandbox.stub(repliesHelper, 'sendReplyWithTopicTemplate')
+    .returns(true);
+
+  await repliesHelper.autoReply(t.context.req, t.context.res);
+  helpers.request.postCampaignActivityFromReq.should.not.have.been.called;
+  repliesHelper.sendReplyWithTopicTemplate.should.have.been.called;
+});
+
+test('autoReply calls sendErrorResponse if postCampaignActivityFromReq fails', async (t) => {
+  t.context.req.topic = topicFactory.getValidTextPostConfig();
+  const mockError = { message: 'oh no' };
+  sandbox.stub(helpers.request, 'postCampaignActivityFromReq')
+    .returns(Promise.reject(mockError));
+  sandbox.stub(repliesHelper, 'sendReplyWithTopicTemplate')
+    .returns(true);
+
+  await repliesHelper.autoReply(t.context.req, t.context.res);
+  repliesHelper.sendReplyWithTopicTemplate.should.not.have.been.called;
+  helpers.sendErrorResponse.should.have.been.calledWith(t.context.res, mockError);
+});
+
+test('autoReply calls sendErrorResponse if sendReplyWithTopicTemplate fails', async (t) => {
+  t.context.req.topic = topicFactory.getValidTopicWithoutCampaign();
+  const mockError = { message: 'oh no' };
+  sandbox.stub(helpers.request, 'postCampaignActivityFromReq')
+    .returns(Promise.resolve(gCampResponse.data));
+  sandbox.stub(repliesHelper, 'sendReplyWithTopicTemplate')
+    .throws(mockError);
+
+  await repliesHelper.autoReply(t.context.req, t.context.res);
+  helpers.sendErrorResponse.should.have.been.calledWith(t.context.res, mockError);
+});
+
+// campaignClosed
 test('campaignClosed(): should call sendReplyWithTopicTemplate', async (t) => {
   const template = templates.campaignClosed;
   await assertSendingReplyWithTopicTemplate(t.context.req, t.context.res, template);

--- a/test/unit/lib/middleware/messages/member/catchAll-autoReply.test.js
+++ b/test/unit/lib/middleware/messages/member/catchAll-autoReply.test.js
@@ -1,0 +1,131 @@
+'use strict';
+
+require('dotenv').config();
+
+const test = require('ava');
+const chai = require('chai');
+const sinon = require('sinon');
+const sinonChai = require('sinon-chai');
+const httpMocks = require('node-mocks-http');
+const underscore = require('underscore');
+
+const helpers = require('../../../../../../lib/helpers');
+const topicFactory = require('../../../../../helpers/factories/topic');
+
+chai.should();
+chai.use(sinonChai);
+
+// module to be tested
+const autoReplyCatchAll = require('../../../../../../lib/middleware/messages/member/catchAll-autoReply');
+
+const sandbox = sinon.sandbox.create();
+
+test.beforeEach((t) => {
+  sandbox.stub(helpers, 'sendErrorResponse')
+    .returns(underscore.noop);
+  t.context.req = httpMocks.createRequest();
+  t.context.res = httpMocks.createResponse();
+});
+
+test.afterEach((t) => {
+  sandbox.restore();
+  t.context = {};
+});
+
+test('autoReplyCatchAll should call replies.autoReply if request.shouldSendAutoReply is false', async (t) => {
+  const next = sinon.stub();
+  const middleware = autoReplyCatchAll();
+  sandbox.stub(helpers.request, 'shouldSendAutoReply')
+    .returns(false);
+  sandbox.stub(helpers.replies, 'autoReply')
+    .returns(underscore.noop);
+
+  // test
+  await middleware(t.context.req, t.context.res, next);
+
+  helpers.request.shouldSendAutoReply.should.have.been.calledWith(t.context.req);
+  next.should.have.been.called;
+  helpers.replies.autoReply.should.not.have.been.called;
+});
+
+test('autoReplyCatchAll should call postCampaignActivityFromReq if shouldSendAutoReply and hasCampaign', async (t) => {
+  const next = sinon.stub();
+  const middleware = autoReplyCatchAll();
+  t.context.req.topic = topicFactory.getValidTextPostConfig();
+  sandbox.stub(helpers.request, 'shouldSendAutoReply')
+    .returns(true);
+  sandbox.stub(helpers.request, 'hasCampaign')
+    .returns(true);
+  sandbox.stub(helpers.request, 'postCampaignActivityFromReq')
+    .returns(Promise.resolve());
+  sandbox.stub(helpers.replies, 'sendReplyWithTopicTemplate')
+    .returns(underscore.noop);
+
+  // test
+  await middleware(t.context.req, t.context.res, next);
+
+  helpers.request.postCampaignActivityFromReq.should.have.been.called;
+  helpers.replies.sendReplyWithTopicTemplate.should.have.been.called;
+  helpers.sendErrorResponse.should.not.have.been.called;
+});
+
+test('autoReplyCatchAll does not call postCampaignActivityFromReq if shouldSendAutoReply and topic does not have campaign', async (t) => {
+  const next = sinon.stub();
+  const middleware = autoReplyCatchAll();
+  t.context.req.topic = topicFactory.getValidTopicWithoutCampaign();
+  sandbox.stub(helpers.request, 'shouldSendAutoReply')
+    .returns(true);
+  sandbox.stub(helpers.request, 'hasCampaign')
+    .returns(false);
+  sandbox.stub(helpers.request, 'postCampaignActivityFromReq')
+    .returns(Promise.resolve());
+  sandbox.stub(helpers.replies, 'sendReplyWithTopicTemplate')
+    .returns(underscore.noop);
+
+  // test
+  await middleware(t.context.req, t.context.res, next);
+
+  helpers.request.postCampaignActivityFromReq.should.not.have.been.called;
+  helpers.replies.sendReplyWithTopicTemplate.should.have.been.called;
+});
+
+test('autoReplyCatchAll calls sendErrorResponse if postCampaignActivityFromReq fails', async (t) => {
+  const next = sinon.stub();
+  const middleware = autoReplyCatchAll();
+  t.context.req.topic = topicFactory.getValidTextPostConfig();
+  sandbox.stub(helpers.request, 'shouldSendAutoReply')
+    .returns(true);
+  sandbox.stub(helpers.request, 'hasCampaign')
+    .returns(true);
+  const mockError = { message: 'oh no' };
+  sandbox.stub(helpers.request, 'postCampaignActivityFromReq')
+    .returns(Promise.reject(mockError));
+  sandbox.stub(helpers.replies, 'sendReplyWithTopicTemplate')
+    .returns(true);
+
+  // test
+  await middleware(t.context.req, t.context.res, next);
+
+  helpers.replies.sendReplyWithTopicTemplate.should.not.have.been.called;
+  helpers.sendErrorResponse.should.have.been.calledWith(t.context.res, mockError);
+});
+
+test('autoReplyCatchAll calls sendErrorResponse if sendReplyWithTopicTemplate fails', async (t) => {
+  const next = sinon.stub();
+  const middleware = autoReplyCatchAll();
+  t.context.req.topic = topicFactory.getValidTopicWithoutCampaign();
+  sandbox.stub(helpers.request, 'shouldSendAutoReply')
+    .returns(true);
+  sandbox.stub(helpers.request, 'hasCampaign')
+    .returns(true);
+  const mockError = { message: 'oh no' };
+  sandbox.stub(helpers.request, 'postCampaignActivityFromReq')
+    .returns(Promise.resolve());
+  sandbox.stub(helpers.replies, 'sendReplyWithTopicTemplate')
+    .throws(mockError);
+
+  // test
+  await middleware(t.context.req, t.context.res, next);
+
+  helpers.sendErrorResponse.should.have.been.calledWith(t.context.res, mockError);
+});

--- a/test/unit/lib/middleware/messages/member/catchAll.test.js
+++ b/test/unit/lib/middleware/messages/member/catchAll.test.js
@@ -16,7 +16,7 @@ chai.should();
 chai.use(sinonChai);
 
 // module to be tested
-const catchAllMacro = require('../../../../../../lib/middleware/messages/member/macro-catch-all');
+const catchAllMacro = require('../../../../../../lib/middleware/messages/member/catchAll');
 
 const sandbox = sinon.sandbox.create();
 
@@ -42,22 +42,6 @@ test.beforeEach((t) => {
 test.afterEach((t) => {
   sandbox.restore();
   t.context = {};
-});
-
-test('catchAllMacro should call replies.autoReply if request.shouldSendAutoReply', async (t) => {
-  const next = sinon.stub();
-  const middleware = catchAllMacro();
-  sandbox.stub(helpers.request, 'shouldSendAutoReply')
-    .returns(true);
-  sandbox.stub(helpers.replies, 'autoReply')
-    .returns(underscore.noop);
-
-  // test
-  await middleware(t.context.req, t.context.res, next);
-
-  helpers.request.shouldSendAutoReply.should.have.been.calledWith(t.context.req);
-  next.should.not.have.been.called;
-  helpers.replies.autoReply.should.have.been.calledWith(t.context.req, t.context.res);
 });
 
 test('catchAllMacro should call replies.noCampaign if not request.hasCampaign', async (t) => {


### PR DESCRIPTION
#### What's this PR do?
If a user sends a message while in an `autoReply` topic that has a campaign set, post it to the gambit-campaigns `campaignActivity` endpoint to create a signup. This starts on deprecating the need for the `externalPostConfig` (but isn't ready to deprecate until we add entry/welcome messages for web signups or keywords that would change the conversation topic to the autoReply.

#### How should this be reviewed?
On staging, broadcast 6zj3wladnGyWuMWAUYyg8c will change a user's topic to an autoReply topic with a campaign set (2Wzzquygx2wwMWe8kQAMgc). Verify upon entering the topic, a signup is posted for the campaign (2299)

#### Relevant tickets
https://www.pivotaltracker.com/story/show/157369418

#### Checklist
- [ ] Tests added for new features/bug fixes.
- [ ] Tested on staging.
