### PR TITLE
Removes support for legacy broadcast type [pr]

### DIFF
--- a/config/lib/helpers/broadcast.js
+++ b/config/lib/helpers/broadcast.js
@@ -9,12 +9,6 @@ module.exports = {
     textPostBroadcast: 'textPostBroadcast',
     legacy: 'broadcast',
   },
-  default: {
-    templates: {
-      campaign: 'askSignup',
-      topic: 'rivescript',
-    },
-  },
   customerIo: {
     userIdField: '{{customer.id}}',
   },

--- a/documentation/endpoints/messages.md
+++ b/documentation/endpoints/messages.md
@@ -66,9 +66,9 @@ Name | Type | Description
 <summary><strong>Example Request</strong></summary>
 
 ```
-curl -X "POST" "http://localhost:5100/api/v2/messages?origin=broadcast"
-     -H 'Content-Type: application/json; charset=utf-8'
-     -u 'puppet:totallysecret'
+curl -X "POST" "http://localhost:5100/api/v2/messages?origin=broadcast" \
+     -H 'Content-Type: application/json; charset=utf-8' \
+     -u 'puppet:totallysecret' \
      -d $'{
   "northstarId": "5547be89429c64ec7e8b518d",
   "broadcastId": "4nwTwvXmfuuYAGYgusGyyW"

--- a/documentation/endpoints/messages.md
+++ b/documentation/endpoints/messages.md
@@ -66,12 +66,12 @@ Name | Type | Description
 <summary><strong>Example Request</strong></summary>
 
 ```
-curl -X "POST" "http://localhost:5100/api/v2/messages?origin=broadcast" \
-     -H 'Content-Type: application/json; charset=utf-8' \
-     -u 'puppet:totallysecret' \
+curl -X "POST" "http://localhost:5100/api/v2/messages?origin=broadcast"
+     -H 'Content-Type: application/json; charset=utf-8'
+     -u 'puppet:totallysecret'
      -d $'{
   "northstarId": "5547be89429c64ec7e8b518d",
-  "broadcastId": "5Akz30ejtKCsiWgwKIkOyo"
+  "broadcastId": "4nwTwvXmfuuYAGYgusGyyW"
 }'
 ```
 
@@ -84,24 +84,31 @@ curl -X "POST" "http://localhost:5100/api/v2/messages?origin=broadcast" \
   "data": {
     "messages": [
       {
-        "_id": "5a5e9bb842ced115e4dbfda4",
-        "updatedAt": "2018-01-17T00:41:28.911Z",
-        "createdAt": "2018-01-17T00:41:28.911Z",
-        "text": "Hi it's Freddie! Want to know how you could enter for the chance to win a $5K scholarship by sharing one of your big regrets? It takes 2 mins! Reply Yes or No",
+        "platformMessageId": "SM9f73c7a8d1fc444faeeec9964a270514",
+        "_id": "5b7c9cea350595000404de44",
+        "updatedAt": "2018-08-21T23:14:50.529Z",
+        "createdAt": "2018-08-21T23:14:50.314Z",
+        "text": "I don't want to wait, for our lives to be over",
         "direction": "outbound-api-send",
-        "template": "askSignup",
-        "conversationId": "5a2c391d36515819a6446d6e",
-        "campaignId": 7978,
-        "topic": "campaign",
-        "broadcastId": "5Akz30ejtKCsiWgwKIkOyo",
+        "template": "autoReplyBroadcast",
+        "conversationId": "5ac7a86b8c02c10004d92577",
+        "campaignId": 8158,
+        "topic": "61RPZx8atiGyeoeaqsckOE",
+        "userId": "5547be89469c64ec7d8b518d",
+        "broadcastId": "4nwTwvXmfuuYAGYgusGyyW",
         "__v": 0,
         "metadata": {
-          "requestId": "17b1ab02-205b-4728-b4c9-d778bf89f561"
+            "requestId": "e8cbf79d-6cd3-4028-b1aa-d8455c166d57",
+            "delivery": {
+                "totalSegments": 1,
+                "queuedAt": "2018-08-21T23:14:50.000Z"
+            }
         },
         "attachments": []
       }
     ]
   }
+}
 ```
 
 </details>

