### PR TITLE
Rivescript cache part 1 [pr]

### DIFF
--- a/config/lib/helpers/rivescript.js
+++ b/config/lib/helpers/rivescript.js
@@ -4,6 +4,7 @@
  * @see @see https://www.rivescript.com/docs/tutorial#the-code-explained
  */
 module.exports = {
+  cacheKey: 'contentApi',
   commands: {
     trigger: '+',
     // @see https://www.rivescript.com/docs/tutorial#redirections

--- a/lib/helpers/rivescript.js
+++ b/lib/helpers/rivescript.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const helpers = require('../helpers');
+const logger = require('../logger');
 const gambitCampaigns = require('../gambit-campaigns');
 const rivescript = require('../rivescript');
 const config = require('../../config/lib/helpers/rivescript');
@@ -9,10 +10,12 @@ const config = require('../../config/lib/helpers/rivescript');
  * @param {Object} query
  * @return {Promise}
  */
-function fetchDefaultTopicTriggers(query = {}) {
-  return gambitCampaigns.fetchDefaultTopicTriggers(query)
-    // TODO: Set Rivescript cache
-    .then(res => res.data.map(module.exports.parseDefaultTopicTrigger));
+function fetchDefaultTopicTriggers() {
+  logger.debug('fetchDefaultTopicTriggers');
+
+  return gambitCampaigns.fetchDefaultTopicTriggers()
+    .then(res => res.data.map(module.exports.parseDefaultTopicTrigger))
+    .then(data => helpers.cache.rivescript.set(config.cacheKey, data));
 }
 
 /**
@@ -106,11 +109,9 @@ function joinRivescriptLines(lines) {
  * @return {Promise}
  */
 function loadBot() {
-  // TODO: We may eventually add enough defaultTopicTrigger entries that we need to execute multiple
-  // GET requests fo fetch all content required for our default topic.
   return module.exports.fetchDefaultTopicTriggers()
-    .then(data => rivescript
-      .createNewBot(data.map(module.exports.getRivescriptFromDefaultTopicTrigger)));
+    .then(res => res.map(module.exports.getRivescriptFromDefaultTopicTrigger))
+    .then(rivescripts => rivescript.loadBotWithRivescripts(rivescripts));
 }
 
 /**
@@ -119,10 +120,15 @@ function loadBot() {
  * @param {String} messageText
  * @return {Promise}
  */
-function getBotReply(userId, topicId, messageText) {
-  // TODO: Check if Rivescript cache is set. If it isn't, we need to reload the bot.
-  // If Rivescript bot receives a message in a topic that it doesn't know about, it logs a
-  // "User x was in an empty topic Y" message to the console. This avoids that message.
+async function getBotReply(userId, topicId, messageText) {
+  const cache = await helpers.cache.rivescript.get(config.cacheKey);
+  if (!cache) {
+    logger.debug('rivescript cache miss');
+    await loadBot();
+  } else {
+    logger.debug('rivescript cache hit');
+  }
+
   const rivescriptTopicId = helpers.topic
     .isRivescriptTopicId(topicId) ? topicId : helpers.topic.getDefaultTopicId();
   return rivescript.getBotReply(userId, rivescriptTopicId, messageText);

--- a/lib/helpers/rivescript.js
+++ b/lib/helpers/rivescript.js
@@ -130,7 +130,7 @@ async function getBotReply(userId, topicId, messageText) {
   const cache = await helpers.cache.rivescript.get(cacheKey);
   if (!cache) {
     logger.debug('rivescript cache miss');
-    await loadBot();
+    await module.exports.loadBot();
   } else {
     logger.debug('rivescript cache hit');
   }

--- a/lib/helpers/rivescript.js
+++ b/lib/helpers/rivescript.js
@@ -6,16 +6,23 @@ const gambitCampaigns = require('../gambit-campaigns');
 const rivescript = require('../rivescript');
 const config = require('../../config/lib/helpers/rivescript');
 
+const cacheKey = config.cacheKey;
+
 /**
  * @param {Object} query
  * @return {Promise}
  */
-function fetchDefaultTopicTriggers() {
-  logger.debug('fetchDefaultTopicTriggers');
+async function getRivescripts() {
+  logger.debug('getRivescripts');
+  const cache = await helpers.cache.rivescript.get(cacheKey);
+  if (cache) {
+    return cache;
+  }
 
+  // TODO: Check our fetchResponse.meta to determine whether to fetch more triggers.
   return gambitCampaigns.fetchDefaultTopicTriggers()
-    .then(res => res.data.map(module.exports.parseDefaultTopicTrigger))
-    .then(data => helpers.cache.rivescript.set(config.cacheKey, data));
+    .then(res => res.data.map(module.exports.parseRivescript))
+    .then(rivescripts => helpers.cache.rivescript.set(cacheKey, rivescripts));
 }
 
 /**
@@ -24,15 +31,15 @@ function fetchDefaultTopicTriggers() {
  * @param {Object} defaultTopicTrigger
  * @return {Object}
  */
-function parseDefaultTopicTrigger(defaultTopicTrigger) {
+function parseRivescript(defaultTopicTrigger) {
   if (!defaultTopicTrigger) {
-    throw new Error('parseDefaultTopicTrigger cannot parse falsy defaultTopicTrigger');
+    throw new Error('parseRivescript cannot parse falsy defaultTopicTrigger');
   }
   const data = Object.assign({}, defaultTopicTrigger);
   if (data.topic && data.topic.id) {
     data.reply = helpers.macro.getChangeTopicMacroFromTopicId(data.topic.id);
   }
-  return data;
+  return module.exports.getRivescriptFromDefaultTopicTrigger(data);
 }
 
 /**
@@ -109,8 +116,7 @@ function joinRivescriptLines(lines) {
  * @return {Promise}
  */
 function loadBot() {
-  return module.exports.fetchDefaultTopicTriggers()
-    .then(res => res.map(module.exports.getRivescriptFromDefaultTopicTrigger))
+  return module.exports.getRivescripts()
     .then(rivescripts => rivescript.loadBotWithRivescripts(rivescripts));
 }
 
@@ -121,14 +127,15 @@ function loadBot() {
  * @return {Promise}
  */
 async function getBotReply(userId, topicId, messageText) {
-  const cache = await helpers.cache.rivescript.get(config.cacheKey);
+  const cache = await helpers.cache.rivescript.get(cacheKey);
   if (!cache) {
     logger.debug('rivescript cache miss');
     await loadBot();
   } else {
     logger.debug('rivescript cache hit');
   }
-
+  // If Rivescript bot receives a message in a topic that it doesn't know about, it logs a
+  // "User x was in an empty topic Y" message to the console. This avoids that message.
   const rivescriptTopicId = helpers.topic
     .isRivescriptTopicId(topicId) ? topicId : helpers.topic.getDefaultTopicId();
   return rivescript.getBotReply(userId, rivescriptTopicId, messageText);
@@ -143,15 +150,15 @@ function parseAskYesNoResponse(messageText) {
 }
 
 module.exports = {
-  getBotReply,
-  fetchDefaultTopicTriggers,
   formatRivescriptLine,
+  getBotReply,
   getRedirectRivescript,
   getReplyRivescript,
   getRivescriptFromDefaultTopicTrigger,
   getRivescriptFromTriggerTextAndRivescriptLine,
+  getRivescripts,
   joinRivescriptLines,
   loadBot,
   parseAskYesNoResponse,
-  parseDefaultTopicTrigger,
+  parseRivescript,
 };

--- a/lib/rivescript.js
+++ b/lib/rivescript.js
@@ -29,17 +29,13 @@ function loadingDone() {
  *
  * @param {Array} rivescripts
  */
-function createNewBot(rivescripts) {
+function loadBotWithRivescripts(rivescripts = []) {
+  logger.debug('loadBotWithRivescripts');
+  additionalRivescripts = rivescripts;
   try {
-    additionalRivescripts = rivescripts;
-    brain = new RiveScript({
-      debug: config.debug,
-      concat: config.concat,
-    });
-    // Note: The v2 release of rivescript-js (still in alpha) returns a Promise, which means any
-    // Rivescript errors found when loading will stop the bot from loading entirely. We don't have
-    // a need to pass a Contentful ID to a reply because we're no longer adding specific Rivescript
-    // for our Content API topics -- but holding off on updating the package for now.
+    if (!brain) {
+      brain = new RiveScript({ debug: config.debug, concat: config.concat });
+    }
     brain.loadDirectory(config.directory, loadingDone, handleError);
   } catch (err) {
     logger.error('bot.createNewBot', err);
@@ -76,6 +72,6 @@ function getBotReply(userId, topicId, messageText) {
 }
 
 module.exports = {
-  createNewBot,
+  loadBotWithRivescripts,
   getBotReply,
 };

--- a/lib/rivescript.js
+++ b/lib/rivescript.js
@@ -32,6 +32,7 @@ function loadingDone() {
 function loadBotWithRivescripts(rivescripts = []) {
   logger.debug('loadBotWithRivescripts');
   additionalRivescripts = rivescripts;
+  hasSortedReplies = false;
   try {
     if (!brain) {
       brain = new RiveScript({ debug: config.debug, concat: config.concat });

--- a/server.js
+++ b/server.js
@@ -8,7 +8,6 @@ require('newrelic');
 
 const config = require('./config');
 const logger = require('./lib/logger');
-const helpers = require('./lib/helpers');
 const app = require('./app');
 
 // Start mongoose connection
@@ -33,7 +32,3 @@ db.on('error', (error) => {
 db.once('open', () => {
   app.listen(config.port, () => logger.info(`Conversations API is running on port=${config.port}.`));
 });
-
-helpers.rivescript.loadBot()
-  // TODO: Retry loading Bot if an error occurred.
-  .catch(error => logger.error('loadBot error', { error }));

--- a/test/unit/lib/lib-helpers/rivescript.test.js
+++ b/test/unit/lib/lib-helpers/rivescript.test.js
@@ -36,33 +36,37 @@ test.afterEach(() => {
   sandbox.restore();
 });
 
-// fetchDefaultTopicTriggers
-test('fetchDefaultTopicTriggers should call parseDefaultTopicTrigger on gambitCampaigns.fetchDefaultTopicTriggers success', async () => {
+// getRivescripts
+test('getRivescripts should call parseRivescript on gambitCampaigns.fetchDefaultTopicTriggers success', async () => {
   const data = [replyTrigger, redirectTrigger];
   const mockParsedTrigger = defaultTopicTriggerFactory.getValidReplyDefaultTopicTrigger();
+  sandbox.stub(helpers.cache.rivescript, 'get')
+    .returns(Promise.resolve(null));
   sandbox.stub(gambitCampaigns, 'fetchDefaultTopicTriggers')
     .returns(Promise.resolve({ data }));
-  sandbox.stub(rivescriptHelper, 'parseDefaultTopicTrigger')
+  sandbox.stub(rivescriptHelper, 'parseRivescript')
     .returns(mockParsedTrigger);
 
-  const result = await rivescriptHelper.fetchDefaultTopicTriggers();
+  const result = await rivescriptHelper.getRivescripts();
   data.forEach((item) => {
-    rivescriptHelper.parseDefaultTopicTrigger.should.have.been.calledWith(item);
+    rivescriptHelper.parseRivescript.should.have.been.calledWith(item);
   });
   gambitCampaigns.fetchDefaultTopicTriggers.should.have.been.called;
   result.should.deep.equal([mockParsedTrigger, mockParsedTrigger]);
 });
 
-test('fetchDefaultTopicTriggers should throw on gambitCampaigns.fetchDefaultTopicTriggers fail', async (t) => {
+test('getRivescripts should throw on gambitCampaigns.fetchDefaultTopicTriggers fail', async (t) => {
   const mockError = new Error('epic fail');
+  sandbox.stub(helpers.cache.rivescript, 'get')
+    .returns(Promise.resolve(null));
   sandbox.stub(gambitCampaigns, 'fetchDefaultTopicTriggers')
     .returns(Promise.reject(mockError));
-  sandbox.stub(rivescriptHelper, 'parseDefaultTopicTrigger')
+  sandbox.stub(rivescriptHelper, 'parseRivescript')
     .returns(replyTrigger);
 
-  const result = await t.throws(rivescriptHelper.fetchDefaultTopicTriggers());
+  const result = await t.throws(rivescriptHelper.getRivescripts());
   gambitCampaigns.fetchDefaultTopicTriggers.should.have.been.called;
-  rivescriptHelper.parseDefaultTopicTrigger.should.not.have.been.called;
+  rivescriptHelper.parseRivescript.should.not.have.been.called;
   result.should.deep.equal(mockError);
 });
 
@@ -159,40 +163,30 @@ test('joinRivescriptLines returns input array joined by the config line separato
 });
 
 // loadBot
-test('loadBot calls fetchDefaultTopicTriggers and creates a new Rivescript bot with result', async () => {
-  const fetchDefaultTopicTriggers = [replyTrigger, redirectTrigger, replyTrigger];
-  sandbox.stub(rivescriptHelper, 'fetchDefaultTopicTriggers')
-    .returns(Promise.resolve(fetchDefaultTopicTriggers));
-  sandbox.stub(rivescriptHelper, 'getRivescriptFromDefaultTopicTrigger')
-    .returns(mockRivescript);
+test('loadBot calls getRivescripts and creates a new Rivescript bot with result', async () => {
+  const getRivescripts = [replyTrigger, redirectTrigger, replyTrigger];
+  sandbox.stub(rivescriptHelper, 'getRivescripts')
+    .returns(Promise.resolve(getRivescripts));
   sandbox.stub(rivescriptApi, 'loadBotWithRivescripts')
     .returns(underscore.noop);
 
   await rivescriptHelper.loadBot();
-  rivescriptHelper.fetchDefaultTopicTriggers.should.have.been.called;
-  fetchDefaultTopicTriggers.forEach((item) => {
-    rivescriptHelper.getRivescriptFromDefaultTopicTrigger.should.have.been.calledWith(item);
-  });
+  rivescriptHelper.getRivescripts.should.have.been.called;
   rivescriptApi.loadBotWithRivescripts.should.have.been
-    .calledWith([mockRivescript, mockRivescript, mockRivescript]);
+    .calledWith(getRivescripts);
 });
 
-// parseDefaultTopicTrigger
-test('parseDefaultTopicTrigger should throw error if defaultTopicTrigger undefined', (t) => {
-  t.throws(() => rivescriptHelper.parseDefaultTopicTrigger());
+// parseRivescript
+test('parseRivescript should throw error if defaultTopicTrigger undefined', (t) => {
+  t.throws(() => rivescriptHelper.parseRivescript());
 });
 
-test('parseDefaultTopicTrigger should return defaultTopicTrigger if defaultTopicTrigger.topicId undefined', () => {
+test('parseRivescript should return defaultTopicTrigger if defaultTopicTrigger.topicId undefined', () => {
   const defaultTopicTrigger = defaultTopicTriggerFactory.getValidReplyDefaultTopicTrigger();
-  const result = rivescriptHelper.parseDefaultTopicTrigger(defaultTopicTrigger);
-  result.should.deep.equal(defaultTopicTrigger);
+  sandbox.stub(rivescriptHelper, 'getRivescriptFromDefaultTopicTrigger')
+    .returns(mockRivescript);
+  const result = rivescriptHelper.parseRivescript(defaultTopicTrigger);
+  result.should.deep.equal(mockRivescript);
 });
 
-test('parseDefaultTopicTrigger should return object with a changeTopic macro reply if defaultTopicTrigger.topic set', () => {
-  const mockChangeTopicMacro = `changeTopicTo${stubs.getTopicId()}`;
-  sandbox.stub(helpers.macro, 'getChangeTopicMacroFromTopicId')
-    .returns(mockChangeTopicMacro);
-  const defaultTopicTrigger = defaultTopicTriggerFactory.getValidChangeTopicDefaultTopicTrigger();
-  const result = rivescriptHelper.parseDefaultTopicTrigger(defaultTopicTrigger);
-  result.reply.should.equal(mockChangeTopicMacro);
-});
+// TODO: Add test for changeTopicMacro

--- a/test/unit/lib/lib-helpers/rivescript.test.js
+++ b/test/unit/lib/lib-helpers/rivescript.test.js
@@ -165,7 +165,7 @@ test('loadBot calls fetchDefaultTopicTriggers and creates a new Rivescript bot w
     .returns(Promise.resolve(fetchDefaultTopicTriggers));
   sandbox.stub(rivescriptHelper, 'getRivescriptFromDefaultTopicTrigger')
     .returns(mockRivescript);
-  sandbox.stub(rivescriptApi, 'createNewBot')
+  sandbox.stub(rivescriptApi, 'loadBotWithRivescripts')
     .returns(underscore.noop);
 
   await rivescriptHelper.loadBot();
@@ -173,7 +173,7 @@ test('loadBot calls fetchDefaultTopicTriggers and creates a new Rivescript bot w
   fetchDefaultTopicTriggers.forEach((item) => {
     rivescriptHelper.getRivescriptFromDefaultTopicTrigger.should.have.been.calledWith(item);
   });
-  rivescriptApi.createNewBot.should.have.been
+  rivescriptApi.loadBotWithRivescripts.should.have.been
     .calledWith([mockRivescript, mockRivescript, mockRivescript]);
 });
 

--- a/test/unit/lib/lib-helpers/rivescript.test.js
+++ b/test/unit/lib/lib-helpers/rivescript.test.js
@@ -27,6 +27,10 @@ const mockRivescriptLine = `${mockRivescriptCommand}${lineBreak}`;
 const mockRedirectLine = `${config.commands.redirect}${config.separators.command}${mockWord}${lineBreak}`;
 const mockReplyLine = `${config.commands.reply}${config.separators.command}${mockWord}${lineBreak}`;
 const mockRivescript = [mockRivescriptLine, mockReplyLine].join(lineBreak);
+const mockRivescriptReply = {
+  text: stubs.getRandomMessageText(),
+  topic: stubs.getContentfulId(),
+};
 const replyTrigger = defaultTopicTriggerFactory.getValidReplyDefaultTopicTrigger();
 const redirectTrigger = defaultTopicTriggerFactory.getValidReplyDefaultTopicTrigger();
 
@@ -34,6 +38,33 @@ const sandbox = sinon.sandbox.create();
 
 test.afterEach(() => {
   sandbox.restore();
+});
+
+// getBotReply
+test('getBotReply should call loadBot if rivescript cache is not set', async () => {
+  sandbox.stub(helpers.cache.rivescript, 'get')
+    .returns(Promise.resolve(false));
+  sandbox.stub(rivescriptHelper, 'loadBot')
+    .returns(Promise.resolve(true));
+  sandbox.stub(rivescriptApi, 'getBotReply')
+    .returns(Promise.resolve(mockRivescriptReply));
+
+  const result = await rivescriptHelper.getBotReply();
+  rivescriptHelper.loadBot.should.have.been.called;
+  result.should.deep.equal(mockRivescriptReply);
+});
+
+test('getBotReply does not call loadBot if rivescript cache is set', async () => {
+  sandbox.stub(helpers.cache.rivescript, 'get')
+    .returns(Promise.resolve(true));
+  sandbox.stub(rivescriptHelper, 'loadBot')
+    .returns(Promise.resolve(true));
+  sandbox.stub(rivescriptApi, 'getBotReply')
+    .returns(Promise.resolve(mockRivescriptReply));
+
+  const result = await rivescriptHelper.getBotReply();
+  rivescriptHelper.loadBot.should.not.have.been.called;
+  result.should.deep.equal(mockRivescriptReply);
 });
 
 // getRivescripts


### PR DESCRIPTION
#### What's this PR do?

Fills out the rivescript cache helper introduced in #385 to regularly reload the Rivescript bot replies. 

* Modifies the `getBotReply` rivescript helper to reload the bot if the Rivescript cache is empty, deprecating the need to load the bot in `server.js` 

#### How should this be reviewed?
Easiest way to verify expected behavior is to set your local `DS_GAMBIT_CONVERSATIONS_RIVESCRIPT_CACHE_TTL` config setting to a small value, and verify that default topic triggers are fetched and the bot is reloaded once the cache expires.

#### Any background context you want to provide?

Part 2: Provide an endpoint to clear the Rivescript cache, so editors can manually clear cache to verify triggers

Part 3: Which truly allows editors to clear cache, introduce Redis caching so all dynos load the additional rivescript from a single source. When this is introduced, we'll no longer need to serve the `GET /defaultTopicTriggers` as a cached list of default topic triggers, but instead can query Contentful without caching all results.

#### Relevant tickets
Fixes https://www.pivotaltracker.com/story/show/158037562 at a bare minimum

#### Checklist
- [ ] Tests added for new features/bug fixes.
- [x] Tested on staging.
