### PR TITLE
Updates askSubscriptionStatus templates

### DIFF
--- a/brain/topics.rive
+++ b/brain/topics.rive
@@ -1,4 +1,5 @@
 // topics.rive
+// TODO: Move each of these topics into separate files in /brain/topics
 
 // Unsubcribed users should only receive replies to a select few triggers.
 > topic unsubscribed
@@ -47,42 +48,11 @@
  * (which is hardcoded as the 'random' topic in Rivescript).
  */
 
-// Asks user to update their subscription status.
-+ status
-- Hi it's Freddie at DoSomething! I send texts w updates on news & easy ways to take action. Want texts: A)Weekly B)Monthly C)I need more info D)Text STOP to stop {topic=ask_subscription_status}
-
-> topic ask_subscription_status includes random
-
-+ a
-- subscriptionStatusActive{topic=random}
-
-+ b
-- subscriptionStatusLess{topic=random}
-
-+ c [*]
-- Sure! Maybe it's been a while since you signed up for DoSomething.org texts, so I'll give you the run down of what these texts are all about. Once a week, I text over 3 million young people with updates on what's happening in the news and/or easy ways to take action in your community.\n\nWant an example of the news we share? Take 2 mins to catch up on what's happening in the news this week and learn what you can do about it https://www.dosomething.org/us/family-separations-us-border?user_id={{user.id}},broadcastsource=info
-
-+ d [*]
-- subscriptionStatusStop{topic=unsubscribed}
-
-+ [*] more [*]
-@ c
-
-+ [*]
-- Whoops, I'm sorry I didn't get that - do you want A) Weekly B) Monthly C) Need More Info D) STOP
-
-< topic
-
 // The survey_response topic is commonly used by broadcast entries. This will eventually be
 // deprecated by a content type like an AutoReplyBroadcast that sends a generic auto reply message
 // and changes conversation topic back to random so user gets prompted to continue a campaign.
 
-// NOTE: We're currently survey_response follow up broadcasts to users in askSubscriptionStatus, so
-// we'll duplicate the D unsuscribe trigger for now.
 > topic survey_response includes random
-
-+ d [*]
-- subscriptionStatusStop{topic=unsubscribed}
 
 + [*]
 - I'm sorry I didn't understand that! Text Q if you have a question.{topic=random}

--- a/brain/topics/askSubscriptionStatus.rive
+++ b/brain/topics/askSubscriptionStatus.rive
@@ -15,7 +15,7 @@
 - subscriptionStatusLess{topic=random}
 
 + c [*]
-- Sure! Maybe it's been a while since you signed up for DoSomething.org texts, so I'll give you the run down of what these texts are all about. Once a week, I text over 3 million young people with updates on what's happening in the news and/or easy ways to take action in your community.\n\nWant an example of an easy way to take action? Take 2 mins to learn how to spot the signs of an abusive relationship and what you can do about it: https://www.dosomething.org/us/spot-the-signs-guide?user_id={{user.id}}
+- Sure! Once a week, I text over 3 million young people with updates on what's happening in the news and/or easy ways to take action in your community.\n\nWant an example of an easy way to take action? Take 2 mins to learn how to spot the signs of an abusive relationship and what you can do about it. Read our guide: https://www.dosomething.org/us/spot-the-signs-guide?source=sms&utm_source=dosomething&utm_medium=sms&utm_campaign=permissioning_moreinfo&user_id={{user.id}}
 
 + [*] more [*]
 @ c

--- a/brain/topics/askSubscriptionStatus.rive
+++ b/brain/topics/askSubscriptionStatus.rive
@@ -1,0 +1,26 @@
+/** 
+ * Asks user to update their subscription status.
+ */
+
++ status
+- Hi it's Freddie at DoSomething! I send texts w updates on news & easy ways to take action. Want texts: A)Weekly B)Monthly C)I need more info D)Text STOP to stop {topic=ask_subscription_status}
+
+// Includes 'random' to catch all triggers defined in the default topic
+> topic ask_subscription_status includes random
+
++ a
+- subscriptionStatusActive{topic=random}
+
++ b
+- subscriptionStatusLess{topic=random}
+
++ c [*]
+- Sure! Maybe it's been a while since you signed up for DoSomething.org texts, so I'll give you the run down of what these texts are all about. Once a week, I text over 3 million young people with updates on what's happening in the news and/or easy ways to take action in your community.\n\nWant an example of an easy way to take action? Take 2 mins to learn how to spot the signs of an abusive relationship and what you can do about it: https://www.dosomething.org/us/spot-the-signs-guide?user_id={{user.id}}
+
++ [*] more [*]
+@ c
+
++ [*]
+- Whoops, I'm sorry I didn't get that - do you want A) Weekly B) Monthly C) Need More Info
+
+< topic

