### PR TITLE
Adds a GET /rivescript endpoint

### DIFF
--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -3,6 +3,7 @@
 const broadcastsIndexRoute = require('./broadcasts/index');
 const broadcastsSingleRoute = require('./broadcasts/single');
 const mongooseRoutes = require('./mongoose');
+const rivescriptRoute = require('./rivescript');
 const v2MessagesRoute = require('./messages');
 
 // middleware
@@ -36,4 +37,6 @@ module.exports = function init(app) {
      */
     parseMessageMetadataMiddleware(),
     v2MessagesRoute);
+  app.use('/api/v2/rivescript',
+    rivescriptRoute);
 };

--- a/app/routes/rivescript/index.js
+++ b/app/routes/rivescript/index.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const express = require('express');
+
+const router = express.Router();
+
+// Middleware
+const indexMiddleware = require('../../../lib/middleware/rivescript');
+
+router.get('/', indexMiddleware());
+
+module.exports = router;

--- a/documentation/endpoints/rivescript.md
+++ b/documentation/endpoints/rivescript.md
@@ -1,0 +1,62 @@
+# Rivescript
+
+```
+GET /api/v2/rivescript
+```
+
+Returns the deparsed rivescript used for outbound replies.
+
+## Examples
+
+<details>
+<summary><strong>Example Request</strong></summary>
+
+```
+curl -X "GET" "http://localhost:5100/api/v2/rivescript" \
+     -H "Authorization: Basic cHVwcGV0OnRvdGFsbHlzZWNyZXQ="
+```
+</details>
+
+<details>
+<summary><strong>Example Response</strong></summary>
+
+```
+{
+  "data": {
+    "begin": {...}
+    "topics": {
+      "random": [
+        {
+          "trigger": "info",
+          "reply": [
+            "sendInfoMessage"
+          ],
+          "condition": [],
+          "redirect": null,
+          "previous": null
+        },
+        {
+          "trigger": "help",
+          "reply": [],
+          "condition": [],
+          "redirect": "info",
+          "previous": null
+        },
+        {
+          "trigger": "subscribe",
+          "reply": [
+            "subscriptionStatusActive"
+          ],
+          "condition": [],
+          "redirect": null,
+          "previous": null
+        },
+        ...
+      ]
+    }
+    ...
+  }
+}
+ 
+```
+</details>

--- a/lib/helpers/rivescript.js
+++ b/lib/helpers/rivescript.js
@@ -13,6 +13,7 @@ async function getDeparsedRivescript() {
   if (!cache) {
     await module.exports.loadBot();
   }
+  // @see https://github.com/aichaos/rivescript-js/blob/master/docs/rivescript.md#data-deparse
   return rivescript.getBot().deparse();
 }
 

--- a/lib/helpers/rivescript.js
+++ b/lib/helpers/rivescript.js
@@ -8,6 +8,14 @@ const config = require('../../config/lib/helpers/rivescript');
 
 const cacheKey = config.cacheKey;
 
+async function getDeparsedRivescript() {
+  const cache = await helpers.cache.rivescript.get(cacheKey);
+  if (!cache) {
+    await module.exports.loadBot();
+  }
+  return rivescript.getBot().deparse();
+}
+
 /**
  * @param {Object} query
  * @return {Promise}
@@ -152,6 +160,7 @@ function parseAskYesNoResponse(messageText) {
 module.exports = {
   formatRivescriptLine,
   getBotReply,
+  getDeparsedRivescript,
   getRedirectRivescript,
   getReplyRivescript,
   getRivescriptFromDefaultTopicTrigger,

--- a/lib/middleware/rivescript/index.js
+++ b/lib/middleware/rivescript/index.js
@@ -1,0 +1,9 @@
+'use strict';
+
+const helpers = require('../../helpers');
+
+module.exports = function getRivescript() {
+  return (req, res) => helpers.rivescript.getDeparsedRivescript()
+    .then(data => res.send({ data }))
+    .catch(err => helpers.sendErrorResponse(res, err));
+};

--- a/lib/rivescript.js
+++ b/lib/rivescript.js
@@ -35,7 +35,6 @@ function streamAndSortRepliesWithRivescripts(rivescripts) {
  */
 function loadBotWithRivescripts(rivescripts = []) {
   logger.debug('loadBotWithRivescripts');
-  hasSortedReplies = false;
   return module.exports.getBot().loadDirectory(config.directory)
     .then(() => streamAndSortRepliesWithRivescripts(rivescripts));
 }

