### PR TITLE
Adds twilioStudio origin to POST /v2/messages

### DIFF
--- a/config/lib/helpers/request.js
+++ b/config/lib/helpers/request.js
@@ -1,0 +1,8 @@
+'use strict';
+
+module.exports = {
+  origin: {
+    twilio: 'twilio',
+    twilioStudio: 'twilioStudio',
+  },
+};

--- a/documentation/endpoints/messages.md
+++ b/documentation/endpoints/messages.md
@@ -506,3 +506,64 @@ curl -X "POST" "http://localhost:5100/api/v2/messages?origin=gambit-slack" \
 }
 ```
 </details>
+
+## Twilio Studio
+
+```
+POST /v2/messages?origin=twilioStudio
+```
+ 
+ Receives an inbound Twilio message, and returns the corresponding Northstar user and Rivescript reply. This used by Twilio Functions via a Twilio Studio flow prototyping Gambit integration -- see [pull#404](https://github.com/DoSomething/gambit-conversations/pull/404)
+
+* Creates a new Northstar User if it doesn't exist for the sender.
+
+* Does not create any documents in the `messages` collection for now, as outbound messages are sent via the Twilio Studio flow that use the Functions that post here.
+
+### Input
+
+See https://www.twilio.com/docs/api/messaging/message.
+
+<details>
+<summary><strong>Example Request</strong></summary>
+
+```
+curl -X "POST" "http://localhost:5100/api/v2/messages?origin=twilioStudio" \
+     -H "Content-Type: application/json; charset=utf-8" \
+     -u puppet:totallysecret \
+     -d $'{
+  "MessageSid": "MM09a8f657567f807443191c1e7exxxxxx",
+  "MediaUrl0": "http://www.fillmurray.com/g/200/300",
+  "From":  "+5555555555",
+  "Body": "hi",
+  "MediaContentType0": "image/png"
+}'
+
+```
+
+</details>
+
+<details>
+<summary><strong>Example Response</strong></summary>
+
+```
+{
+  "user": {
+    "id": "5547be89469c64ec7d8b518d",
+    ...
+    "last_authenticated_at": "2018-09-07T20:01:28+00:00",
+    "last_messaged_at": "2018-09-19T04:48:39+00:00",
+    "updated_at": "2018-09-19T04:48:39+00:00",
+    "created_at": "2013-01-23T02:47:30+00:00"
+  },
+  "reply": {
+    "text": "Thanks for your interest in DoSomething Strategic's newsletter, 'Til Next Tuesday! Trust us, it's way less boring than the other ones you get. Text back your email to sign up now.",
+    "match": "tmi",
+    "topic": {
+      "id": "tmi_level1",
+      "type": "rivescript",
+      "name": "tmi_level1"
+    }
+  }
+}
+```
+</details>

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -6,12 +6,13 @@ const logger = require('./logger');
 const config = require('../config/lib/helpers');
 const helpers = require('./helpers/index');
 
-// TODO: Move contents of this helper.js file into lib/helpers/index.js or to modular helpers
 
 // register helpers
 Object.keys(helpers).forEach((helperName) => {
   module.exports[helperName] = helpers[helperName];
 });
+
+// TODO: Move functions below into lib/helpers/response.js
 
 /**
  * Sends response with err code and message.

--- a/lib/helpers/index.js
+++ b/lib/helpers/index.js
@@ -9,6 +9,7 @@ const front = require('./front');
 const macro = require('./macro');
 const request = require('./request');
 const replies = require('./replies');
+const response = require('./response');
 const rivescript = require('./rivescript');
 const tags = require('./tags');
 const template = require('./template');
@@ -30,6 +31,7 @@ module.exports = {
   macro,
   request,
   replies,
+  response,
   rivescript,
   tags,
   template,

--- a/lib/helpers/request.js
+++ b/lib/helpers/request.js
@@ -6,6 +6,8 @@ const logger = require('../logger');
 const analytics = require('./analytics');
 const UnprocessibleEntityError = require('../../app/exceptions/UnprocessibleEntityError');
 
+const config = require('../../config/lib/helpers/request');
+
 /**
  * Updates conversation with given topic, and updates user subscription status to pending if
  * the new topic is an askSubscriptionStatus.
@@ -210,7 +212,7 @@ function isLastOutboundTopicTemplate(req) {
  * @return {Boolean}
  */
 function isTwilio(req) {
-  return req.query.origin === 'twilio' || module.exports.isTwilioStudio(req);
+  return req.query.origin === config.origin.twilio || module.exports.isTwilioStudio(req);
 }
 
 /**
@@ -218,7 +220,7 @@ function isTwilio(req) {
  * @return {Boolean}
  */
 function isTwilioStudio(req) {
-  return req.query.origin === 'twilioStudio';
+  return req.query.origin === config.origin.twilioStudio;
 }
 
 /**

--- a/lib/helpers/request.js
+++ b/lib/helpers/request.js
@@ -206,6 +206,22 @@ function isLastOutboundTopicTemplate(req) {
 }
 
 /**
+ * @param {Object} req
+ * @return {Boolean}
+ */
+function isTwilio(req) {
+  return req.query.origin === 'twilio' || module.exports.isTwilioStudio(req);
+}
+
+/**
+ * @param {Object} req
+ * @return {Boolean}
+ */
+function isTwilioStudio(req) {
+  return req.query.origin === 'twilioStudio';
+}
+
+/**
  * Updates req.macro to saidYes or saidNo if inbound message can be parsed as either.
  *
  * @async
@@ -324,9 +340,8 @@ module.exports = {
   isLastOutboundTopicTemplate,
   isSaidNoMacro,
   isSaidYesMacro,
-  isTwilio: function isTwilio(req) {
-    return req.query.origin === 'twilio';
-  },
+  isTwilio,
+  isTwilioStudio,
   parseAskYesNoResponse,
   postCampaignActivity,
   setBroadcastId: function setBroadcastId(req, broadcastId) {

--- a/lib/helpers/response.js
+++ b/lib/helpers/response.js
@@ -1,0 +1,12 @@
+'use strict';
+
+/**
+ * Sends response with an object and given data property
+ */
+function sendData(res, data) {
+  return res.send({ data });
+}
+
+module.exports = {
+  sendData,
+};

--- a/lib/helpers/response.js
+++ b/lib/helpers/response.js
@@ -1,7 +1,7 @@
 'use strict';
 
 /**
- * Sends response with an object and given data property
+ * Sends response with object having a data property set to arg.
  */
 function sendData(res, data) {
   return res.send({ data });

--- a/lib/middleware/messages/member/rivescript-reply-get.js
+++ b/lib/middleware/messages/member/rivescript-reply-get.js
@@ -15,7 +15,16 @@ module.exports = function getRivescriptReply() {
         helpers.request.setMacro(req, req.rivescriptReplyText);
       }
 
-      return next();
+      if (!helpers.request.isTwilioStudio(req)) {
+        return next();
+      }
+
+      const data = {
+        user: req.user,
+        reply: rivescriptRes,
+      };
+
+      return res.send({ data });
     })
     .catch(err => helpers.sendErrorResponse(res, err));
 };

--- a/lib/middleware/messages/member/rivescript-reply-get.js
+++ b/lib/middleware/messages/member/rivescript-reply-get.js
@@ -6,6 +6,10 @@ const helpers = require('../../../helpers');
 module.exports = function getRivescriptReply() {
   return (req, res, next) => helpers.request.getRivescriptReply(req)
     .then((rivescriptRes) => {
+      if (helpers.request.isTwilioStudio(req)) {
+        return helpers.response.sendData(res, { user: req.user, reply: rivescriptRes });
+      }
+
       req.rivescriptReplyText = rivescriptRes.text;
       req.rivescriptMatch = rivescriptRes.match;
       req.rivescriptReplyTopic = rivescriptRes.topic;
@@ -15,16 +19,7 @@ module.exports = function getRivescriptReply() {
         helpers.request.setMacro(req, req.rivescriptReplyText);
       }
 
-      if (!helpers.request.isTwilioStudio(req)) {
-        return next();
-      }
-
-      const data = {
-        user: req.user,
-        reply: rivescriptRes,
-      };
-
-      return res.send({ data });
+      return next();
     })
     .catch(err => helpers.sendErrorResponse(res, err));
 };

--- a/test/unit/lib/lib-helpers/request.test.js
+++ b/test/unit/lib/lib-helpers/request.test.js
@@ -17,6 +17,8 @@ const campaignFactory = require('../../../helpers/factories/campaign');
 const conversationFactory = require('../../../helpers/factories/conversation');
 const topicFactory = require('../../../helpers/factories/topic');
 
+const config = require('../../../../config/lib/helpers/request');
+
 chai.should();
 chai.use(sinonChai);
 
@@ -333,6 +335,26 @@ test('isLastOutboundTopicTemplate should return whether if req.lastOutboundTempl
   t.truthy(requestHelper.isLastOutboundTopicTemplate(t.context.req));
   helpers.template.isGambitCampaignsTemplate
     .should.have.been.calledWith(t.context.req.lastOutboundTemplate);
+});
+
+// isTwilio
+test('isTwilio should return true if req.query.origin is set to twilio', (t) => {
+  t.falsy(requestHelper.isTwilio(t.context.req));
+  t.context.req.query.origin = config.origin.twilio;
+  t.truthy(requestHelper.isTwilio(t.context.req));
+});
+
+test('isTwilio should return true if isTwilioStudio', (t) => {
+  sandbox.stub(requestHelper, 'isTwilioStudio')
+    .returns(true);
+  t.truthy(requestHelper.isTwilio(t.context.req));
+});
+
+// isTwilioStudio
+test('isTwilioStudio should return true if req.query.origin is set to twilioStudio', (t) => {
+  t.falsy(requestHelper.isTwilioStudio(t.context.req));
+  t.context.req.query.origin = config.origin.twilioStudio;
+  t.truthy(requestHelper.isTwilioStudio(t.context.req));
 });
 
 // parseAskYesNoResponse

--- a/test/unit/lib/lib-helpers/response.test.js
+++ b/test/unit/lib/lib-helpers/response.test.js
@@ -1,0 +1,32 @@
+'use strict';
+
+require('dotenv').config();
+const test = require('ava');
+const chai = require('chai');
+const sinon = require('sinon');
+const sinonChai = require('sinon-chai');
+const httpMocks = require('node-mocks-http');
+
+chai.should();
+chai.use(sinonChai);
+
+// module to be tested
+const responseHelper = require('../../../../lib/helpers/response');
+
+const sandbox = sinon.sandbox.create();
+
+test.beforeEach((t) => {
+  t.context.res = httpMocks.createResponse();
+  sandbox.spy(t.context.res, 'send');
+});
+
+test.afterEach(() => {
+  sandbox.restore();
+});
+
+// sendData
+test('sendData calls send with an object and data property', (t) => {
+  const data = ['Hello'];
+  responseHelper.sendData(t.context.res, data);
+  t.context.res.send.should.have.been.calledWith({ data });
+});

--- a/test/unit/lib/middleware/messages/member/rivescript-reply-get.test.js
+++ b/test/unit/lib/middleware/messages/member/rivescript-reply-get.test.js
@@ -11,6 +11,8 @@ const underscore = require('underscore');
 
 const helpers = require('../../../../../../lib/helpers');
 const conversationFactory = require('../../../../../helpers/factories/conversation');
+const userFactory = require('../../../../../helpers/factories/user');
+const stubs = require('../../../../../helpers/stubs');
 
 const macroHelper = helpers.macro;
 const mockConversation = conversationFactory.getValidConversation();
@@ -22,6 +24,7 @@ const mockRivescriptReply = {
   topic: mockTopic,
   match: mockMatch,
 };
+const mockUser = userFactory.getValidUser();
 
 // setup "x.should.y" assertion style
 chai.should();
@@ -38,8 +41,9 @@ test.beforeEach((t) => {
     .returns(underscore.noop);
   t.context.req = httpMocks.createRequest();
   t.context.req.conversation = mockConversation;
-  t.context.req.inboundMessageText = 'King of the North';
+  t.context.req.inboundMessageText = stubs.getRandomMessageText();
   t.context.res = httpMocks.createResponse();
+  sandbox.spy(t.context.res, 'send');
 });
 
 test.afterEach((t) => {
@@ -124,4 +128,23 @@ test('getRivescriptReply should not set req.macro if helpers.macro.isMacro fails
   macroHelper.isMacro.should.have.been.called;
   next.should.not.have.been.called;
   helpers.sendErrorResponse.should.have.been.called;
+});
+
+test('getRivescriptReply should send data with user and reply if request is twilioStudio', async (t) => {
+  // setup
+  const next = sinon.stub();
+  const middleware = getRivescriptReply();
+  sandbox.stub(helpers.request, 'getRivescriptReply')
+    .returns(Promise.resolve(mockRivescriptReply));
+  sandbox.stub(helpers.request, 'isTwilioStudio')
+    .returns(true);
+  t.context.req.user = mockUser;
+  const data = {
+    user: mockUser,
+    reply: mockRivescriptReply,
+  };
+
+  // test
+  await middleware(t.context.req, t.context.res, next);
+  t.context.res.send.should.have.been.calledWith({ data });
 });

--- a/test/unit/lib/middleware/messages/member/rivescript-reply-get.test.js
+++ b/test/unit/lib/middleware/messages/member/rivescript-reply-get.test.js
@@ -39,11 +39,12 @@ const sandbox = sinon.sandbox.create();
 test.beforeEach((t) => {
   sandbox.stub(helpers, 'sendErrorResponse')
     .returns(underscore.noop);
+  sandbox.stub(helpers.response, 'sendData')
+    .returns(underscore.noop);
   t.context.req = httpMocks.createRequest();
   t.context.req.conversation = mockConversation;
   t.context.req.inboundMessageText = stubs.getRandomMessageText();
   t.context.res = httpMocks.createResponse();
-  sandbox.spy(t.context.res, 'send');
 });
 
 test.afterEach((t) => {
@@ -146,5 +147,5 @@ test('getRivescriptReply should send data with user and reply if request is twil
 
   // test
   await middleware(t.context.req, t.context.res, next);
-  t.context.res.send.should.have.been.calledWith({ data });
+  helpers.response.sendData.should.have.been.calledWith(t.context.res, data);
 });


### PR DESCRIPTION
#### What's this PR do?

Adds support for a Twilio Studio prototype to get the Rivescript reply (and loaded user) for an execution triggered via incoming message. If the origin is set to `twilioStudio`, we do not post to the Twilio API to send an outbound reply; the reply is handled within the Studio flow execution steps.

#### How should this be reviewed?

Post a Twilio message payload to `POST /v2/messages?origin=twilioStudio` for your mobile number. Verify that your conversation state is not changed, and a message is not sent to your phone (instead the HTTP response data should be set an object with  `user` and  `reply` object properties.

#### Any background context you want to provide?

It makes sense to casually maintain a [working prototype of Twilio Studio flow integration](https://docs.google.com/document/d/1kWvVOk00ZE99XPyuRjcW0iONUIR_oeAMf_R8zGrZnd0/edit?ts=5b9fb80b#) as new Studio features get released. Here's a snapshot of the prototype flow currently, supporting mock voting plan keyword, voting plan broadcast, auto reply broadcast, and text post broadcast conversations.


<img width="937" alt="screen shot 2018-09-19 at 3 21 01 pm" src="https://user-images.githubusercontent.com/1236811/45842203-d3f3f480-bcd0-11e8-877c-3f2338afa136.png">


#### Relevant tickets
https://www.pivotaltracker.com/story/show/158991881

#### Checklist
- [x] Tests added for new features/bug fixes.
- [x] Tested on staging.