--- a/lib/helpers/broadcast.js
+++ b/lib/helpers/broadcast.js
@@ -35,6 +35,14 @@ function isAskSubscriptionStatus(broadcast) {
  * @param {Object} broadcast
  * @return {Boolean}
  */
+function isAskYesNo(broadcast) {
+  return broadcast.type === config.types.askYesNo;
+}
+
+/**
+ * @param {Object} broadcast
+ * @return {Boolean}
+ */
 function isLegacyBroadcast(broadcast) {
   return broadcast.type === config.types.legacy;
 }
@@ -113,6 +121,7 @@ module.exports = {
   fetch,
   fetchById,
   isAskSubscriptionStatus,
+  isAskYesNo,
   isLegacyBroadcast,
   /**
    * @param {boolean} useApiVersion2

--- a/lib/helpers/topic.js
+++ b/lib/helpers/topic.js
@@ -79,7 +79,6 @@ function getSupportTopic() {
  * @return {Boolean}
  */
 function hasCampaign(topic) {
-  logger.debug('topic.hasCampaign');
   return topic.campaign && topic.campaign.id;
 }
 

--- a/lib/helpers/topic.js
+++ b/lib/helpers/topic.js
@@ -78,6 +78,15 @@ function getSupportTopic() {
  * @param {Object} topic
  * @return {Boolean}
  */
+function hasCampaign(topic) {
+  logger.debug('topic.hasCampaign');
+  return topic.campaign && topic.campaign.id;
+}
+
+/**
+ * @param {Object} topic
+ * @return {Boolean}
+ */
 function isAskSubscriptionStatus(topic) {
   return topic.id === config.rivescriptTopics.askSubscriptionStatus.id;
 }
@@ -124,6 +133,7 @@ module.exports = {
   getRenderedTextFromTopicAndTemplateName,
   getRivescriptTopicById,
   getSupportTopic,
+  hasCampaign,
   isAskSubscriptionStatus,
   isAskYesNo,
   isAutoReply,

--- a/lib/middleware/messages/broadcast/broadcast-get.js
+++ b/lib/middleware/messages/broadcast/broadcast-get.js
@@ -17,9 +17,9 @@ module.exports = function getBroadcast() {
       // Check if the saidYes topic has a campaign, and send error if closed.
       if (helpers.broadcast.isAskYesNo(broadcast)) {
         const saidYesTemplate = broadcast.templates.saidYes;
-        const hasCampaign = saidYesTemplate.topic.campaign && saidYesTemplate.topic.campaign.id;
+        const hasCampaign = helpers.topic.hasCampaign(saidYesTemplate.topic);
         if (hasCampaign && helpers.campaign.isClosedCampaign(saidYesTemplate.topic.campaign)) {
-          errorMessage = 'Broadcast saidYes topic campaign is closed.';
+          errorMessage = 'Broadcast saidYes topic campaign has ended.';
           return helpers.sendErrorResponse(res, new UnprocessibleEntityError(errorMessage));
         }
         return next();
@@ -27,14 +27,14 @@ module.exports = function getBroadcast() {
 
       // Any other broadcast should have a message topic set.
       if (!broadcast.message.topic.id) {
-        errorMessage = 'Broadcast does not have a topic';
+        errorMessage = 'Broadcast message does not have a topic set.';
         return helpers.sendErrorResponse(res, new UnprocessibleEntityError(errorMessage));
       }
 
       // Check if our broadcast message topic has campaign, and send error if closed.
-      const hasCampaign = broadcast.message.topic.campaign.id;
+      const hasCampaign = helpers.topic.hasCampaign(broadcast.message.topic);
       if (hasCampaign && helpers.campaign.isClosedCampaign(broadcast.message.topic.campaign)) {
-        errorMessage = 'Broadcast topic campaign is closed.';
+        errorMessage = 'Broadcast message topic campaign has ended.';
         return helpers.sendErrorResponse(res, new UnprocessibleEntityError(errorMessage));
       }
 

--- a/lib/middleware/messages/broadcast/broadcast-get.js
+++ b/lib/middleware/messages/broadcast/broadcast-get.js
@@ -1,11 +1,43 @@
 'use strict';
 
 const helpers = require('../../../helpers');
+const UnprocessibleEntityError = require('../../../../app/exceptions/UnprocessibleEntityError');
 
 module.exports = function getBroadcast() {
   return (req, res, next) => helpers.broadcast.fetchById(req.broadcastId)
     .then((broadcast) => {
       req.broadcast = broadcast;
+      let errorMessage;
+
+      if (helpers.broadcast.isLegacyBroadcast(broadcast)) {
+        errorMessage = 'Broadcast type \'broadcast\' is no longer supported.';
+        return helpers.sendErrorResponse(res, new UnprocessibleEntityError(errorMessage));
+      }
+
+      // Check if the saidYes topic has a campaign, and send error if closed.
+      if (helpers.broadcast.isAskYesNo(broadcast)) {
+        const saidYesTemplate = broadcast.templates.saidYes;
+        const hasCampaign = saidYesTemplate.topic.campaign && saidYesTemplate.topic.campaign.id;
+        if (hasCampaign && helpers.campaign.isClosedCampaign(saidYesTemplate.topic.campaign)) {
+          errorMessage = 'Broadcast saidYes topic campaign is closed.';
+          return helpers.sendErrorResponse(res, new UnprocessibleEntityError(errorMessage));
+        }
+        return next();
+      }
+
+      // Any other broadcast should have a message topic set.
+      if (!broadcast.message.topic.id) {
+        errorMessage = 'Broadcast does not have a topic';
+        return helpers.sendErrorResponse(res, new UnprocessibleEntityError(errorMessage));
+      }
+
+      // Check if our broadcast message topic has campaign, and send error if closed.
+      const hasCampaign = broadcast.message.topic.campaign.id;
+      if (hasCampaign && helpers.campaign.isClosedCampaign(broadcast.message.topic.campaign)) {
+        errorMessage = 'Broadcast topic campaign is closed.';
+        return helpers.sendErrorResponse(res, new UnprocessibleEntityError(errorMessage));
+      }
+
       return next();
     })
     .catch(err => helpers.sendErrorResponse(res, err));

--- a/lib/middleware/messages/broadcast/broadcast-parse.js
+++ b/lib/middleware/messages/broadcast/broadcast-parse.js
@@ -13,22 +13,6 @@ module.exports = function parseBroadcast() {
         helpers.attachments.add(req, attachment, 'outbound');
       });
 
-      // Parse topic that we'll need to update the user's conversation with.
-      // TODO: We'll be able to deprecate the legacy type and remove this check once:
-      // - The askYesNo topic returns its relevant replies
-      // - An autoReply topic has an optional campaign value set, which will deprecate the use of
-      //   the externalPostConfig content type used to create signups and send a single reply.
-      if (helpers.broadcast.isLegacyBroadcast(req.broadcast)) {
-        // The legacy type has a topic text field used to save a Rivescript topic id.
-        if (req.broadcast.topic) {
-          helpers.request.setTopic(req, helpers.topic.getRivescriptTopicById(req.broadcast.topic));
-          return next();
-        }
-        // Otherwise we save the campaignId to use later to find the topic to set.
-        helpers.request.setCampaignId(req, req.broadcast.campaignId);
-        return next();
-      }
-
       if (helpers.broadcast.isAskSubscriptionStatus(req.broadcast)) {
         helpers.request.setTopic(req, helpers.topic.getAskSubscriptionStatusTopic());
         return next();

--- a/lib/middleware/messages/broadcast/conversation-update.js
+++ b/lib/middleware/messages/broadcast/conversation-update.js
@@ -5,32 +5,12 @@ const UnprocessibleEntityError = require('../../../../app/exceptions/Unprocessib
 
 module.exports = function updateConversation() {
   return (req, res, next) => {
-    if (req.topic) {
-      return helpers.request.changeTopic(req, req.topic).then(() => next());
+    if (!req.topic) {
+      return helpers.sendErrorResponse(res, new UnprocessibleEntityError('req.topic undefined'));
     }
 
-    // TODO: Once we get askYesNo broadcasts in place to deprecate the askSignup legacy broadcast,
-    // send error if req.topic undefined, as we'll no longer need to find a topic by campaignId.
-    if (!req.campaignId) {
-      const error = new UnprocessibleEntityError('Broadcast does not contain topic or campaignId.');
-      return helpers.sendErrorResponse(res, error);
-    }
-    // TODO: Fetching topic by campaign will be removed.
-    return helpers.campaign.fetchById(req.campaignId)
-      .then((campaign) => {
-        if (helpers.campaign.isClosedCampaign(campaign)) {
-          const error = new UnprocessibleEntityError('Broadcast campaign is closed.');
-          return helpers.sendErrorResponse(res, error);
-        }
-
-        const firstTopic = campaign.topics[0];
-        if (!firstTopic) {
-          const error = new UnprocessibleEntityError('Broadcast campaign does not have topics.');
-          return helpers.sendErrorResponse(res, error);
-        }
-
-        return helpers.request.changeTopic(req, firstTopic).then(() => next());
-      })
+    return helpers.request.changeTopic(req, req.topic)
+      .then(() => next())
       .catch(err => helpers.sendErrorResponse(res, err));
   };
 };

--- a/test/unit/lib/lib-helpers/broadcast.test.js
+++ b/test/unit/lib/lib-helpers/broadcast.test.js
@@ -131,6 +131,12 @@ test('isAskSubscriptionStatus returns whether broadcast type is askSubscriptionS
   t.falsy(broadcastHelper.isAskSubscriptionStatus(askYesNoBroadcast));
 });
 
+// isAskYesNo
+test('isAskYesNo returns whether broadcast type is askYesNo', (t) => {
+  t.truthy(broadcastHelper.isAskYesNo(askYesNoBroadcast));
+  t.falsy(broadcastHelper.isAskYesNo(askSubscriptionStatusBroadcast));
+});
+
 // isLegacyBroadcast
 test('isLegacyBroadcast returns whether broadcast type is legacy', (t) => {
   t.truthy(broadcastHelper.isLegacyBroadcast(legacyBroadcast));

--- a/test/unit/lib/lib-helpers/request.test.js
+++ b/test/unit/lib/lib-helpers/request.test.js
@@ -287,7 +287,7 @@ test('getRivescriptReply should call helpers.rivescript.getBotReply with req var
 });
 
 // hasCampaign
-test('hasCampaign should return boolean of whether req.campign defined', (t) => {
+test('hasCampaign should return boolean of whether req.campaign defined', (t) => {
   t.context.req.campaign = campaignFactory.getValidCampaign();
   t.truthy(requestHelper.hasCampaign(t.context.req));
   t.context.req.campaign = null;

--- a/test/unit/lib/lib-helpers/topic.test.js
+++ b/test/unit/lib/lib-helpers/topic.test.js
@@ -88,6 +88,12 @@ test('getSupportTopic should return config.rivescriptTopics.support', () => {
   result.should.deep.equal(config.rivescriptTopics.support);
 });
 
+// hasCampaign
+test('hasCampaign should return boolean of whether topic.campaign.id exists', (t) => {
+  t.truthy(topicHelper.hasCampaign(topicFactory.getValidTextPostConfig()));
+  t.falsy(topicHelper.hasCampaign(topicFactory.getValidTopicWithoutCampaign()));
+});
+
 // isAskSubscriptionStatus
 test('isAskSubscriptionStatus returns whether topic is rivescriptTopics.isAskSubscriptionStatus', (t) => {
   const mockTopic = topicFactory.getValidTopic();

--- a/test/unit/lib/middleware/messages/broadcast/broadcast-get.test.js
+++ b/test/unit/lib/middleware/messages/broadcast/broadcast-get.test.js
@@ -17,7 +17,7 @@ const broadcastFactory = require('../../../../../helpers/factories/broadcast');
 
 // stubs
 const broadcastId = stubs.getBroadcastId();
-const mockBroadcast = broadcastFactory.getValidLegacyCampaignBroadcast();
+const legacyBroadcast = broadcastFactory.getValidLegacyCampaignBroadcast();
 
 // setup "x.should.y" assertion style
 chai.should();
@@ -45,33 +45,28 @@ test.afterEach((t) => {
   t.context = {};
 });
 
-/**
- * Tests
- */
-test('getBroadcast should inject broadcast property from fetchById result', async (t) => {
-  // setup
+test('getBroadcast should return error if broadcast is legacy type', async (t) => {
   const next = sinon.stub();
   const middleware = getBroadcast();
   sandbox.stub(helpers.broadcast, 'fetchById')
-    .returns(Promise.resolve(mockBroadcast));
+    .returns(Promise.resolve(legacyBroadcast));
 
   // test
   await middleware(t.context.req, t.context.res, next);
   helpers.broadcast.fetchById.should.have.been.calledWith(broadcastId);
-  next.should.have.been.called;
-  helpers.sendErrorResponse.should.not.have.been.called;
+  next.should.not.have.been.called;
+  helpers.sendErrorResponse.should.have.been.called;
 });
 
 test('getBroadcast should call sendErrorResponse if fetchById fails', async (t) => {
-  // setup
   const next = sinon.stub();
   const middleware = getBroadcast();
+  const stubError = { message: 'Epic fail' };
   sandbox.stub(helpers.broadcast, 'fetchById')
-    .returns(Promise.reject(new Error()));
+    .returns(Promise.reject(stubError));
 
   // test
   await middleware(t.context.req, t.context.res, next);
-  helpers.sendErrorResponse.should.have.been.called;
-  t.context.req.should.not.have.property('broadcast');
+  helpers.sendErrorResponse.should.have.been.calledWith(t.context.res, stubError);
   next.should.not.have.been.called;
 });

--- a/test/unit/lib/middleware/messages/broadcast/broadcast-parse.test.js
+++ b/test/unit/lib/middleware/messages/broadcast/broadcast-parse.test.js
@@ -42,52 +42,6 @@ test.afterEach((t) => {
   t.context = {};
 });
 
-test('parseBroadcast should inject campaignId into req if legacy campaign broadcast', async (t) => {
-  const next = sinon.stub();
-  const middleware = parseBroadcast();
-  const broadcast = broadcastFactory.getValidLegacyCampaignBroadcast();
-  t.context.req.broadcast = broadcast;
-  sandbox.stub(helpers.request, 'setOutboundMessageText')
-    .returns(underscore.noop);
-
-  // test
-  await middleware(t.context.req, t.context.res, next);
-  helpers.request.setCampaignId.should.have.been.calledWith(t.context.req, broadcast.campaignId);
-  helpers.request.setTopic.should.not.have.been.called;
-  helpers.request.setOutboundMessageText
-    .should.have.been.calledWith(t.context.req, broadcast.message.text);
-  helpers.request.setOutboundMessageTemplate
-    .should.have.been.calledWith(t.context.req, broadcast.message.template);
-  helpers.attachments.add
-    .should.have.been.calledWith(t.context.req, broadcast.message.attachments[0]);
-  next.should.have.been.called;
-});
-
-test('parseBroadcast should inject topic into req if legacy rivescript topic broadcast', async (t) => {
-  const next = sinon.stub();
-  const middleware = parseBroadcast();
-  const broadcast = broadcastFactory.getValidLegacyRivescriptTopicBroadcast();
-  t.context.req.broadcast = broadcast;
-  const mockRivescriptTopic = { id: broadcast.topic };
-  sandbox.stub(helpers.topic, 'getRivescriptTopicById')
-    .returns(mockRivescriptTopic);
-
-  sandbox.stub(helpers.request, 'setOutboundMessageText')
-    .returns(underscore.noop);
-
-  // test
-  await middleware(t.context.req, t.context.res, next);
-  helpers.request.setCampaignId.should.not.have.been.called;
-  helpers.request.setTopic.should.have.been.calledWith(t.context.req, mockRivescriptTopic);
-  helpers.request.setOutboundMessageText
-    .should.have.been.calledWith(t.context.req, broadcast.message.text);
-  helpers.request.setOutboundMessageTemplate
-    .should.have.been.calledWith(t.context.req, broadcast.message.template);
-  helpers.attachments.add
-    .should.have.been.calledWith(t.context.req, broadcast.message.attachments[0]);
-  next.should.have.been.called;
-});
-
 test('parseBroadcast should inject the broadcast.message.topic into req.topic if exists', async (t) => {
   const next = sinon.stub();
   const middleware = parseBroadcast();


### PR DESCRIPTION
#### What's this PR do?

Throws an error if a broadcast message is received for a broadcast with type `broadcast`, and removes deprecated code in `lib/middleware/messages/broadcast`.

Also throws an error if broadcast topic has a campaign that has closed.

#### How should this be reviewed?
Can spot check a few different test broadcasts:

* `5mPrrJjImQAGYi4goYWk2S` - a legacy broadcast which should return "type not supported" error message

* `63DRYWUnPUIwCSqmG24Uae` - a draft autoReply broadcast which should return "message topic not set" error message

* `1bzn5a1cdWgAIKMcQgOMYS` - autoReply broadcast without a campaign should work as expected (change topic)

* `5q56wA4uJ2SoAi6uAS4uYK` - askYesNo broadcast where saidYes topic campaign has ended, should send error

* `1HpwqqPTfyeseSS6e4IaK2` - askYesNo with active campaign should work as expected (change topic)

Will add more entries to test closed campaigns for both `askYesNo` and other newer types.


#### Relevant tickets
https://www.pivotaltracker.com/story/show/157369418

#### Checklist
- [x] Documentation added for new features/changed endpoints.
- [x] Tests added for new features/bug fixes.
- [x] Tested on staging.
