### PR TITLE
Hotfix broken stats on askYesNo broadcasts

### DIFF
--- a/lib/helpers/broadcast.js
+++ b/lib/helpers/broadcast.js
@@ -76,6 +76,10 @@ function formatStats(data) {
   const result = {
     outbound: {
       total: 0,
+      // TODO: This is a hotfix to unbreak stats specifically for askYesNo broadcasts, to avoid a
+      // Cannot set property 'saidYes' of undefined error below when calculating counts per
+      // direction. We should adjust the logic when calculating the stats for askYesNo types.
+      macros: {},
     },
     inbound: {
       total: 0,

--- a/test/helpers/stubs.js
+++ b/test/helpers/stubs.js
@@ -141,6 +141,7 @@ module.exports = {
     return {
       outbound: {
         total: empty ? 0 : totalOutbound,
+        macros: empty ? {} : macros,
       },
       inbound: {
         total: empty ? 0 : totalInbound,


### PR DESCRIPTION
#### What's this PR do?

Avoids an internal server error when executing a `GET /broadcasts`  request for an `askYesNo`, which occurs when adding up the counts of macros per direction. Need to revisit when we're saving the `broadcastId` to the message (which is convenient as we're not scheduled to send any of these next week)

#### How should this be reviewed?
Verify https://gambit-admin-staging.herokuapp.com/broadcasts/2X4r3fZrTGA2mGemowgiEI works. The reason this broadcast doesn't break in Gambit Admin production is because we don't have any stats to calculate -- it's never been sent on production.

#### Any background context you want to provide?
Ideally we can scrap these stats completely once Looker is 📊 

#### Relevant tickets
https://github.com/DoSomething/gambit-conversations/pull/382

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.
