### PR TITLE
Refactors postCampaignActivity request helper to accept a broadcastId param

### DIFF
--- a/lib/helpers/replies.js
+++ b/lib/helpers/replies.js
@@ -100,9 +100,9 @@ module.exports.continueTopic = function (req, res) {
     return module.exports.campaignClosed(req, res);
   }
 
-  return helpers.request.postCampaignActivityFromReq(req)
+  return helpers.request.postCampaignActivity(req)
     .then((gambitCampaignsRes) => {
-      logger.debug('postCampaignActivityFromReq success', gambitCampaignsRes, req);
+      logger.debug('postCampaignActivity success', gambitCampaignsRes, req);
       return exports.sendReplyWithTopicTemplate(req, res, gambitCampaignsRes.replyTemplate);
     })
     .catch(err => helpers.sendErrorResponse(res, err));

--- a/lib/helpers/request.js
+++ b/lib/helpers/request.js
@@ -94,6 +94,7 @@ async function executeSaidNoMacro(req, res) {
  * @return {Promise}
  */
 async function executeSaidYesMacro(req, res) {
+  const broadcastId = req.topic.id;
   const saidYesTemplate = req.topic.templates.saidYes;
   // Although saidYesTopic is a required field, check that an id exists (it may not if this is a
   // draft entry and we're using the Preview API.
@@ -105,10 +106,7 @@ async function executeSaidYesMacro(req, res) {
 
   // If our new topic contains a campaign, post activity to create a signup.
   if (module.exports.hasCampaign(req)) {
-    const data = module.exports.getCampaignActivityPayloadFromReq(req);
-    data.broadcastId = req.topic.id;
-    logger.debug('posting campaignActivity', { data });
-    await gambitCampaigns.postCampaignActivity(data);
+    await module.exports.postCampaignActivity(req, broadcastId);
   }
 
   return helpers.replies.saidYes(req, res, saidYesTemplate.text);
@@ -116,9 +114,10 @@ async function executeSaidYesMacro(req, res) {
 
 /**
  * @param {Object} req
+ * @param {String} broadcastId
  * @return {Object}
  */
-function getCampaignActivityPayloadFromReq(req) {
+function getCampaignActivityPayload(req, broadcastId = null) {
   const data = {
     userId: req.userId,
     campaignId: req.campaign.id,
@@ -127,10 +126,12 @@ function getCampaignActivityPayloadFromReq(req) {
     text: req.inboundMessageText,
     mediaUrl: req.mediaUrl,
     platform: req.platform,
+    broadcastId: broadcastId || req.broadcastId,
   };
   if (req.keyword) {
     data.keyword = req.keyword.toLowerCase();
   }
+  logger.debug('getCampaignActivityPayload', { data });
 
   return data;
 }
@@ -239,11 +240,12 @@ async function parseAskYesNoResponse(req) {
 
 /**
  * @param {Object} req
+ * @param {String} broadcastId
  * @return {Promise}
  */
-function postCampaignActivityFromReq(req) {
+function postCampaignActivity(req, broadcastId = null) {
   return gambitCampaigns
-    .postCampaignActivity(module.exports.getCampaignActivityPayloadFromReq(req));
+    .postCampaignActivity(module.exports.getCampaignActivityPayload(req, broadcastId));
 }
 
 /**
@@ -328,7 +330,7 @@ module.exports = {
   executeChangeTopicMacro,
   executeSaidNoMacro,
   executeSaidYesMacro,
-  getCampaignActivityPayloadFromReq,
+  getCampaignActivityPayload,
   getRivescriptReply,
   getUserIdParamFromReq,
   hasCampaign,
@@ -344,7 +346,7 @@ module.exports = {
     return req.query.origin === 'twilio';
   },
   parseAskYesNoResponse,
-  postCampaignActivityFromReq,
+  postCampaignActivity,
   setBroadcastId: function setBroadcastId(req, broadcastId) {
     req.broadcastId = broadcastId;
     analytics.addCustomAttributes({ broadcastId });

--- a/lib/helpers/request.js
+++ b/lib/helpers/request.js
@@ -126,7 +126,7 @@ function getCampaignActivityPayload(req, broadcastId = null) {
     text: req.inboundMessageText,
     mediaUrl: req.mediaUrl,
     platform: req.platform,
-    broadcastId: broadcastId || req.broadcastId,
+    broadcastId: broadcastId || req.lastOutboundBroadcastId,
   };
   if (req.keyword) {
     data.keyword = req.keyword.toLowerCase();

--- a/lib/middleware/messages/member/catchAll-autoReply.js
+++ b/lib/middleware/messages/member/catchAll-autoReply.js
@@ -10,7 +10,7 @@ module.exports = function catchAllAutoReply() {
       }
 
       if (helpers.request.hasCampaign(req)) {
-        await helpers.request.postCampaignActivityFromReq(req);
+        await helpers.request.postCampaignActivity(req);
       }
 
       return helpers.replies.autoReply(req, res);

--- a/test/unit/lib/lib-helpers/replies.test.js
+++ b/test/unit/lib/lib-helpers/replies.test.js
@@ -180,7 +180,7 @@ test('autoReply(): should call sendReplyWithTopicTemplate', async (t) => {
 });
 
 test('continueTopic(): sendReplyWithTopicTemplate should be called', async (t) => {
-  sandbox.stub(helpers.request, 'postCampaignActivityFromReq')
+  sandbox.stub(helpers.request, 'postCampaignActivity')
     .returns(Promise.resolve(gCampResponse.data));
   sandbox.stub(repliesHelper, 'sendReplyWithTopicTemplate')
     .returns(resolvedPromise);
@@ -190,7 +190,7 @@ test('continueTopic(): sendReplyWithTopicTemplate should be called', async (t) =
 });
 
 test('continueTopic(): helpers.sendErrorResponse should be called if postCampaignActivity fails', async (t) => {
-  sandbox.stub(helpers.request, 'postCampaignActivityFromReq')
+  sandbox.stub(helpers.request, 'postCampaignActivity')
     .returns(Promise.reject(gCampResponse.data));
   sandbox.stub(repliesHelper, 'sendReplyWithTopicTemplate')
     .returns(resolvedPromise);

--- a/test/unit/lib/lib-helpers/request.test.js
+++ b/test/unit/lib/lib-helpers/request.test.js
@@ -226,7 +226,7 @@ test('executeSaidYesMacro should not post campaign activity if new topic does no
 // getCampaignActivityPayload
 test('getCampaignActivityPayload returns object with properties from req', (t) => {
   t.context.req.userId = userId;
-  t.context.req.broadcastId = stubs.getContentfulId();
+  t.context.req.lastOutboundBroadcastId = stubs.getContentfulId();
   t.context.req.campaign = campaignFactory.getValidCampaign();
   t.context.req.topic = topicFactory.getValidTopic();
   t.context.req.inboundMessageText = stubs.getRandomMessageText();
@@ -241,7 +241,7 @@ test('getCampaignActivityPayload returns object with properties from req', (t) =
   result.mediaUrl.should.equal(t.context.req.mediaUrl);
   result.postType.should.equal(t.context.req.topic.postType);
   result.platform.should.equal(t.context.req.platform);
-  result.broadcastId.should.equal(t.context.req.broadcastId);
+  result.broadcastId.should.equal(t.context.req.lastOutboundBroadcastId);
   result.should.not.have.property('keyword');
 });
 

--- a/test/unit/lib/lib-helpers/request.test.js
+++ b/test/unit/lib/lib-helpers/request.test.js
@@ -185,20 +185,20 @@ test('executeSaidYesMacro should call post campaign activity if new topic has ca
   const askYesNo = broadcastFactory.getValidAskYesNo();
   const saidYesTemplate = askYesNo.templates.saidYes;
   t.context.req.topic = askYesNo;
-  sandbox.stub(requestHelper, 'getCampaignActivityPayloadFromReq')
+  sandbox.stub(requestHelper, 'getCampaignActivityPayload')
     .returns({});
   sandbox.stub(requestHelper, 'changeTopic')
     .returns(Promise.resolve(true));
   sandbox.stub(requestHelper, 'hasCampaign')
     .returns(true);
-  sandbox.stub(gambitCampaigns, 'postCampaignActivity')
+  sandbox.stub(requestHelper, 'postCampaignActivity')
     .returns(Promise.resolve());
   sandbox.stub(helpers.replies, 'sendReply')
     .returns(underscore.noop);
 
   await requestHelper.executeSaidYesMacro(t.context.req);
   requestHelper.changeTopic.should.have.been.calledWith(t.context.req, saidYesTemplate.topic);
-  gambitCampaigns.postCampaignActivity.should.have.been.calledWith({ broadcastId: askYesNo.id });
+  requestHelper.postCampaignActivity.should.have.been.calledWith(t.context.req, askYesNo.id);
   helpers.replies.sendReply
     .should.have.been.calledWith(t.context.req, t.context.res, saidYesTemplate.text, 'saidYes');
 });
@@ -392,16 +392,16 @@ test('parseAskYesNoResponse does not update macro if parseAskYesNoResponse does 
   message.updateMacro.should.not.have.been.called;
 });
 
-// postCampaignActivityFromReq
-test('postCampaignActivityFromReq should post getCampaignActivityPayloadFromReq as campaignActivity', async () => {
+// postCampaignActivity
+test('postCampaignActivity should post getCampaignActivityPayload as campaignActivity', async () => {
   const postData = { text: stubs.getRandomMessageText() };
   const postResult = { data: 123 };
-  sandbox.stub(requestHelper, 'getCampaignActivityPayloadFromReq')
+  sandbox.stub(requestHelper, 'getCampaignActivityPayload')
     .returns(postData);
   sandbox.stub(gambitCampaigns, 'postCampaignActivity')
     .returns(Promise.resolve(postResult));
 
-  const result = await requestHelper.postCampaignActivityFromReq();
+  const result = await requestHelper.postCampaignActivity();
   gambitCampaigns.postCampaignActivity.should.have.been.calledWith(postData);
   result.should.deep.equal(postResult);
 });

--- a/test/unit/lib/middleware/messages/member/catchAll-autoReply.test.js
+++ b/test/unit/lib/middleware/messages/member/catchAll-autoReply.test.js
@@ -49,7 +49,7 @@ test('autoReplyCatchAll should call replies.autoReply if topic.isAutoReply is fa
   helpers.replies.autoReply.should.not.have.been.called;
 });
 
-test('autoReplyCatchAll should call postCampaignActivityFromReq if shouldSendAutoReply and hasCampaign', async (t) => {
+test('autoReplyCatchAll should call postCampaignActivity if shouldSendAutoReply and hasCampaign', async (t) => {
   const next = sinon.stub();
   const middleware = autoReplyCatchAll();
   t.context.req.topic = topicFactory.getValidTextPostConfig();
@@ -57,7 +57,7 @@ test('autoReplyCatchAll should call postCampaignActivityFromReq if shouldSendAut
     .returns(true);
   sandbox.stub(helpers.request, 'hasCampaign')
     .returns(true);
-  sandbox.stub(helpers.request, 'postCampaignActivityFromReq')
+  sandbox.stub(helpers.request, 'postCampaignActivity')
     .returns(Promise.resolve());
   sandbox.stub(helpers.replies, 'sendReplyWithTopicTemplate')
     .returns(underscore.noop);
@@ -65,12 +65,12 @@ test('autoReplyCatchAll should call postCampaignActivityFromReq if shouldSendAut
   // test
   await middleware(t.context.req, t.context.res, next);
 
-  helpers.request.postCampaignActivityFromReq.should.have.been.called;
+  helpers.request.postCampaignActivity.should.have.been.called;
   helpers.replies.sendReplyWithTopicTemplate.should.have.been.called;
   helpers.sendErrorResponse.should.not.have.been.called;
 });
 
-test('autoReplyCatchAll does not call postCampaignActivityFromReq if shouldSendAutoReply and topic does not have campaign', async (t) => {
+test('autoReplyCatchAll does not call postCampaignActivity if shouldSendAutoReply and topic does not have campaign', async (t) => {
   const next = sinon.stub();
   const middleware = autoReplyCatchAll();
   t.context.req.topic = topicFactory.getValidTopicWithoutCampaign();
@@ -78,7 +78,7 @@ test('autoReplyCatchAll does not call postCampaignActivityFromReq if shouldSendA
     .returns(true);
   sandbox.stub(helpers.request, 'hasCampaign')
     .returns(false);
-  sandbox.stub(helpers.request, 'postCampaignActivityFromReq')
+  sandbox.stub(helpers.request, 'postCampaignActivity')
     .returns(Promise.resolve());
   sandbox.stub(helpers.replies, 'sendReplyWithTopicTemplate')
     .returns(underscore.noop);
@@ -86,11 +86,11 @@ test('autoReplyCatchAll does not call postCampaignActivityFromReq if shouldSendA
   // test
   await middleware(t.context.req, t.context.res, next);
 
-  helpers.request.postCampaignActivityFromReq.should.not.have.been.called;
+  helpers.request.postCampaignActivity.should.not.have.been.called;
   helpers.replies.sendReplyWithTopicTemplate.should.have.been.called;
 });
 
-test('autoReplyCatchAll calls sendErrorResponse if postCampaignActivityFromReq fails', async (t) => {
+test('autoReplyCatchAll calls sendErrorResponse if postCampaignActivity fails', async (t) => {
   const next = sinon.stub();
   const middleware = autoReplyCatchAll();
   t.context.req.topic = topicFactory.getValidTextPostConfig();
@@ -99,7 +99,7 @@ test('autoReplyCatchAll calls sendErrorResponse if postCampaignActivityFromReq f
   sandbox.stub(helpers.request, 'hasCampaign')
     .returns(true);
   const mockError = { message: 'oh no' };
-  sandbox.stub(helpers.request, 'postCampaignActivityFromReq')
+  sandbox.stub(helpers.request, 'postCampaignActivity')
     .returns(Promise.reject(mockError));
   sandbox.stub(helpers.replies, 'sendReplyWithTopicTemplate')
     .returns(true);
@@ -120,7 +120,7 @@ test('autoReplyCatchAll calls sendErrorResponse if sendReplyWithTopicTemplate fa
   sandbox.stub(helpers.request, 'hasCampaign')
     .returns(true);
   const mockError = { message: 'oh no' };
-  sandbox.stub(helpers.request, 'postCampaignActivityFromReq')
+  sandbox.stub(helpers.request, 'postCampaignActivity')
     .returns(Promise.resolve());
   sandbox.stub(helpers.replies, 'sendReplyWithTopicTemplate')
     .throws(mockError);


### PR DESCRIPTION
#### What's this PR do?

Implements changes discussed in https://github.com/DoSomething/gambit-conversations/pull/385#pullrequestreview-148067648, to continue sending a `broadcastId` parameter when posting activity for non-askYesNo broadcasts, e.g. a `textPostBroadcast`.  Adds test coverage to `getCampaignActivity` and fixes an existing bug where we weren't passing `broadcastId` for inbound messages, as `req.broadcastId` doesn't ever get set for an inbound member message 😿 

#### How should this be reviewed?

* Test an askYesNo broadcast (4K6E6y2wnY6aesy6KgOQoO), verify the askYesNo id is passed as the `broadcastId` parameter upon responding with a yes

* Test a textPost broadcast (2E3ZSy29UQKumUYImq2mSK), verify the textPostBroadcast id is passed as the `broadcastId` parameter upon responding with a text post


#### Relevant tickets
A better fix for https://github.com/DoSomething/gambit-conversations/issues/384

#### Checklist
- [x] Tests added for new features/bug fixes.
- [x] Tested on staging.
