### PR TITLE
Almost fixes cache clear for GET /rivescript

### DIFF
--- a/lib/helpers/rivescript.js
+++ b/lib/helpers/rivescript.js
@@ -43,7 +43,7 @@ async function getRivescripts(resetCache = false) {
  * @return {Promise}
  */
 function fetchRivescripts() {
-  return gambitCampaigns.fetchDefaultTopicTriggers()
+  return gambitCampaigns.fetchDefaultTopicTriggers({ cache: false, limit: 150 })
     // TODO: Check our res.meta to determine whether to fetch more triggers.
     .then((res) => {
       logger.debug('fetchDefaultTopicTriggers success', { count: res.data.length });

--- a/lib/helpers/rivescript.js
+++ b/lib/helpers/rivescript.js
@@ -14,25 +14,37 @@ const cacheKey = config.cacheKey;
  */
 async function getDeparsedRivescript(resetCache = false) {
   if (!rivescript.isReady() || resetCache === true) {
-    await module.exports.loadBot();
+    await module.exports.loadBot(resetCache);
   }
   // @see https://github.com/aichaos/rivescript-js/blob/master/docs/rivescript.md#data-deparse
   return rivescript.getBot().deparse();
 }
 
 /**
+ * @param {Boolean} resetCache
  * @return {Promise}
  */
-async function getRivescripts() {
+async function getRivescripts(resetCache = false) {
   logger.debug('getRivescripts');
+  if (resetCache === true) {
+    logger.debug('rivescript cache clear');
+    return module.exports.fetchRivescripts();
+  }
   const cache = await helpers.cache.rivescript.get(cacheKey);
   if (cache) {
     logger.debug('rivescript cache hit');
     return cache;
   }
+  logger.debug('rivescript cache miss');
+  return module.exports.fetchRivescripts();
+}
 
-  // TODO: Check our fetchResponse.meta to determine whether to fetch more triggers.
+/**
+ * @return {Promise}
+ */
+function fetchRivescripts() {
   return gambitCampaigns.fetchDefaultTopicTriggers()
+    // TODO: Check our res.meta to determine whether to fetch more triggers.
     .then((res) => {
       logger.debug('fetchDefaultTopicTriggers success', { count: res.data.length });
       return res.data.map(module.exports.parseRivescript);
@@ -128,10 +140,11 @@ function joinRivescriptLines(lines) {
 }
 
 /**
+ * @param {Boolean} resetCache
  * @return {Promise}
  */
-function loadBot() {
-  return module.exports.getRivescripts()
+function loadBot(resetCache = false) {
+  return module.exports.getRivescripts(resetCache)
     .then(rivescripts => rivescript.loadBotWithRivescripts(rivescripts));
 }
 
@@ -167,6 +180,7 @@ function parseAskYesNoResponse(messageText) {
 }
 
 module.exports = {
+  fetchRivescripts,
   formatRivescriptLine,
   getBotReply,
   getDeparsedRivescript,


### PR DESCRIPTION
#### What's this PR do?

This PR passes a `true` resetCache arg from the `helpers.rivescript.getDeparsedRivescript` to the `helpers.rivescript.loadBot`, to force fetching Rivescript from the Content API and make the cache clear parameter actually work 🤦‍♂️ 

This PR also passes a `cache` query parameter in a `GET /defaultTopicTriggers` request to the Content API, which will need to be implemented in order to truly refresh the bot with the latest default topic triggers upon a Rivescript cache clear.

#### How should this be reviewed?

I've been modifying the response of our [test "puppetsloth" trigger](https://app.contentful.com/spaces/owik07lyerdj/entries/1DiZPY8uyEWg0mSeWQkuEk) to verify expected behavior, but it'll be a bit more straight forward to test once a cache clear parameter is [introduced in Content API](https://github.com/DoSomething/gambit-campaigns/blob/master/documentation/endpoints/defaultTopicTriggers.md), as currently the steps to replicate locally are trickier when both apps share same redis instance.

#### Any background context you want to provide?

Once we deploy our new release with cached Rivescript in redis, we'll eventually remove the cached list of all defaultTopicTriggers in the Content API to avoid unnecessary complexities.

#### Relevant tickets
https://www.pivotaltracker.com/story/show/158037562

#### Checklist
- [x] Tests added for new features/bug fixes.
- [x] Tested on staging.
