### PR TITLE
Fixes bug in reloading Rivescript after cache clear

### DIFF
--- a/lib/middleware/rivescript/index.js
+++ b/lib/middleware/rivescript/index.js
@@ -1,13 +1,18 @@
 'use strict';
 
 const helpers = require('../../helpers');
+const logger = require('../../logger');
 
 module.exports = function getRivescript() {
   return (req, res) => {
     const resetCache = req.query.cache === 'false';
 
     return helpers.rivescript.getDeparsedRivescript(resetCache)
-      .then(data => res.send({ data }))
+      .then((data) => {
+        const triggers = data.topics.random;
+        logger.debug('data.topics.random', { count: triggers.length });
+        return res.send({ data });
+      })
       .catch(err => helpers.sendErrorResponse(res, err));
   };
 };

--- a/lib/rivescript.js
+++ b/lib/rivescript.js
@@ -5,14 +5,25 @@ const logger = require('./logger');
 const config = require('../config/lib/rivescript');
 
 let brain;
-let hasSortedReplies = false;
+let hasSortedReplies;
+
+function createNewBot() {
+  try {
+    brain = new RiveScript({ debug: config.debug, concat: config.concat });
+    hasSortedReplies = false;
+    return brain;
+  } catch (err) {
+    logger.error('createNewBot error', err);
+    throw new Error(err.message);
+  }
+}
 
 /**
  * Sets brain to new RiveScript instance if not set already.
  */
 function getBot() {
   if (!brain) {
-    brain = new RiveScript({ debug: config.debug, concat: config.concat });
+    return createNewBot();
   }
   return brain;
 }
@@ -54,8 +65,9 @@ function isReady() {
  */
 function loadBotWithRivescripts(rivescripts = []) {
   logger.debug('loadBotWithRivescripts');
-  hasSortedReplies = false;
-  return module.exports.getBot().loadDirectory(config.directory)
+  // Purge all loaded Rivescript.
+  createNewBot();
+  return brain.loadDirectory(config.directory)
     .then(() => streamAndSortRepliesWithRivescripts(rivescripts));
 }
 

--- a/test/unit/lib/middleware/rivescript/index.test.js
+++ b/test/unit/lib/middleware/rivescript/index.test.js
@@ -21,7 +21,7 @@ const getRivescript = require('../../../../../lib/middleware/rivescript/index');
 
 const sandbox = sinon.sandbox.create();
 
-const deparsedRivescript = { topics: [] };
+const deparsedRivescript = { topics: { random: [] } };
 
 test.beforeEach((t) => {
   stubs.stubLogger(sandbox, logger);

--- a/test/unit/lib/rivescript.test.js
+++ b/test/unit/lib/rivescript.test.js
@@ -30,6 +30,7 @@ test.afterEach(() => {
   rivescript.__set__('brain', undefined);
   rivescript.__set__('config', config);
   rivescript.__set__('hasSortedReplies', false);
+  rivescript.__set__('RiveScript', undefined);
 });
 
 // getBot


### PR DESCRIPTION
#### What's this PR do?

Fixes bug where a Rivescript cache clear adds and sorts triggers from the Content API without ever purging the existing in-memory replies, creating duplicate triggers.  Found this by testing out the cache clear in https://github.com/DoSomething/gambit-admin/pull/69, where React began throwing errors for duplicate keys when rendering a `TriggerListItem` component.

#### How should this be reviewed?

Verify the number of triggers found in the `data.topics.random` array property remains the same upon testing a few `GET /rivescript?cache=false` requests.

#### Any background context you want to provide?

We haven't merged #394 into production yet, we'll want to get this fix in before we do.

#### Relevant tickets
https://www.pivotaltracker.com/story/show/158037562

#### Checklist
- [ ] Tests added for new features/bug fixes.
- [x] Tested on staging.
