### PR TITLE
Reload bot when cached Rivescript does not match current Rivescript

### DIFF
--- a/lib/helpers/rivescript.js
+++ b/lib/helpers/rivescript.js
@@ -160,7 +160,7 @@ function loadBot(resetCache = false) {
  * @return {Promise<boolean>}
  */
 async function isBotCurrent() {
-  if (!rivescript.ready) {
+  if (!rivescript.isReady()) {
     return false;
   }
   const cache = await helpers.cache.rivescript.get(cacheKey);

--- a/lib/helpers/rivescript.js
+++ b/lib/helpers/rivescript.js
@@ -10,19 +10,9 @@ const config = require('../../config/lib/helpers/rivescript');
 const cacheKey = config.cacheKey;
 
 /**
- * @param {Boolean} resetCache
- * @return {Promise}
+ * @return {Object}
  */
-async function getDeparsedRivescript(resetCache = false) {
-  if (resetCache === true) {
-    await module.exports.loadBot(true);
-  } else {
-    const isCurrent = await module.exports.isBotCurrent();
-    if (isCurrent === false) {
-      await module.exports.loadBot();
-    }
-  }
-
+function getDeparsedRivescript() {
   // @see https://github.com/aichaos/rivescript-js/blob/master/docs/rivescript.md#data-deparse
   return rivescript.getBot().deparse();
 }
@@ -156,19 +146,23 @@ function loadBot(resetCache = false) {
 }
 
 /**
+ * @return {Boolean}
+ */
+function isBotReady() {
+  return rivescript.isReady();
+}
+
+/**
  * @return {Promise}
  */
-async function isBotCurrent() {
-  if (!rivescript.isReady()) {
-    return false;
-  }
+async function isRivescriptCurrent() {
   const cache = await helpers.cache.rivescript.get(cacheKey);
   if (!cache) {
-    logger.debug('isBotCurrent rivescript cache miss');
+    logger.debug('isRivescriptCurrent cache miss');
     return false;
   }
   const result = underscore.isEqual(cache, rivescript.getAdditionalRivescripts());
-  logger.debug('isBotCurrent', { result });
+  logger.debug('isRivescriptCurrent', { result });
   return result;
 }
 
@@ -179,8 +173,8 @@ async function isBotCurrent() {
  * @return {Promise}
  */
 async function getBotReply(userId, topicId, messageText) {
-  const isCurrent = await module.exports.isBotCurrent();
-  if (isCurrent === false) {
+  const isCurrent = await module.exports.isRivescriptCurrent();
+  if (!isCurrent) {
     await module.exports.loadBot();
   }
 
@@ -209,7 +203,8 @@ module.exports = {
   getRivescriptFromDefaultTopicTrigger,
   getRivescriptFromTriggerTextAndRivescriptLine,
   getRivescripts,
-  isBotCurrent,
+  isBotReady,
+  isRivescriptCurrent,
   joinRivescriptLines,
   loadBot,
   parseAskYesNoResponse,

--- a/lib/helpers/rivescript.js
+++ b/lib/helpers/rivescript.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const underscore = require('underscore');
 const helpers = require('../helpers');
 const logger = require('../logger');
 const gambitCampaigns = require('../gambit-campaigns');
@@ -13,9 +14,15 @@ const cacheKey = config.cacheKey;
  * @return {Promise}
  */
 async function getDeparsedRivescript(resetCache = false) {
-  if (!rivescript.isReady() || resetCache === true) {
-    await module.exports.loadBot(resetCache);
+  if (resetCache === true) {
+    await module.exports.loadBot(true);
+  } else {
+    const isCurrent = await module.exports.isBotCurrent();
+    if (isCurrent === false) {
+      await module.exports.loadBot();
+    }
   }
+
   // @see https://github.com/aichaos/rivescript-js/blob/master/docs/rivescript.md#data-deparse
   return rivescript.getBot().deparse();
 }
@@ -149,19 +156,33 @@ function loadBot(resetCache = false) {
 }
 
 /**
+ * @async
+ * @return {Promise<boolean>}
+ */
+async function isBotCurrent() {
+  if (!rivescript.ready) {
+    return false;
+  }
+  const cache = await helpers.cache.rivescript.get(cacheKey);
+  if (!cache) {
+    logger.debug('isBotCurrent rivescript cache miss');
+    return false;
+  }
+  const result = underscore.isEqual(cache, rivescript.getAdditionalRivescripts());
+  logger.debug('isBotCurrent', { result });
+  return result;
+}
+
+/**
  * @param {String} userId
  * @param {String} topicId
  * @param {String} messageText
  * @return {Promise}
  */
 async function getBotReply(userId, topicId, messageText) {
-  if (!rivescript.isReady()) {
+  const isCurrent = await module.exports.isBotCurrent();
+  if (isCurrent === false) {
     await module.exports.loadBot();
-  } else {
-    const cache = await helpers.cache.rivescript.get(cacheKey);
-    if (!cache) {
-      await module.exports.loadBot();
-    }
   }
 
   // If Rivescript bot receives a message in a topic that it doesn't know about, it logs a
@@ -189,6 +210,7 @@ module.exports = {
   getRivescriptFromDefaultTopicTrigger,
   getRivescriptFromTriggerTextAndRivescriptLine,
   getRivescripts,
+  isBotCurrent,
   joinRivescriptLines,
   loadBot,
   parseAskYesNoResponse,

--- a/lib/helpers/rivescript.js
+++ b/lib/helpers/rivescript.js
@@ -156,8 +156,7 @@ function loadBot(resetCache = false) {
 }
 
 /**
- * @async
- * @return {Promise<boolean>}
+ * @return {Promise}
  */
 async function isBotCurrent() {
   if (!rivescript.isReady()) {

--- a/lib/middleware/rivescript/index.js
+++ b/lib/middleware/rivescript/index.js
@@ -4,15 +4,22 @@ const helpers = require('../../helpers');
 const logger = require('../../logger');
 
 module.exports = function getRivescript() {
-  return (req, res) => {
-    const resetCache = req.query.cache === 'false';
-
-    return helpers.rivescript.getDeparsedRivescript(resetCache)
-      .then((data) => {
-        const triggers = data.topics.random;
-        logger.debug('data.topics.random', { count: triggers.length });
-        return res.send({ data });
-      })
-      .catch(err => helpers.sendErrorResponse(res, err));
+  return async (req, res) => {
+    try {
+      const resetCache = req.query.cache === 'false';
+      if (resetCache === true || !helpers.rivescript.isBotReady()) {
+        await helpers.rivescript.loadBot(resetCache);
+      } else {
+        const isCurrent = helpers.rivescript.isRivescriptCurrent();
+        if (!isCurrent) {
+          await helpers.rivescript.loadBot();
+        }
+      }
+      const data = helpers.rivescript.getDeparsedRivescript();
+      logger.debug('data.topics.random', { count: data.topics.random.length });
+      return res.send({ data });
+    } catch (err) {
+      return helpers.sendErrorResponse(res, err);
+    }
   };
 };

--- a/lib/rivescript.js
+++ b/lib/rivescript.js
@@ -19,6 +19,9 @@ function createNewBot() {
   }
 }
 
+/**
+ * @return {Array}
+ */
 function getAdditionalRivescripts() {
   return additionalRivescripts;
 }
@@ -45,7 +48,7 @@ function logStreamError(error) {
 /**
  * @return {Promise}
  */
-function streamAndSortRepliesWithRivescripts() {
+function streamAndSortReplies() {
   // @see https://github.com/aichaos/rivescript-js/blob/master/docs/rivescript.md#bool-stream-string-code-func-onerror
   additionalRivescripts.forEach(item => brain.stream(item, logStreamError));
   logger.info('rivescript.brain.stream success');
@@ -69,12 +72,15 @@ function isReady() {
  * @param {Array} rivescripts - Rivescript parsed from the Content API
  */
 function loadBotWithRivescripts(rivescripts) {
+  if (!rivescripts || rivescripts.length === 0) {
+    return Promise.reject(new Error('loadBotWithRivescripts missing required rivescripts arg'));
+  }
   logger.debug('loadBotWithRivescripts');
   additionalRivescripts = rivescripts;
   // Purge all loaded Rivescript.
   createNewBot();
   return brain.loadDirectory(config.directory)
-    .then(() => streamAndSortRepliesWithRivescripts());
+    .then(() => module.exports.streamAndSortReplies());
 }
 
 /**
@@ -114,4 +120,5 @@ module.exports = {
   getBotReply,
   isReady,
   loadBotWithRivescripts,
+  streamAndSortReplies,
 };

--- a/lib/rivescript.js
+++ b/lib/rivescript.js
@@ -4,6 +4,7 @@ const RiveScript = require('rivescript');
 const logger = require('./logger');
 const config = require('../config/lib/rivescript');
 
+let additionalRivescripts;
 let brain;
 let hasSortedReplies;
 
@@ -16,6 +17,10 @@ function createNewBot() {
     logger.error('createNewBot error', err);
     throw new Error(err.message);
   }
+}
+
+function getAdditionalRivescripts() {
+  return additionalRivescripts;
 }
 
 /**
@@ -38,15 +43,16 @@ function logStreamError(error) {
 }
 
 /**
- * @param {Array} rivescripts
+ * @return {Promise}
  */
-function streamAndSortRepliesWithRivescripts(rivescripts) {
+function streamAndSortRepliesWithRivescripts() {
   // @see https://github.com/aichaos/rivescript-js/blob/master/docs/rivescript.md#bool-stream-string-code-func-onerror
-  rivescripts.forEach(item => brain.stream(item, logStreamError));
+  additionalRivescripts.forEach(item => brain.stream(item, logStreamError));
   logger.info('rivescript.brain.stream success');
   brain.sortReplies();
   logger.info('rivescript.brain.sortReplies success');
   hasSortedReplies = true;
+  return Promise.resolve();
 }
 
 /**
@@ -60,15 +66,15 @@ function isReady() {
  * Creates a Rivescript bot and loads it with our hardcoded rivescript as well as rivescripts passed
  * in a rivescripts array property.
  *
- * TODO: Don't provide an empty array, return a rejected error.
  * @param {Array} rivescripts - Rivescript parsed from the Content API
  */
-function loadBotWithRivescripts(rivescripts = []) {
+function loadBotWithRivescripts(rivescripts) {
   logger.debug('loadBotWithRivescripts');
+  additionalRivescripts = rivescripts;
   // Purge all loaded Rivescript.
   createNewBot();
   return brain.loadDirectory(config.directory)
-    .then(() => streamAndSortRepliesWithRivescripts(rivescripts));
+    .then(() => streamAndSortRepliesWithRivescripts());
 }
 
 /**
@@ -103,6 +109,7 @@ async function getBotReply(userId, topicId, messageText) {
 }
 
 module.exports = {
+  getAdditionalRivescripts,
   getBot,
   getBotReply,
   isReady,

--- a/lib/rivescript.js
+++ b/lib/rivescript.js
@@ -71,16 +71,18 @@ function isReady() {
  *
  * @param {Array} rivescripts - Rivescript parsed from the Content API
  */
-function loadBotWithRivescripts(rivescripts) {
+async function loadBotWithRivescripts(rivescripts) {
   if (!rivescripts || rivescripts.length === 0) {
-    return Promise.reject(new Error('loadBotWithRivescripts missing required rivescripts arg'));
+    throw new Error('loadBotWithRivescripts missing required rivescripts arg');
   }
   logger.debug('loadBotWithRivescripts');
-  additionalRivescripts = rivescripts;
   // Purge all loaded Rivescript.
   createNewBot();
-  return brain.loadDirectory(config.directory)
-    .then(() => module.exports.streamAndSortReplies());
+  // Loaded hardcoded Rivescript.
+  await brain.loadDirectory(config.directory);
+  // Stream and sort additonal Rivescript.
+  additionalRivescripts = rivescripts;
+  return module.exports.streamAndSortReplies();
 }
 
 /**

--- a/test/unit/lib/lib-helpers/rivescript.test.js
+++ b/test/unit/lib/lib-helpers/rivescript.test.js
@@ -43,7 +43,7 @@ test.afterEach(() => {
 
 // getBotReply
 test('getBotReply should call loadBot if bot is not current', async () => {
-  sandbox.stub(rivescriptHelper, 'isBotCurrent')
+  sandbox.stub(rivescriptHelper, 'isRivescriptCurrent')
     .returns(Promise.resolve(false));
   sandbox.stub(rivescriptHelper, 'loadBot')
     .returns(Promise.resolve(true));
@@ -56,7 +56,7 @@ test('getBotReply should call loadBot if bot is not current', async () => {
 });
 
 test('getBotReply does not call loadBot if bot is current', async () => {
-  sandbox.stub(rivescriptHelper, 'isBotCurrent')
+  sandbox.stub(rivescriptHelper, 'isRivescriptCurrent')
     .returns(Promise.resolve(true));
   sandbox.stub(rivescriptHelper, 'loadBot')
     .returns(Promise.resolve(true));
@@ -69,11 +69,7 @@ test('getBotReply does not call loadBot if bot is current', async () => {
 });
 
 // getDeparsedRivescript
-test('getDeparsedRivescript should call loadBot if bot is not current', async () => {
-  sandbox.stub(rivescriptHelper, 'isBotCurrent')
-    .returns(Promise.resolve(false));
-  sandbox.stub(rivescriptHelper, 'loadBot')
-    .returns(Promise.resolve(true));
+test('getDeparsedRivescript should call Rivescript getBot.deparse', () => {
   sandbox.stub(rivescriptApi, 'getBot')
     .callsFake(() => ({
       deparse: () => { // eslint-disable-line arrow-body-style
@@ -81,42 +77,7 @@ test('getDeparsedRivescript should call loadBot if bot is not current', async ()
       },
     }));
 
-  const result = await rivescriptHelper.getDeparsedRivescript();
-  rivescriptHelper.loadBot.should.have.been.called;
-  result.should.deep.equal(mockDeparsedRivescript);
-});
-
-test('getDeparsedRivescript should call loadBot if resetCache arg is true', async () => {
-  sandbox.stub(rivescriptHelper, 'isBotCurrent')
-    .returns(Promise.resolve(true));
-  sandbox.stub(rivescriptHelper, 'loadBot')
-    .returns(Promise.resolve(true));
-  sandbox.stub(rivescriptApi, 'getBot')
-    .callsFake(() => ({
-      deparse: () => { // eslint-disable-line arrow-body-style
-        return mockDeparsedRivescript;
-      },
-    }));
-
-  const result = await rivescriptHelper.getDeparsedRivescript(true);
-  rivescriptHelper.loadBot.should.have.been.calledWith(true);
-  result.should.deep.equal(mockDeparsedRivescript);
-});
-
-test('getDeparsedRivescript does not call loadBot if bot is current', async () => {
-  sandbox.stub(rivescriptHelper, 'isBotCurrent')
-    .returns(Promise.resolve(true));
-  sandbox.stub(rivescriptHelper, 'loadBot')
-    .returns(Promise.resolve(true));
-  sandbox.stub(rivescriptApi, 'getBot')
-    .callsFake(() => ({
-      deparse: () => { // eslint-disable-line arrow-body-style
-        return mockDeparsedRivescript;
-      },
-    }));
-
-  const result = await rivescriptHelper.getDeparsedRivescript();
-  rivescriptHelper.loadBot.should.not.have.been.called;
+  const result = rivescriptHelper.getDeparsedRivescript();
   result.should.deep.equal(mockDeparsedRivescript);
 });
 
@@ -274,24 +235,24 @@ test('getRivescriptFromDefaultTopicTrigger returns replyRivescript if defaultTop
   result.should.equal(mockRivescript);
 });
 
-// isBotCurrent
-test('isBotCurrent returns false if rivescript not ready', async () => {
+// isRivescriptCurrent
+test('isRivescriptCurrent returns false if rivescript not ready', async () => {
   sandbox.stub(rivescriptApi, 'isReady')
     .returns(false);
-  const result = await rivescriptHelper.isBotCurrent();
+  const result = await rivescriptHelper.isRivescriptCurrent();
   result.should.equal(false);
 });
 
-test('isBotCurrent returns false if rivescript cache is not set', async () => {
+test('isRivescriptCurrent returns false if rivescript cache is not set', async () => {
   sandbox.stub(rivescriptApi, 'isReady')
     .returns(true);
   sandbox.stub(helpers.cache.rivescript, 'get')
     .returns(Promise.resolve(null));
-  const result = await rivescriptHelper.isBotCurrent();
+  const result = await rivescriptHelper.isRivescriptCurrent();
   result.should.equal(false);
 });
 
-test('isBotCurrent returns true if cache is equal to additionalRivescripts and rivescript is ready', async () => {
+test('isRivescriptCurrent returns true if cache is equal to additionalRivescripts and rivescript is ready', async () => {
   const rivescripts = [mockRivescript, mockRivescript];
   sandbox.stub(rivescriptApi, 'isReady')
     .returns(true);
@@ -299,11 +260,11 @@ test('isBotCurrent returns true if cache is equal to additionalRivescripts and r
     .returns(Promise.resolve(rivescripts));
   sandbox.stub(rivescriptApi, 'getAdditionalRivescripts')
     .returns(rivescripts);
-  const result = await rivescriptHelper.isBotCurrent();
+  const result = await rivescriptHelper.isRivescriptCurrent();
   result.should.equal(true);
 });
 
-test('isBotCurrent returns false if cache is not equal to additionalRivescripts and rivescript is ready', async () => {
+test('isRivescriptCurrent returns false if cache is not equal to additionalRivescripts and rivescript is ready', async () => {
   const rivescripts = [mockRivescript, mockRivescript];
   sandbox.stub(rivescriptApi, 'isReady')
     .returns(true);
@@ -311,7 +272,7 @@ test('isBotCurrent returns false if cache is not equal to additionalRivescripts 
     .returns(Promise.resolve([mockRivescript]));
   sandbox.stub(rivescriptApi, 'getAdditionalRivescripts')
     .returns(rivescripts);
-  const result = await rivescriptHelper.isBotCurrent();
+  const result = await rivescriptHelper.isRivescriptCurrent();
   result.should.equal(false);
 });
 

--- a/test/unit/lib/lib-helpers/rivescript.test.js
+++ b/test/unit/lib/lib-helpers/rivescript.test.js
@@ -42,7 +42,7 @@ test.afterEach(() => {
 });
 
 // getBotReply
-test('getBotReply should call loadBot if bot is not current', async () => {
+test('getBotReply should call loadBot if Rivescript is not current', async () => {
   sandbox.stub(rivescriptHelper, 'isRivescriptCurrent')
     .returns(Promise.resolve(false));
   sandbox.stub(rivescriptHelper, 'loadBot')
@@ -55,7 +55,7 @@ test('getBotReply should call loadBot if bot is not current', async () => {
   result.should.deep.equal(mockRivescriptReply);
 });
 
-test('getBotReply does not call loadBot if bot is current', async () => {
+test('getBotReply does not call loadBot if Rivescript is current', async () => {
   sandbox.stub(rivescriptHelper, 'isRivescriptCurrent')
     .returns(Promise.resolve(true));
   sandbox.stub(rivescriptHelper, 'loadBot')
@@ -235,17 +235,23 @@ test('getRivescriptFromDefaultTopicTrigger returns replyRivescript if defaultTop
   result.should.equal(mockRivescript);
 });
 
-// isRivescriptCurrent
-test('isRivescriptCurrent returns false if rivescript not ready', async () => {
+// isBotReady
+test('isBotReady returns false if not rivescript.isReady', async () => {
   sandbox.stub(rivescriptApi, 'isReady')
     .returns(false);
-  const result = await rivescriptHelper.isRivescriptCurrent();
+  const result = await rivescriptHelper.isBotReady();
   result.should.equal(false);
 });
 
-test('isRivescriptCurrent returns false if rivescript cache is not set', async () => {
+test('isBotReady returns true if rivescript.isReady', async () => {
   sandbox.stub(rivescriptApi, 'isReady')
     .returns(true);
+  const result = await rivescriptHelper.isBotReady();
+  result.should.equal(true);
+});
+
+// isRivescriptCurrent
+test('isRivescriptCurrent returns false if rivescript cache is not set', async () => {
   sandbox.stub(helpers.cache.rivescript, 'get')
     .returns(Promise.resolve(null));
   const result = await rivescriptHelper.isRivescriptCurrent();
@@ -254,8 +260,6 @@ test('isRivescriptCurrent returns false if rivescript cache is not set', async (
 
 test('isRivescriptCurrent returns true if cache is equal to additionalRivescripts and rivescript is ready', async () => {
   const rivescripts = [mockRivescript, mockRivescript];
-  sandbox.stub(rivescriptApi, 'isReady')
-    .returns(true);
   sandbox.stub(helpers.cache.rivescript, 'get')
     .returns(Promise.resolve(rivescripts));
   sandbox.stub(rivescriptApi, 'getAdditionalRivescripts')
@@ -266,8 +270,6 @@ test('isRivescriptCurrent returns true if cache is equal to additionalRivescript
 
 test('isRivescriptCurrent returns false if cache is not equal to additionalRivescripts and rivescript is ready', async () => {
   const rivescripts = [mockRivescript, mockRivescript];
-  sandbox.stub(rivescriptApi, 'isReady')
-    .returns(true);
   sandbox.stub(helpers.cache.rivescript, 'get')
     .returns(Promise.resolve([mockRivescript]));
   sandbox.stub(rivescriptApi, 'getAdditionalRivescripts')

--- a/test/unit/lib/lib-helpers/rivescript.test.js
+++ b/test/unit/lib/lib-helpers/rivescript.test.js
@@ -42,25 +42,8 @@ test.afterEach(() => {
 });
 
 // getBotReply
-test('getBotReply should call loadBot if rivescript is not ready', async () => {
-  sandbox.stub(helpers.cache.rivescript, 'get')
-    .returns(Promise.resolve(true));
-  sandbox.stub(rivescriptApi, 'isReady')
-    .returns(false);
-  sandbox.stub(rivescriptHelper, 'loadBot')
-    .returns(Promise.resolve(true));
-  sandbox.stub(rivescriptApi, 'getBotReply')
-    .returns(Promise.resolve(mockRivescriptReply));
-
-  const result = await rivescriptHelper.getBotReply();
-  rivescriptHelper.loadBot.should.have.been.called;
-  result.should.deep.equal(mockRivescriptReply);
-});
-
-test('getBotReply should call loadBot if rivescript is ready but cache is not set', async () => {
-  sandbox.stub(rivescriptApi, 'isReady')
-    .returns(true);
-  sandbox.stub(helpers.cache.rivescript, 'get')
+test('getBotReply should call loadBot if bot is not current', async () => {
+  sandbox.stub(rivescriptHelper, 'isBotCurrent')
     .returns(Promise.resolve(false));
   sandbox.stub(rivescriptHelper, 'loadBot')
     .returns(Promise.resolve(true));
@@ -72,10 +55,8 @@ test('getBotReply should call loadBot if rivescript is ready but cache is not se
   result.should.deep.equal(mockRivescriptReply);
 });
 
-test('getBotReply does not call loadBot if rivescript is ready adn cache is set', async () => {
-  sandbox.stub(rivescriptApi, 'isReady')
-    .returns(true);
-  sandbox.stub(helpers.cache.rivescript, 'get')
+test('getBotReply does not call loadBot if bot is current', async () => {
+  sandbox.stub(rivescriptHelper, 'isBotCurrent')
     .returns(Promise.resolve(true));
   sandbox.stub(rivescriptHelper, 'loadBot')
     .returns(Promise.resolve(true));
@@ -88,9 +69,9 @@ test('getBotReply does not call loadBot if rivescript is ready adn cache is set'
 });
 
 // getDeparsedRivescript
-test('getDeparsedRivescript should call loadBot if rivescript is not ready', async () => {
-  sandbox.stub(rivescriptApi, 'isReady')
-    .returns(false);
+test('getDeparsedRivescript should call loadBot if bot is not current', async () => {
+  sandbox.stub(rivescriptHelper, 'isBotCurrent')
+    .returns(Promise.resolve(false));
   sandbox.stub(rivescriptHelper, 'loadBot')
     .returns(Promise.resolve(true));
   sandbox.stub(rivescriptApi, 'getBot')
@@ -106,8 +87,8 @@ test('getDeparsedRivescript should call loadBot if rivescript is not ready', asy
 });
 
 test('getDeparsedRivescript should call loadBot if resetCache arg is true', async () => {
-  sandbox.stub(rivescriptApi, 'isReady')
-    .returns(true);
+  sandbox.stub(rivescriptHelper, 'isBotCurrent')
+    .returns(Promise.resolve(true));
   sandbox.stub(rivescriptHelper, 'loadBot')
     .returns(Promise.resolve(true));
   sandbox.stub(rivescriptApi, 'getBot')
@@ -122,9 +103,9 @@ test('getDeparsedRivescript should call loadBot if resetCache arg is true', asyn
   result.should.deep.equal(mockDeparsedRivescript);
 });
 
-test('getDeparsedRivescript does not call loadBot if rivescript is ready', async () => {
-  sandbox.stub(rivescriptApi, 'isReady')
-    .returns(true);
+test('getDeparsedRivescript does not call loadBot if bot is current', async () => {
+  sandbox.stub(rivescriptHelper, 'isBotCurrent')
+    .returns(Promise.resolve(true));
   sandbox.stub(rivescriptHelper, 'loadBot')
     .returns(Promise.resolve(true));
   sandbox.stub(rivescriptApi, 'getBot')

--- a/test/unit/lib/lib-helpers/rivescript.test.js
+++ b/test/unit/lib/lib-helpers/rivescript.test.js
@@ -274,6 +274,47 @@ test('getRivescriptFromDefaultTopicTrigger returns replyRivescript if defaultTop
   result.should.equal(mockRivescript);
 });
 
+// isBotCurrent
+test('isBotCurrent returns false if rivescript not ready', async () => {
+  sandbox.stub(rivescriptApi, 'isReady')
+    .returns(false);
+  const result = await rivescriptHelper.isBotCurrent();
+  result.should.equal(false);
+});
+
+test('isBotCurrent returns false if rivescript cache is not set', async () => {
+  sandbox.stub(rivescriptApi, 'isReady')
+    .returns(true);
+  sandbox.stub(helpers.cache.rivescript, 'get')
+    .returns(Promise.resolve(null));
+  const result = await rivescriptHelper.isBotCurrent();
+  result.should.equal(false);
+});
+
+test('isBotCurrent returns true if cache is equal to additionalRivescripts and rivescript is ready', async () => {
+  const rivescripts = [mockRivescript, mockRivescript];
+  sandbox.stub(rivescriptApi, 'isReady')
+    .returns(true);
+  sandbox.stub(helpers.cache.rivescript, 'get')
+    .returns(Promise.resolve(rivescripts));
+  sandbox.stub(rivescriptApi, 'getAdditionalRivescripts')
+    .returns(rivescripts);
+  const result = await rivescriptHelper.isBotCurrent();
+  result.should.equal(true);
+});
+
+test('isBotCurrent returns false if cache is not equal to additionalRivescripts and rivescript is ready', async () => {
+  const rivescripts = [mockRivescript, mockRivescript];
+  sandbox.stub(rivescriptApi, 'isReady')
+    .returns(true);
+  sandbox.stub(helpers.cache.rivescript, 'get')
+    .returns(Promise.resolve([mockRivescript]));
+  sandbox.stub(rivescriptApi, 'getAdditionalRivescripts')
+    .returns(rivescripts);
+  const result = await rivescriptHelper.isBotCurrent();
+  result.should.equal(false);
+});
+
 // joinRivescriptLines
 test('joinRivescriptLines returns input array joined by the config line separator', () => {
   const lines = [mockRivescript, mockRivescript, mockRivescript];

--- a/test/unit/lib/rivescript.test.js
+++ b/test/unit/lib/rivescript.test.js
@@ -27,10 +27,20 @@ const messageText = stubs.getRandomMessageText();
 
 test.afterEach(() => {
   sandbox.restore();
+  rivescript.__set__('additionalRivescripts', undefined);
   rivescript.__set__('brain', undefined);
   rivescript.__set__('config', config);
   rivescript.__set__('hasSortedReplies', false);
   rivescript.__set__('RiveScript', undefined);
+});
+
+// getAdditionalRivescripts
+test('getAdditionalRivescripts should return additionalRivescripts const', () => {
+  const data = ['123', '456'];
+  rivescript.__set__('additionalRivescripts', data);
+
+  const result = rivescript.getAdditionalRivescripts();
+  result.should.deep.equal(data);
 });
 
 // getBot
@@ -88,4 +98,23 @@ test('isReady should return hasSortedReplies', (t) => {
   t.falsy(rivescript.isReady());
   rivescript.__set__('hasSortedReplies', true);
   t.truthy(rivescript.isReady());
+});
+
+// loadBotWithRivescripts
+test('loadBotWithRivescripts should return error if rivescripts arg is not passsed', async (t) => {
+  await t.throws(rivescript.loadBotWithRivescripts());
+});
+
+test('loadBotWithRivescripts should call createNewBot', async () => {
+  const rivescripts = ['123'];
+  const createNewBotSpy = sandbox.spy();
+  rivescript.__set__('createNewBot', createNewBotSpy);
+  rivescript.__set__('brain', {
+    loadDirectory: () => Promise.resolve(),
+  });
+  sandbox.stub(rivescript, 'streamAndSortReplies')
+    .returns(Promise.resolve());
+  await rivescript.loadBotWithRivescripts(rivescripts);
+  createNewBotSpy.should.have.been.called;
+  rivescript.streamAndSortReplies.should.have.been.called;
 });


### PR DESCRIPTION
#### What's this PR do?

Fixes #398 by saving our `additionalRivescript` data from the Content API to memory, in checking whether it matches the cached Rivescript whenever a `GET /rivescript` or `POST /messages?origin=member` request is received.

#### How should this be reviewed?

I've been testing by editing our dev test trigger, puppetsloth, and verifying that a `GET /rivescript?cache=false` refreshes the cache, and that subsequent requests without the cache param (or for member messages) return the updated reply copy. Will deploy to staging to verify that each subsequent `GET /rivescript` request returns the updated reply, as each dyno will check to see whether the saved `additionalRivescript` const is equal to the cached Rivescript value.

#### Any background context you want to provide?
Unblocks deploy of next release with Redis caching.

#### Relevant tickets
Fixes https://www.pivotaltracker.com/story/show/158037562 and 

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [x] Tests added for new features/bug fixes.
- [x] Tested on staging.