--- a/lib/rivescript.js
+++ b/lib/rivescript.js
@@ -19,6 +19,7 @@ function logStreamError(error) {
 }
 
 function streamAndSortRepliesWithRivescripts(rivescripts) {
+  // @see https://github.com/aichaos/rivescript-js/blob/master/docs/rivescript.md#bool-stream-string-code-func-onerror
   rivescripts.forEach(item => brain.stream(item, logStreamError));
   logger.info('rivescript.brain.stream success');
   brain.sortReplies();

--- a/lib/rivescript.js
+++ b/lib/rivescript.js
@@ -5,18 +5,21 @@ const logger = require('./logger');
 const config = require('../config/lib/rivescript');
 
 let brain;
-let additionalRivescripts;
 let hasSortedReplies = false;
 
-function handleError(error) {
-  logger.error('rivescript.handleError', { error });
+function getBot() {
+  if (!brain) {
+    brain = new RiveScript({ debug: config.debug, concat: config.concat });
+  }
+  return brain;
 }
 
-function loadingDone() {
-  logger.info('rivescript.brain.loadDirectory success');
-  // Loads our saved additionalRivescript into the brain.
-  // @see https://github.com/aichaos/rivescript-js/blob/v1.17.2/docs/rivescript.md#bool-stream-string-code-func-onerror
-  additionalRivescripts.forEach(item => brain.stream(item, handleError));
+function logStreamError(error) {
+  logger.error('error streaming rivescript', { error });
+}
+
+function streamAndSortRepliesWithRivescripts(rivescripts) {
+  rivescripts.forEach(item => brain.stream(item, logStreamError));
   logger.info('rivescript.brain.stream success');
   brain.sortReplies();
   logger.info('rivescript.brain.sortReplies success');
@@ -27,20 +30,14 @@ function loadingDone() {
  * Creates a Rivescript bot and loads it with our hardcoded rivescript as well as rivescripts passed
  * in a rivescripts array property.
  *
- * @param {Array} rivescripts
+ * TODO: Don't provide an empty array, return a rejected error.
+ * @param {Array} rivescripts - Rivescript parsed from the Content API
  */
 function loadBotWithRivescripts(rivescripts = []) {
   logger.debug('loadBotWithRivescripts');
-  additionalRivescripts = rivescripts;
   hasSortedReplies = false;
-  try {
-    if (!brain) {
-      brain = new RiveScript({ debug: config.debug, concat: config.concat });
-    }
-    brain.loadDirectory(config.directory, loadingDone, handleError);
-  } catch (err) {
-    logger.error('bot.createNewBot', err);
-  }
+  return module.exports.getBot().loadDirectory(config.directory)
+    .then(() => streamAndSortRepliesWithRivescripts(rivescripts));
 }
 
 /**
@@ -57,7 +54,7 @@ function getBotReply(userId, topicId, messageText) {
   // @see https://github.com/aichaos/rivescript-js/wiki/Asynchronous-Support#user-variable-session-adapters
   brain.setUservars(userId, { topic: topicId });
 
-  return brain.replyAsync(userId, messageText)
+  return brain.reply(userId, messageText)
     .then((rivescriptReplyText) => {
       if (!hasSortedReplies) {
         throw new Error('Still sorting bot replies, please retry your message.');
@@ -73,6 +70,7 @@ function getBotReply(userId, topicId, messageText) {
 }
 
 module.exports = {
-  loadBotWithRivescripts,
+  getBot,
   getBotReply,
+  loadBotWithRivescripts,
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gambit-conversations",
-  "version": "2.14.5",
+  "version": "3.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -101,7 +101,7 @@
       "dependencies": {
         "superagent": {
           "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/superagent/-/superagent-2.3.0.tgz",
+          "resolved": "http://registry.npmjs.org/superagent/-/superagent-2.3.0.tgz",
           "integrity": "sha1-cDUpoHFOV+EjlZ3e+84ZOy5Q0RU=",
           "requires": {
             "component-emitter": "1.2.1",
@@ -804,6 +804,16 @@
         "babel-template": "6.26.0"
       }
     },
+    "babel-loader": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-7.1.5.tgz",
+      "integrity": "sha512-iCHfbieL5d1LfOQeeVJEUyD9rTwBcP/fcEbRCfempxTDuqrKpu0AZjLAQHEQa3Yqyj9ORKe2iHfoj4rHLf7xpw==",
+      "requires": {
+        "find-cache-dir": "1.0.0",
+        "loader-utils": "1.1.0",
+        "mkdirp": "0.5.1"
+      }
+    },
     "babel-messages": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
@@ -978,6 +988,28 @@
         "babel-types": "6.26.0"
       }
     },
+    "babel-polyfill": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
+      "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "core-js": "2.5.7",
+        "regenerator-runtime": "0.10.5"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.5.7",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
+          "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
+        },
+        "regenerator-runtime": {
+          "version": "0.10.5",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+          "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
+        }
+      }
+    },
     "babel-register": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
@@ -1014,7 +1046,6 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-      "dev": true,
       "requires": {
         "core-js": "2.5.4",
         "regenerator-runtime": "0.11.1"
@@ -1023,8 +1054,7 @@
         "core-js": {
           "version": "2.5.4",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.4.tgz",
-          "integrity": "sha1-8si/GB8qgLkvNgEhQpzmOi8K6uA=",
-          "dev": true
+          "integrity": "sha1-8si/GB8qgLkvNgEhQpzmOi8K6uA="
         }
       }
     },
@@ -1121,6 +1151,11 @@
       "requires": {
         "tweetnacl": "0.14.5"
       }
+    },
+    "big.js": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
+      "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q=="
     },
     "binary-extensions": {
       "version": "1.11.0",
@@ -1609,8 +1644,7 @@
     "commondir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-      "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
-      "dev": true
+      "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs="
     },
     "component-emitter": {
       "version": "1.2.1",
@@ -1993,6 +2027,11 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-6.5.1.tgz",
       "integrity": "sha512-PAHp6TxrCy7MGMFidro8uikr+zlJJKJ/Q6mm2ExZ7HwkyR9lSVFfE3kt36qcwa24BQL7y0G9axycGjK1A/0uNQ==",
       "dev": true
+    },
+    "emojis-list": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
+      "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k="
     },
     "empower-core": {
       "version": "0.6.2",
@@ -2683,7 +2722,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-1.0.0.tgz",
       "integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
-      "dev": true,
       "requires": {
         "commondir": "1.0.1",
         "make-dir": "1.2.0",
@@ -2694,7 +2732,6 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-          "dev": true,
           "requires": {
             "locate-path": "2.0.0"
           }
@@ -2703,7 +2740,6 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
           "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
-          "dev": true,
           "requires": {
             "find-up": "2.1.0"
           }
@@ -4699,8 +4735,7 @@
     "json5": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-      "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
-      "dev": true
+      "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
     },
     "jsonwebtoken": {
       "version": "8.2.0",
@@ -4832,11 +4867,20 @@
         "strip-bom": "3.0.0"
       }
     },
+    "loader-utils": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
+      "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
+      "requires": {
+        "big.js": "3.2.0",
+        "emojis-list": "2.1.0",
+        "json5": "0.5.1"
+      }
+    },
     "locate-path": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
       "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-      "dev": true,
       "requires": {
         "p-locate": "2.0.0",
         "path-exists": "3.0.0"
@@ -4845,8 +4889,7 @@
         "path-exists": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-          "dev": true
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
         }
       }
     },
@@ -5020,7 +5063,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.2.0.tgz",
       "integrity": "sha512-aNUAa4UMg/UougV25bbrU4ZaaKNjJ/3/xnvg/twpmKROPdKZPZ9wGgI0opdZzO8q/zUFawoUuixuOv33eZ61Iw==",
-      "dev": true,
       "requires": {
         "pify": "3.0.0"
       },
@@ -5028,8 +5070,7 @@
         "pify": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-          "dev": true
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
         }
       }
     },
@@ -5215,14 +5256,12 @@
     "minimist": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-      "dev": true
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
     "mkdirp": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true,
       "requires": {
         "minimist": "0.0.8"
       }
@@ -8793,7 +8832,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
       "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
-      "dev": true,
       "requires": {
         "p-try": "1.0.0"
       }
@@ -8802,7 +8840,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-      "dev": true,
       "requires": {
         "p-limit": "1.2.0"
       }
@@ -8810,8 +8847,7 @@
     "p-try": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
-      "dev": true
+      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
     },
     "package-hash": {
       "version": "2.0.0",
@@ -9360,8 +9396,7 @@
     "regenerator-runtime": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
-      "dev": true
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
     },
     "regex-cache": {
       "version": "0.4.4",
@@ -9617,23 +9652,19 @@
       }
     },
     "rivescript": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/rivescript/-/rivescript-1.19.0.tgz",
-      "integrity": "sha512-5h7Ukz3ImtcUpGhUeaADNXQHCdRHKJYSIxfUdkXkS9T9+eeReW/8E6VRCXVHPtiLfo5m8PEHOx7AISDczlWrZA==",
+      "version": "2.0.0-alpha.6",
+      "resolved": "https://registry.npmjs.org/rivescript/-/rivescript-2.0.0-alpha.6.tgz",
+      "integrity": "sha512-yqkCVqfD6a0NSygiZxtxRwyPGDydq5G9uJn/rOpDTSuuBwH2gM4radjjqFoI5Qlmf9bEInN8ZuA1aeGQsM4EVA==",
       "requires": {
-        "fs-readdir-recursive": "1.1.0",
-        "rsvp": "3.6.2"
+        "babel-loader": "7.1.5",
+        "babel-polyfill": "6.26.0",
+        "fs-readdir-recursive": "1.1.0"
       }
     },
     "rootpath": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/rootpath/-/rootpath-0.1.2.tgz",
       "integrity": "sha1-Wzeah9ypBum5HWkKWZQ5vvJn6ms="
-    },
-    "rsvp": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
-      "integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw=="
     },
     "run-async": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "newrelic": "4.7.0",
     "request": "^2.81.0",
     "request-promise": "^4.2.1",
-    "rivescript": "^1.17.2",
+    "rivescript": "^2.0.0-alpha.6",
     "superagent": "^3.5.2",
     "twilio": "^3.5.0",
     "underscore": "^1.8.3",

--- a/test/unit/lib/gambit-campaigns.test.js
+++ b/test/unit/lib/gambit-campaigns.test.js
@@ -161,6 +161,8 @@ test('fetchDefaultTopicTriggers should return result of a successful GET /fetchD
   const fetchResponse = { data: defaultTopicTriggers };
   sandbox.stub(gambitCampaigns, 'executeGet')
     .returns(Promise.resolve(fetchResponse));
+  // Why is a line break fixing this broken test? It's failing on this line below saying
+  // gambitCampaigns.getRivescripts is not a function.
   const result = await gambitCampaigns.fetchDefaultTopicTriggers(queryParams);
   result.should.deep.equal(fetchResponse);
   gambitCampaigns.executeGet

--- a/test/unit/lib/lib-helpers/rivescript.test.js
+++ b/test/unit/lib/lib-helpers/rivescript.test.js
@@ -68,7 +68,21 @@ test('getBotReply does not call loadBot if rivescript cache is set', async () =>
 });
 
 // getRivescripts
-test('getRivescripts should call parseRivescript on gambitCampaigns.fetchDefaultTopicTriggers success', async () => {
+// getRivescripts
+test('getRivescripts should return cache data if cache set', async () => {
+  const data = [replyTrigger, redirectTrigger];
+  sandbox.stub(helpers.cache.rivescript, 'get')
+    .returns(Promise.resolve(data));
+  sandbox.stub(gambitCampaigns, 'fetchDefaultTopicTriggers')
+    .returns(Promise.resolve(true));
+
+  const result = await rivescriptHelper.getRivescripts();
+
+  gambitCampaigns.fetchDefaultTopicTriggers.should.not.have.been.called;
+  result.should.deep.equal(data);
+});
+
+test('getRivescripts should call gambitCampaigns.fetchDefaultTopicTriggers if cache not set', async () => {
   const data = [replyTrigger, redirectTrigger];
   const mockParsedTrigger = defaultTopicTriggerFactory.getValidReplyDefaultTopicTrigger();
   sandbox.stub(helpers.cache.rivescript, 'get')

--- a/test/unit/lib/lib-helpers/rivescript.test.js
+++ b/test/unit/lib/lib-helpers/rivescript.test.js
@@ -22,6 +22,7 @@ const rivescriptHelper = require('../../../../lib/helpers/rivescript');
 
 const lineBreak = config.separators.line;
 const mockWord = stubs.getRandomWord();
+const mockDeparsedRivescript = { topics: { random: [], ask_yes_no: [] } };
 const mockRivescriptCommand = `${config.commands.trigger}${config.separators.command}${mockWord}`;
 const mockRivescriptLine = `${mockRivescriptCommand}${lineBreak}`;
 const mockRedirectLine = `${config.commands.redirect}${config.separators.command}${mockWord}${lineBreak}`;
@@ -67,7 +68,41 @@ test('getBotReply does not call loadBot if rivescript cache is set', async () =>
   result.should.deep.equal(mockRivescriptReply);
 });
 
-// getRivescripts
+// getDeparsedRivescript
+test('getDeparsedRivescript should call loadBot if rivescript cache is not set', async () => {
+  sandbox.stub(helpers.cache.rivescript, 'get')
+    .returns(Promise.resolve(false));
+  sandbox.stub(rivescriptHelper, 'loadBot')
+    .returns(Promise.resolve(true));
+  sandbox.stub(rivescriptApi, 'getBot')
+    .callsFake(() => ({
+      deparse: () => { // eslint-disable-line arrow-body-style
+        return mockDeparsedRivescript;
+      },
+    }));
+
+  const result = await rivescriptHelper.getDeparsedRivescript();
+  rivescriptHelper.loadBot.should.have.been.called;
+  result.should.deep.equal(mockDeparsedRivescript);
+});
+
+test('getDeparsedRivescript does not call loadBot if rivescript cache is set', async () => {
+  sandbox.stub(helpers.cache.rivescript, 'get')
+    .returns(Promise.resolve(true));
+  sandbox.stub(rivescriptHelper, 'loadBot')
+    .returns(Promise.resolve(true));
+  sandbox.stub(rivescriptApi, 'getBot')
+    .callsFake(() => ({
+      deparse: () => { // eslint-disable-line arrow-body-style
+        return mockDeparsedRivescript;
+      },
+    }));
+
+  const result = await rivescriptHelper.getDeparsedRivescript();
+  rivescriptHelper.loadBot.should.not.have.been.called;
+  result.should.deep.equal(mockDeparsedRivescript);
+});
+
 // getRivescripts
 test('getRivescripts should return cache data if cache set', async () => {
   const data = [replyTrigger, redirectTrigger];


### PR DESCRIPTION
#### What's this PR do?

Adds a `GET /rivescript` endpoint that returns [deparsed Rivescript](https://github.com/aichaos/rivescript-js/blob/master/docs/rivescript.md#data-deparse). Also updates rivescript-js to v2 to take advantage of the async [`loadDirectory`.](https://github.com/aichaos/rivescript-js/blob/master/docs/rivescript.md#async-loaddirectory-string-path)

#### How should this be reviewed?
Execute a `GET /rivescript` request, verifying that it loads the bot when Rivescript cache is not set. 

#### Any background context you want to provide?

Per part 2 in #390 - this endpoint will eventually support a query parameter to clear Redis cache once we're using Redis to trigger fetching and sorting the Rivescript triggers defined in the Content API.

Skipping on some unit tests for now to try to get a step 3 proof of concept with Redis in a new branch.

#### Relevant tickets
https://www.pivotaltracker.com/story/show/158037562

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tests added for new features/bug fixes.
- [ ] Tested on staging.
