### PR TITLE
Always send hardcoded support requested template

### DIFF
--- a/lib/helpers/replies.js
+++ b/lib/helpers/replies.js
@@ -216,8 +216,5 @@ module.exports.subscriptionStatusStop = function (req, res) {
 };
 
 module.exports.supportRequested = function (req, res) {
-  if (req.campaign) {
-    return exports.sendReplyWithTopicTemplate(req, res, 'memberSupport');
-  }
   return exports.sendGambitConversationsTemplate(req, res, 'supportRequested');
 };

--- a/test/unit/lib/lib-helpers/replies.test.js
+++ b/test/unit/lib/lib-helpers/replies.test.js
@@ -306,16 +306,9 @@ test('subscriptionStatusStop(): should call sendGambitConversationsTemplate', as
   await assertSendingGambitConversationsTemplate(t.context.req, t.context.res, template);
 });
 
-test('supportRequested(): should call sendGambitConversationsTemplate if no campaign is found', async (t) => {
-  // Campaign is being set beforeEach test, so we need to unset it here
-  t.context.req.campaign = undefined;
+test('supportRequested(): should call sendGambitConversationsTemplate', async (t) => {
   const template = gambitConversationsTemplates.supportRequested.name;
   await assertSendingGambitConversationsTemplate(t.context.req, t.context.res, template);
-});
-
-test('supportRequested(): should call sendReplyWithTopicTemplate if campaign is found', async (t) => {
-  const template = templates.memberSupport;
-  await assertSendingReplyWithTopicTemplate(t.context.req, t.context.res, template, 'supportRequested');
 });
 
 test('rivescriptReply(): should call sendReply', async (t) => {


### PR DESCRIPTION
#### What's this PR do?

Removes checking for an override `memberSupport` template to always send through the hardcoded `supportRequested` template. The member support template could be overridden for our older content types, but not the newer `autoReply` type. These overrides on the campaign level never get used anyway by editors, so this PR fixes bug by cutting the unused feature. I'll delete the `memberSupport` field on the campaign type accordingly upon deploy.

#### How should this be reviewed?
* 👁 💻 
* 💬 Can test with the @gambit-staging app, by sending yourself an autoReplyBroadcast, e.g. 1bzn5a1cdWgAIKMcQgOMYS which changes topic to an autoReply. Verify that a Q command returns the supportRequested template (Note: Slack messages don't make it into our Front inbox, but conversation will still be paused)

<img width="523" alt="screen shot 2018-08-22 at 10 19 26 am" src="https://user-images.githubusercontent.com/1236811/44479241-e0fbc600-a5f4-11e8-9d2c-5edd6b28c361.png">


#### Any background context you want to provide?
The reason the bug exists is because the templates object in a `GET /topics/:id` response for an autoReplyBroadcast doesn't contain the various fields defined on a `campaign` content type (e.g. `memberSupport`, `campaignClosed`). Editors don't really ever override any of these fields, so leaning towards scrapping them entirely. If editors do have a need to override a member support or campaign closed field, we could add them to the various topic types when that day comes.

#### Relevant tickets
Fixes https://dosomething.slack.com/archives/C2C8NLNAY/p1534947908000100

#### Checklist
- [x] Tests added for new features/bug fixes.
- [x] Tested on staging.
