### PR TITLE
Fixes getBotReply response by updating Rivescript async function calls

### DIFF
--- a/lib/rivescript.js
+++ b/lib/rivescript.js
@@ -36,6 +36,7 @@ function streamAndSortRepliesWithRivescripts(rivescripts) {
  */
 function loadBotWithRivescripts(rivescripts = []) {
   logger.debug('loadBotWithRivescripts');
+  hasSortedReplies = false;
   return module.exports.getBot().loadDirectory(config.directory)
     .then(() => streamAndSortRepliesWithRivescripts(rivescripts));
 }
@@ -46,27 +47,29 @@ function loadBotWithRivescripts(rivescripts = []) {
  * @param {String} messageText
  * @return {Promise}
  */
-function getBotReply(userId, topicId, messageText) {
+async function getBotReply(userId, topicId, messageText) {
+  logger.debug('getBotReply', { userId, topicId });
   if (!brain) {
-    return Promise.reject(Error('Bot is not loaded, please retry your message.'));
+    throw new Error('Bot is not loaded, please retry your message.');
   }
+  if (!hasSortedReplies) {
+    throw new Error('Still sorting bot replies, please retry your message.');
+  }
+
   // Set the Conversation's current topic in bot.uservars.
   // @see https://github.com/aichaos/rivescript-js/wiki/Asynchronous-Support#user-variable-session-adapters
-  brain.setUservars(userId, { topic: topicId });
+  await brain.setUservar(userId, 'topic', topicId);
 
-  return brain.reply(userId, messageText)
-    .then((rivescriptReplyText) => {
-      if (!hasSortedReplies) {
-        throw new Error('Still sorting bot replies, please retry your message.');
-      }
-      // The inbound message may have triggered a topic change, check bot.uservars to return topic.
-      const updatedUservars = brain.getUservars(userId);
-      return {
-        text: rivescriptReplyText,
-        topicId: updatedUservars.topic,
-        match: updatedUservars.__initialmatch__, // eslint-disable-line no-underscore-dangle
-      };
-    });
+  const rivescriptReplyText = await brain.reply(userId, messageText);
+
+  // The inbound message may have triggered a topic change, inspect bot.uservars for topic value.
+  const updatedUservars = await brain.getUservars(userId);
+
+  return {
+    text: rivescriptReplyText,
+    topicId: updatedUservars[userId].topic,
+    match: updatedUservars[userId].__initialmatch__, // eslint-disable-line no-underscore-dangle
+  };
 }
 
 module.exports = {

--- a/test/unit/lib/rivescript.test.js
+++ b/test/unit/lib/rivescript.test.js
@@ -1,0 +1,64 @@
+'use strict';
+
+// libs
+require('dotenv').config();
+const test = require('ava');
+const chai = require('chai');
+const sinon = require('sinon');
+const sinonChai = require('sinon-chai');
+const rewire = require('rewire');
+
+chai.should();
+chai.use(sinonChai);
+
+const sandbox = sinon.sandbox.create();
+
+const RiveScript = require('rivescript');
+
+const stubs = require('../../helpers/stubs');
+const config = require('../../../config/lib/rivescript');
+
+// Module to test
+const rivescript = rewire('../../../lib/rivescript');
+
+const userId = stubs.getUserId();
+const topicId = 'random';
+const messageText = stubs.getRandomMessageText();
+
+test.afterEach(() => {
+  sandbox.restore();
+  rivescript.__set__('brain', undefined);
+  rivescript.__set__('config', config);
+  rivescript.__set__('hasSortedReplies', false);
+});
+
+// getBot
+test('getBot should create a new Rivescript bot if brain undefined', () => {
+  const RiveScriptSpy = sandbox.spy();
+  rivescript.__set__('RiveScript', RiveScriptSpy);
+
+  rivescript.getBot();
+  RiveScriptSpy.should.have.been.calledWithNew;
+});
+
+test('getBot should return the existing Rivescript bot if already created', () => {
+  const RiveScriptSpy = sandbox.spy();
+  rivescript.__set__('RiveScript', RiveScriptSpy);
+  const newClient = rivescript.getBot();
+  const sameClient = rivescript.getBot();
+
+  // test
+  RiveScriptSpy.should.have.been.calledWithNew;
+  RiveScriptSpy.should.have.been.calledOnce;
+  newClient.should.be.equal(sameClient);
+});
+
+// getBotReply
+test('getBotReply should throw an error if brain undefined', async (t) => {
+  await t.throws(rivescript.getBotReply(userId, topicId, messageText));
+});
+
+test('getBotReply should throw an error if not hasSortedReplies', async (t) => {
+  rivescript.__set__('brain', new RiveScript());
+  await t.throws(rivescript.getBotReply(userId, topicId, messageText));
+});

--- a/test/unit/lib/rivescript.test.js
+++ b/test/unit/lib/rivescript.test.js
@@ -62,3 +62,23 @@ test('getBotReply should throw an error if not hasSortedReplies', async (t) => {
   rivescript.__set__('brain', new RiveScript());
   await t.throws(rivescript.getBotReply(userId, topicId, messageText));
 });
+
+test('getBotReply should return object if brain exists and hasSortedReplies', async () => {
+  const getUservarsResponse = {};
+  getUservarsResponse[userId] = {
+    topic: 'mockTopicId',
+    __initialmatch__: 'mockMatch',
+  };
+  rivescript.__set__('brain', {
+    getUservars: () => Promise.resolve(getUservarsResponse),
+    setUservar: () => Promise.resolve(),
+    reply: () => Promise.resolve('mockReplyText'),
+  });
+  rivescript.__set__('hasSortedReplies', true);
+
+  const result = await rivescript.getBotReply(userId, topicId, messageText);
+  result.text.should.equal('mockReplyText');
+  result.topicId.should.equal('mockTopicId');
+  result.match.should.equal('mockMatch');
+});
+


### PR DESCRIPTION
#### What's this PR do?

#395 was happening because the `setUservars` and `getUservars` functions are async. Opened https://github.com/aichaos/rivescript-js/pull/289 to document additional breaking changes.

#### How should this be reviewed?

Verify that a topic change trigger such as PUMP or SAFE changes topic and returns expected template.

#### Any background context you want to provide?
Epic fail introduced by #392. This one was tricky because quick replies returned the correct response, but I didn't test a topic change trigger, which would have caught this. Will add unit tests.. integration tests could be an option but our topic change triggers may change at any point in time, making it tough to test (unless we always kept a draft dev test trigger in tact)

#### Relevant tickets
Fixes #395 

#### Checklist
- [x] Tests added for new features/bug fixes.
- [x] Tested on staging.