--- a/config/lib/helpers/template.js
+++ b/config/lib/helpers/template.js
@@ -5,8 +5,8 @@ const underscore = require('underscore');
 const activeStatusText = 'Hi I\'m Freddie from DoSomething.org! Welcome to my weekly updates (up to 8msg/month). Things to know: Msg&DataRatesApply. Text HELP for help, text STOP to stop.';
 const helpCenterUrl = 'http://doso.me/1jf4/291kep';
 // Note: This url may also appear in hardcoded askSubscriptionStatus topic.
-// @see brain/topics.rive
-const newsUrl = 'https://www.dosomething.org/us/family-separations-us-border';
+// @see brain/topics/askSubscriptionStatus.rive
+const newsUrl = 'https://www.dosomething.org/us/spot-the-signs-guide?user_id={{user.id}}';
 // TODO: DRY menuCommand definition.
 // @see lib/helpers.js
 const menuCommand = 'menu';
@@ -75,11 +75,11 @@ const templatesMap = {
     },
     subscriptionStatusActive: {
       name: 'subscriptionStatusActive',
-      text: activeStatusText,
+      text: `${activeStatusText}\n\nI'll text you again next week, but in the meantime do you wanna take 2 mins to learn how to spot the signs of an abusive relationship and what you can do about it? ${newsUrl}`,
     },
     subscriptionStatusLess: {
       name: 'subscriptionStatusLess',
-      text: `Okay, great! I'll text you once a month with updates on what's happening in the news and/or easy ways for you to take action in your community! Wanna take 2 mins to catch up on what's happening in the news this week and what you can do about it? ${newsUrl}?user_id={{user.id}},broadcastsource=monthly`,
+      text: `Okay, great! I'll text you once a month with updates on what's happening in the news and/or easy ways for you to take action in your community! Wanna take 2 mins to learn how to spot the signs of an abusive relationship and what you can do about it? ${newsUrl}`,
     },
     subscriptionStatusResubscribed: {
       name: 'subscriptionStatusResubscribed',

--- a/config/lib/helpers/template.js
+++ b/config/lib/helpers/template.js
@@ -6,7 +6,7 @@ const activeStatusText = 'Hi I\'m Freddie from DoSomething.org! Welcome to my we
 const helpCenterUrl = 'http://doso.me/1jf4/291kep';
 // Note: This url may also appear in hardcoded askSubscriptionStatus topic.
 // @see brain/topics/askSubscriptionStatus.rive
-const newsUrl = 'https://www.dosomething.org/us/spot-the-signs-guide?user_id={{user.id}}';
+const newsUrl = 'https://www.dosomething.org/us/spot-the-signs-guide?source=sms&utm_source=dosomething&utm_medium=sms&utm_campaign=permissioning_weekly&user_id={{user.id}}';
 // TODO: DRY menuCommand definition.
 // @see lib/helpers.js
 const menuCommand = 'menu';
@@ -75,11 +75,11 @@ const templatesMap = {
     },
     subscriptionStatusActive: {
       name: 'subscriptionStatusActive',
-      text: `${activeStatusText}\n\nI'll text you again next week, but in the meantime do you wanna take 2 mins to learn how to spot the signs of an abusive relationship and what you can do about it? ${newsUrl}`,
+      text: `${activeStatusText}\n\nOkay, great! I'll text you once a week with updates on what's happening in the news and/or easy ways for you to take action in your community! Wanna take 2 mins to learn how to spot the signs of an abusive relationship and what you can do about it? Read our guide here: ${newsUrl}`,
     },
     subscriptionStatusLess: {
       name: 'subscriptionStatusLess',
-      text: `Okay, great! I'll text you once a month with updates on what's happening in the news and/or easy ways for you to take action in your community! Wanna take 2 mins to learn how to spot the signs of an abusive relationship and what you can do about it? ${newsUrl}`,
+      text: `Okay, great! I'll text you once a month with updates on what's happening in the news and/or easy ways for you to take action in your community! Wanna take 2 mins to learn how to spot the signs of an abusive relationship and what you can do about it? Read our guide here: ${newsUrl}`,
     },
     subscriptionStatusResubscribed: {
       name: 'subscriptionStatusResubscribed',

--- a/config/lib/helpers/template.js
+++ b/config/lib/helpers/template.js
@@ -75,7 +75,7 @@ const templatesMap = {
     },
     subscriptionStatusActive: {
       name: 'subscriptionStatusActive',
-      text: `${activeStatusText}\n\nOkay, great! I'll text you once a week with updates on what's happening in the news and/or easy ways for you to take action in your community! Wanna take 2 mins to learn how to spot the signs of an abusive relationship and what you can do about it? Read our guide here: ${newsUrl}`,
+      text: `Okay, great! I'll text you once a week with updates on what's happening in the news and/or easy ways for you to take action in your community! Wanna take 2 mins to learn how to spot the signs of an abusive relationship and what you can do about it? Read our guide here: ${newsUrl}`,
     },
     subscriptionStatusLess: {
       name: 'subscriptionStatusLess',

--- a/test/integration/app/v2-routes/messages-subscription-status-active.test.js
+++ b/test/integration/app/v2-routes/messages-subscription-status-active.test.js
@@ -4,7 +4,7 @@ const test = require('ava');
 const chai = require('chai');
 const nock = require('nock');
 
-
+const tagsHelper = require('../../../../lib/helpers/tags');
 const templatesHelper = require('../../../../lib/helpers/template');
 const integrationHelper = require('../../../helpers/integration');
 const Message = require('../../../../app/models/Message');
@@ -77,7 +77,8 @@ test.serial('POST /api/v2/messages?origin=subscriptionStatusActive should create
   const outboundMessage = await Message.findOne({ conversationId: conversation.id });
   should.exist(outboundMessage);
   outboundMessage.template.should.be.equal(subscriptionStatusActiveData.name);
-  outboundMessage.text.should.be.equal(subscriptionStatusActiveData.text);
+  const renderedText = tagsHelper.render(subscriptionStatusActiveData.text, { user: user.data });
+  outboundMessage.text.should.be.equal(renderedText);
 });
 
 test.serial('POST /api/v2/messages?origin=subscriptionStatusActive should not create a new convo if the user has one already', async (t) => {
@@ -108,7 +109,8 @@ test.serial('POST /api/v2/messages?origin=subscriptionStatusActive should not cr
   messages.length.should.be.equal(1);
   const message = messages[0];
   message.template.should.be.equal(subscriptionStatusActiveData.name);
-  message.text.should.be.equal(subscriptionStatusActiveData.text);
+  const renderedText = tagsHelper.render(subscriptionStatusActiveData.text, { user: user.data });
+  message.text.should.be.equal(renderedText);
 });
 
 test.serial('POST /api/v2/messages?origin=subscriptionStatusActive should not create convo if the user has no mobile', async (t) => {


### PR DESCRIPTION
#### What's this PR do?

Updates the Rivescript in the `ask_subscription_status` topic per https://dosomething.slack.com/archives/C2C8NLNAY/p1534264417000100?thread_ts=1534263735.000100&cid=C2C8NLNAY. 

* Starts on a `brain/topics` dir to make it easier to view changes per topic (will move the rest in a future PR)
* Removes the `d [*]` trigger option to unsubscribe

#### How should this be reviewed?
Text `status` or send yourself an [askSubscriptionStatus broadcast](https://gambit-admin.herokuapp.com/broadcasts/58QNVt7wJiyu2YeeAaemgS), e.g. `58QNVt7wJiyu2YeeAaemgS` to verify expected behavior.

#### Any background context you want to provide?
We can get away with setting our `subscriptionStatusActive` template copy to the reply for now because we don't have any webhooks posting to the `POST /messages?origin=subscriptionStatusActive` endpoint.... but we should eventually revisit how this works we can separate replies in an `askSubscriptionStatus` broadcast from our welcome compliance messaging (refs https://www.pivotaltracker.com/story/show/158460231)

Ideally the `askSubscriptionStatus` content type will follow the same approach as our `askYesNo` content type: we'll add different text fields for templates/macros like `saidActive`, `saidLess`, needsMoreInfo`, etc. (https://www.pivotaltracker.com/story/show/159634690)

#### Relevant tickets
Fixes https://www.pivotaltracker.com/story/show/159571877

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [x] Tests added for new features/bug fixes.
- [x] Tested on staging.
