### PR TITLE
Adds votingPlanMethodOfTransport macros [pr]

### DIFF
--- a/brain/index.rive
+++ b/brain/index.rive
@@ -62,12 +62,15 @@
 ! sub wuts    = what is
 
 // Arrays
+! array bike      = bicycle|bike|bikin|biking|cycling
 ! array bot       = bot robot machine computer
 ! array botname   = freddie freddi alicia alysa alysha
 ! array die       = die|kill myself|killing myself
   ^ commit suicide|committing suicide|commiting suicide
 ! array dosomething = dosomething|dosomethingorg|do something
-! array greetings     = hola|howdy
+! array drive     = car|driv|drive|drivin|driving|truck\
+]''
+! array greetings = hola|howdy
   ^ hi|hii|hiii|hiiii|hiiiii|hiiiiii
   ^ hello|helloo|hellooo|hellloooo
   ^ hey|heyy|heyyy|heyyyy|heyyyy|heyyyyyy 
@@ -83,20 +86,18 @@
   ^ suicidal|suicidial|suicide
 ! array messaging = text|texts|txt|texting|txting|talking|talkign
   ^ messaging|contacting|sending|list|this list
-! array bike = bicycle|bike|bikin|biking|cycling
-! array drive = car|driv|drive|drivin|driving|truck
-! array walk = walk|walki|walkin|walking|feet
-! array publictransport = bart|bus|ferry|metro|meta|muni|subway|train
 ! array my        = my this
 ! array no        = n no nah nope nay
 ! array photo     = photo photos mms pic pics pix image image img
 ! array please    = pls|plz|please|can you|will you
+! array publictransport = bart|bus|ferry|metro|meta|muni|subway|train|trans|transport|transportation
 ! array question  = is there|who|what|when|why|how
 ! array send      = send submit text
 ! array social    = social media|facebook|twitter|instagram|social
 ! array unsubscribe = unsubscribe|cancel
   ^ leave|remove|quit|end|exit|opt out|optout|discontinue|take me off
   ^ atop|dtop|sotp|srop|stip|stop|stop all|stopp|stopall|stp
+! array walk      = walk|walki|walkin|walking|feet
 ! array want      = want|am going|am thinking about
 ! array why       = why y how
 ! array yes       = y ya yas yea yeah yep yes yup

--- a/brain/index.rive
+++ b/brain/index.rive
@@ -73,6 +73,7 @@
   ^ hi|hii|hiii|hiiii|hiiiii|hiiiiii
   ^ hello|helloo|hellooo|hellloooo
   ^ hey|heyy|heyyy|heyyyy|heyyyy|heyyyyyy 
+  ^ yo|yoo|yoyo|yoyoyo
 ! array human     = human person real
 ! array is        = is|will not stop|keeps|was|was being|gets|am|am being|have been
 ! array hurting   = hurt|hurting|hurting|hurts
@@ -89,14 +90,16 @@
 ! array no        = n no nah nope nay
 ! array photo     = photo photos mms pic pics pix image image img
 ! array please    = pls|plz|please|can you|will you
-! array publictransport = bart|bus|ferry|metro|mta|muni|subwaytrain|trans|transport|transportation
+! array publictransport = bart|bus|cable car|ferry
+   ^ lirr|metro|mta|muni|rail|subway|train|tram|trans|transport|transportation|trolley
 ! array question  = is there|who|what|when|why|how
 ! array send      = send submit text
 ! array social    = social media|facebook|twitter|instagram|social
 ! array unsubscribe = unsubscribe|cancel
   ^ leave|remove|quit|end|exit|opt out|optout|discontinue|take me off
   ^ atop|dtop|sotp|srop|stip|stop|stop all|stopp|stopall|stp
-! array walk      = walk|walki|walkin|walking|feet
+! array walk      = walk|walki|walkin|walking
+   ^ feet|jog|joggin|jogging|run|runnin|running|step|steppin|steps
 ! array want      = want|am going|am thinking about
 ! array why       = why y how
 ! array yes       = y ya yas yea yeah yep yes yup

--- a/brain/index.rive
+++ b/brain/index.rive
@@ -68,8 +68,7 @@
 ! array die       = die|kill myself|killing myself
   ^ commit suicide|committing suicide|commiting suicide
 ! array dosomething = dosomething|dosomethingorg|do something
-! array drive     = car|driv|drive|drivin|driving|truck\
-]''
+! array drive     = car|driv|drive|drivin|driving|truck|whip
 ! array greetings = hola|howdy
   ^ hi|hii|hiii|hiiii|hiiiii|hiiiiii
   ^ hello|helloo|hellooo|hellloooo

--- a/brain/index.rive
+++ b/brain/index.rive
@@ -83,6 +83,10 @@
   ^ suicidal|suicidial|suicide
 ! array messaging = text|texts|txt|texting|txting|talking|talkign
   ^ messaging|contacting|sending|list|this list
+! array bike = bicycle|bike|bikin|biking|cycling
+! array drive = car|driv|drive|drivin|driving|truck
+! array walk = walk|walki|walkin|walking|feet
+! array publictransport = bart|bus|ferry|metro|meta|muni|subway|train
 ! array my        = my this
 ! array no        = n no nah nope nay
 ! array photo     = photo photos mms pic pics pix image image img

--- a/brain/index.rive
+++ b/brain/index.rive
@@ -89,7 +89,7 @@
 ! array no        = n no nah nope nay
 ! array photo     = photo photos mms pic pics pix image image img
 ! array please    = pls|plz|please|can you|will you
-! array publictransport = bart|bus|ferry|metro|meta|muni|subway|train|trans|transport|transportation
+! array publictransport = bart|bus|ferry|metro|mta|muni|subwaytrain|trans|transport|transportation
 ! array question  = is there|who|what|when|why|how
 ! array send      = send submit text
 ! array social    = social media|facebook|twitter|instagram|social

--- a/brain/macros.rive
+++ b/brain/macros.rive
@@ -7,7 +7,7 @@
 @ info
 
 + q
-- supportRequested{topic=support}
+- supportRequested
 
 + question
 @ q
@@ -22,13 +22,13 @@
 @ subscribe
 
 + (week|weekly)
-- subscriptionStatusActive{topic=random}
+- subscriptionStatusActive
 
 + (less|month|monthly)
-- subscriptionStatusLess{topic=random}
+- subscriptionStatusLess
 
 + stop
-- subscriptionStatusStop{topic=unsubscribed}
+- subscriptionStatusStop
 
 + @unsubscribe
 @ stop

--- a/brain/topics/askSubscriptionStatus.rive
+++ b/brain/topics/askSubscriptionStatus.rive
@@ -1,26 +1,24 @@
-/** 
- * Asks user to update their subscription status.
- */
+// Current options are A) Weekly B) Monthly C) Need more info
+// @see config/lib/macro
 
 + status
-- Hi it's Freddie at DoSomething! I send texts w updates on news & easy ways to take action. Want texts: A)Weekly B)Monthly C)I need more info D)Text STOP to stop {topic=ask_subscription_status}
+- askSubscriptionStatus
 
-// Includes 'random' to catch all triggers defined in the default topic
 > topic ask_subscription_status includes random
 
 + a
-- subscriptionStatusActive{topic=random}
+- subscriptionStatusActive
 
 + b
-- subscriptionStatusLess{topic=random}
+- subscriptionStatusLess
 
 + c [*]
-- Sure! Once a week, I text over 3 million young people with updates on what's happening in the news and/or easy ways to take action in your community.\n\nWant an example of an easy way to take action? Take 2 mins to learn how to spot the signs of an abusive relationship and what you can do about it. Read our guide: https://www.dosomething.org/us/spot-the-signs-guide?source=sms&utm_source=dosomething&utm_medium=sms&utm_campaign=permissioning_moreinfo&user_id={{user.id}}
+- subscriptionStatusNeedMoreInfo
 
 + [*] more [*]
 @ c
 
 + [*]
-- Whoops, I'm sorry I didn't get that - do you want A) Weekly B) Monthly C) Need More Info
+- invalidSubscriptionStatus
 
 < topic

--- a/brain/topics/askVotingPlanStatus.rive
+++ b/brain/topics/askVotingPlanStatus.rive
@@ -1,5 +1,5 @@
 + make a plan
-- askVotingPlanStatus{topic=ask_voting_plan_status}
+- askVotingPlanStatus
 
 // Current options are A) Yes B) No C) Already voted D) Can't vote
 // @see config/lib/macro
@@ -7,22 +7,22 @@
 > topic ask_voting_plan_status includes random
 
 + a
-- votingPlanStatusVoting{topic=ask_voting_plan_method_of_transport}
+- votingPlanStatusVoting
 
 + [*] @yes [*]
 @ a
 
 + b
-- votingPlanStatusNotVoting{topic=random}
+- votingPlanStatusNotVoting
 
 + @no [*]
 @ b
 
 + c
-- votingPlanStatusVoted{topic=random}
+- votingPlanStatusVoted
 
 + d
-- votingPlanCantVote{topic=random}
+- votingPlanCantVote
 
 + [*]
 - invalidVotingPlanStatus

--- a/brain/topics/unsubscribed.rive
+++ b/brain/topics/unsubscribed.rive
@@ -7,10 +7,10 @@
 @ info
 
 + less
-- subscriptionStatusLess{topic=random}
+- subscriptionStatusLess
 
 + join
-- subscriptionStatusResubscribed{topic=random}
+- subscriptionStatusResubscribed
 
 + @unsubscribe
 - subscriptionStatusStop

--- a/brain/topics/votingPlan/askMethodOfTransport.rive
+++ b/brain/topics/votingPlan/askMethodOfTransport.rive
@@ -18,13 +18,13 @@
 + c
 - votingPlanMethodOfTransportBike
 
-+ [*]  @bike [*]
++ [*] @bike [*]
 @ c
 
 + d
 - votingPlanMethodOfTransportPublicTransport
 
-+ [*]  @publictransport [*]
++ [*] @publictransport [*]
 @ d
 
 + [*] (mass|public) [*]

--- a/brain/topics/votingPlan/askMethodOfTransport.rive
+++ b/brain/topics/votingPlan/askMethodOfTransport.rive
@@ -1,0 +1,33 @@
+// Current options are A) Drive B) Walk C) Bike D) Public transportation
+// @see config/lib/macro
+
+> topic ask_voting_plan_method_of_transport includes random
+
++ a
+- votingPlanMethodOfTransportDrive
+
++ [*] @drive [*]
+@ a
+
++ b
+- votingPlanMethodOfTransportWalk
+
++ [*] @walk [*]
+@ b
+
++ c
+- votingPlanMethodOfTransportBike
+
++ [*]  @bike [*]
+@ c
+
++ d
+- votingPlanMethodOfTransportPublicTransport
+
++ [*]  @publictransport [*]
+@ d
+
++ [*]
+- invalidVotingPlanMethodOfTransport
+
+< topic

--- a/brain/topics/votingPlan/askMethodOfTransport.rive
+++ b/brain/topics/votingPlan/askMethodOfTransport.rive
@@ -27,6 +27,9 @@
 + [*]  @publictransport [*]
 @ d
 
++ [*] (mass|public) [*]
+@ d
+
 + [*]
 - invalidVotingPlanMethodOfTransport
 

--- a/config/lib/helpers/macro.js
+++ b/config/lib/helpers/macro.js
@@ -2,11 +2,15 @@
 
 const profile = require('./user').fields;
 
-const askVotingPlanStatusText = 'Are you planning on voting? A) Yes B) No C) Already voted D) Can\'t vote';
 const activeSubscriptionStatusText = 'Hi I\'m Freddie from DoSomething.org! Welcome to my weekly updates (up to 8msg/month). Things to know: Msg&DataRatesApply. Text HELP for help, text STOP to stop.';
-// Note: This url may also appear in hardcoded askSubscriptionStatus topic.
+const askVotingPlanMethodOfTransportText = 'How are you getting there? A) Drive B) Walk C) Bike D) Public transportation';
+const askVotingPlanStatusText = 'Are you planning on voting? A) Yes B) No C) Already voted D) Can\'t vote';
+const completedVotingPlanText = 'Sounds good -- don\'t forget to {{user.voting_plan_method_of_transport}} to the polls on Election Day!';
+// TODO: Define askSubscriptionStatus replies as macros to DRY the news URL promo that changes.
 // @see brain/topics/askSubscriptionStatus.rive
 const newsUrl = 'https://www.dosomething.org/us/spot-the-signs-guide?source=sms&utm_source=dosomething&utm_medium=sms&utm_campaign=permissioning_weekly&user_id={{user.id}}';
+// TODO: DRY with topic helper definitions.
+const defaultTopic = { id: 'random' };
 
 module.exports = {
   // If a macro contains a text property, it's sent as the reply to the inbound message.
@@ -15,12 +19,17 @@ module.exports = {
     askVotingPlanStatus: {
       name: 'askVotingPlanStatus',
       text: askVotingPlanStatusText,
+      topic: { id: 'ask_voting_plan_status' },
     },
     catchAll: {
       name: 'catchAll',
     },
     changeTopic: {
       name: 'changeTopic',
+    },
+    invalidVotingPlanMethodOfTransport: {
+      name: 'invalidVotingPlanMethodOfTransport',
+      text: `Sorry, I didn't get that. ${askVotingPlanMethodOfTransportText}`,
     },
     invalidVotingPlanStatus: {
       name: 'invalidVotingPlanStatus',
@@ -47,6 +56,7 @@ module.exports = {
     subscriptionStatusActive: {
       name: 'subscriptionStatusActive',
       text: activeSubscriptionStatusText,
+      topic: defaultTopic,
       profileUpdate: {
         field: profile.subscriptionStatus.name,
         value: profile.subscriptionStatus.values.active,
@@ -55,6 +65,7 @@ module.exports = {
     subscriptionStatusLess: {
       name: 'subscriptionStatusLess',
       text: `Okay, great! I'll text you once a month with updates on what's happening in the news and/or easy ways for you to take action in your community! Wanna take 2 mins to learn how to spot the signs of an abusive relationship and what you can do about it? Read our guide here: ${newsUrl}`,
+      topic: defaultTopic,
       profileUpdate: {
         field: profile.subscriptionStatus.name,
         value: profile.subscriptionStatus.values.less,
@@ -63,6 +74,7 @@ module.exports = {
     subscriptionStatusResubscribed: {
       name: 'subscriptionStatusResubscribed',
       text: activeSubscriptionStatusText,
+      topic: defaultTopic,
       profileUpdate: {
         field: profile.subscriptionStatus.name,
         value: profile.subscriptionStatus.values.active,
@@ -71,6 +83,7 @@ module.exports = {
     subscriptionStatusStop: {
       name: 'subscriptionStatusStop',
       text: 'You\'re unsubscribed from DoSomething.org Alerts. No more msgs will be sent. Reply HELP for help. Text JOIN to receive 4-8 msgs/mth or LESS for 1msg/mth.',
+      topic: { id: 'unsubscribed' },
       profileUpdate: {
         field: profile.subscriptionStatus.name,
         value: profile.subscriptionStatus.values.stop,
@@ -79,10 +92,49 @@ module.exports = {
     supportRequested: {
       name: 'supportRequested',
       text: 'What\'s your question? I\'ll try my best to answer it.',
+      topic: { id: 'support' },
+    },
+    votingPlanMethodOfTransportBike: {
+      name: 'votingPlanMethodOfTransportBike',
+      text: completedVotingPlanText,
+      topic: defaultTopic,
+      profileUpdate: {
+        field: profile.votingPlanMethodOfTransport.name,
+        value: profile.votingPlanMethodOfTransport.values.bike,
+      },
+    },
+    votingPlanMethodOfTransportDrive: {
+      name: 'votingPlanMethodOfTransportDrive',
+      text: completedVotingPlanText,
+      topic: defaultTopic,
+      profileUpdate: {
+        field: profile.votingPlanMethodOfTransport.name,
+        value: profile.votingPlanMethodOfTransport.values.drive,
+      },
+    },
+    votingPlanMethodOfTransportPublicTransport: {
+      name: 'votingPlanMethodOfTransportPublicTransport',
+      text: completedVotingPlanText,
+      topic: defaultTopic,
+      profileUpdate: {
+        field: profile.votingPlanMethodOfTransport.name,
+        value: profile.votingPlanMethodOfTransport.values.publicTransport,
+      },
+    },
+    votingPlanMethodOfTransportWalk: {
+      name: 'votingPlanMethodOfTransportWalk',
+      text: completedVotingPlanText,
+      topic: defaultTopic,
+      profileUpdate: {
+        field: profile.votingPlanMethodOfTransport.name,
+        value: profile.votingPlanMethodOfTransport.values.walk,
+      },
     },
     votingPlanStatusCantVote: {
       name: 'votingPlanStatusCantVote',
+      // Placeholder template: this will be set on an askVotingPlanStatus broadcast.
       text: 'Ok -- we\'ll check in with you next election.',
+      topic: defaultTopic,
       profileUpdate: {
         field: profile.votingPlanStatus.name,
         value: profile.votingPlanStatus.values.cantVote,
@@ -90,7 +142,9 @@ module.exports = {
     },
     votingPlanStatusNotVoting: {
       name: 'votingPlanStatusNotVoting',
-      text: 'Mind sharing why you aren\t not voting?',
+      // Placeholder template: this will be set on an askVotingPlanStatus broadcast.
+      text: 'Mind sharing why you aren\'t not voting?',
+      topic: defaultTopic,
       profileUpdate: {
         field: profile.votingPlanStatus.name,
         value: profile.votingPlanStatus.values.notVoting,
@@ -99,6 +153,7 @@ module.exports = {
     votingPlanStatusVoted: {
       name: 'votingPlanStatusVoted',
       text: 'Awesome! Thank you for voting.',
+      topic: defaultTopic,
       profileUpdate: {
         field: profile.votingPlanStatus.name,
         value: profile.votingPlanStatus.values.voted,
@@ -106,7 +161,8 @@ module.exports = {
     },
     votingPlanStatusVoting: {
       name: 'votingPlanStatusVoting',
-      text: 'Great! I\'ll check in with you soon to make a plan.',
+      text: askVotingPlanMethodOfTransportText,
+      topic: { id: 'ask_voting_plan_method_of_transport' },
       profileUpdate: {
         field: profile.votingPlanStatus.name,
         value: profile.votingPlanStatus.values.voting,

--- a/config/lib/helpers/macro.js
+++ b/config/lib/helpers/macro.js
@@ -3,11 +3,11 @@
 const profile = require('./user').fields;
 
 const activeSubscriptionStatusText = 'Hi I\'m Freddie from DoSomething.org! Welcome to my weekly updates (up to 8msg/month). Things to know: Msg&DataRatesApply. Text HELP for help, text STOP to stop.';
+const askSubscriptionStatusText = 'Do you want texts: A)Weekly B)Monthly C)I need more info';
 const askVotingPlanMethodOfTransportText = 'How are you getting there? A) Drive B) Walk C) Bike D) Public transportation';
 const askVotingPlanStatusText = 'Are you planning on voting? A) Yes B) No C) Already voted D) Can\'t vote';
 const completedVotingPlanText = 'Sounds good -- don\'t forget to {{user.voting_plan_method_of_transport}} to the polls on Election Day!';
-// TODO: Define askSubscriptionStatus replies as macros to DRY the news URL promo that changes.
-// @see brain/topics/askSubscriptionStatus.rive
+const invalidAnswerText = 'Sorry, I didn\'t get that.';
 const newsUrl = 'https://www.dosomething.org/us/spot-the-signs-guide?source=sms&utm_source=dosomething&utm_medium=sms&utm_campaign=permissioning_weekly&user_id={{user.id}}';
 // TODO: DRY with topic helper definitions.
 const defaultTopic = { id: 'random' };
@@ -21,19 +21,28 @@ module.exports = {
       text: askVotingPlanStatusText,
       topic: { id: 'ask_voting_plan_status' },
     },
+    askSubscriptionStatus: {
+      name: 'askSubscriptionStatus',
+      text: askSubscriptionStatusText,
+      topic: { id: 'ask_subscription_status' },
+    },
     catchAll: {
       name: 'catchAll',
     },
     changeTopic: {
       name: 'changeTopic',
     },
+    invalidSubscriptionStatus: {
+      name: 'invalidSubscriptionStatus',
+      text: `${invalidAnswerText} ${askSubscriptionStatusText}`,
+    },
     invalidVotingPlanMethodOfTransport: {
       name: 'invalidVotingPlanMethodOfTransport',
-      text: `Sorry, I didn't get that. ${askVotingPlanMethodOfTransportText}`,
+      text: `${invalidAnswerText} ${askVotingPlanMethodOfTransportText}`,
     },
     invalidVotingPlanStatus: {
       name: 'invalidVotingPlanStatus',
-      text: `Sorry, I didn't get that. ${askVotingPlanStatusText}`,
+      text: `${invalidAnswerText} ${askVotingPlanStatusText}`,
     },
     noReply: {
       name: 'noReply',
@@ -70,6 +79,10 @@ module.exports = {
         field: profile.subscriptionStatus.name,
         value: profile.subscriptionStatus.values.less,
       },
+    },
+    subscriptionStatusNeedMoreInfo: {
+      name: 'subscriptionStatusNeedMoreInfo',
+      text: `Sure! Once a week, I text over 3 million young people with updates on what's happening in the news and/or easy ways to take action in your community.\n\nWant an example of an easy way to take action? Take 2 mins to learn how to spot the signs of an abusive relationship and what you can do about it. Read our guide: ${newsUrl}`,
     },
     subscriptionStatusResubscribed: {
       name: 'subscriptionStatusResubscribed',

--- a/config/lib/helpers/user.js
+++ b/config/lib/helpers/user.js
@@ -10,6 +10,15 @@ const userFields = {
     name: 'sms_status',
     values: subscriptionStatusValues,
   },
+  votingPlanMethodOfTransport: {
+    name: 'voting_plan_method_of_transport',
+    values: {
+      bike: 'bike',
+      drive: 'drive',
+      publicTransport: 'public_transport',
+      walk: 'walk',
+    },
+  },
   votingPlanStatus: {
     name: 'voting_plan_status',
     values: {

--- a/lib/helpers/macro.js
+++ b/lib/helpers/macro.js
@@ -40,9 +40,9 @@ function getProfileUpdate(macroName) {
  * @param {String} macroName
  * @return {String}
  */
-function getReplyText(macroName) {
+function getTemplate(macroName) {
   const macroConfig = config.macros[macroName];
-  return macroConfig ? macroConfig.text : null;
+  return macroConfig ? macroConfig.template : null;
 }
 
 /**
@@ -69,6 +69,10 @@ function isSaidYes(macroName) {
   return (macroName === module.exports.macros.saidYes());
 }
 
+function getMacro(macroName) {
+  return config.macros[macroName];
+}
+
 /**
  * Is given string a Rivescript macro?
  * @param {String} text
@@ -82,8 +86,9 @@ function isMacro(text) {
 
 module.exports = {
   getChangeTopicMacroFromTopicId,
+  getMacro,
   getProfileUpdate,
-  getReplyText,
+  getTemplate,
   isChangeTopic,
   isMacro,
   isSaidNo,

--- a/lib/helpers/macro.js
+++ b/lib/helpers/macro.js
@@ -38,15 +38,6 @@ function getProfileUpdate(macroName) {
 
 /**
  * @param {String} macroName
- * @return {String}
- */
-function getTemplate(macroName) {
-  const macroConfig = config.macros[macroName];
-  return macroConfig ? macroConfig.template : null;
-}
-
-/**
- * @param {String} macroName
  * @return {Boolean}
  */
 function isChangeTopic(macroName) {
@@ -88,7 +79,6 @@ module.exports = {
   getChangeTopicMacroFromTopicId,
   getMacro,
   getProfileUpdate,
-  getTemplate,
   isChangeTopic,
   isMacro,
   isSaidNo,

--- a/lib/helpers/replies.js
+++ b/lib/helpers/replies.js
@@ -14,8 +14,8 @@ module.exports.sendReply = async function (req, res, messageText, messageTemplat
   logger.debug('sendReply', { messageTemplate }, req);
 
   try {
-    const user = await helpers.user.updateByMemberMessageReq(req);
-    logger.debug('updated user', { id: user.id, sms_status: user.sms_status }, req);
+    req.user = await helpers.user.updateByMemberMessageReq(req);
+    logger.debug('updated user', { id: req.user.id }, req);
 
     const direction = 'outbound-reply';
     const notARetry = !req.isARetryRequest();

--- a/lib/middleware/messages/member/macro-reply.js
+++ b/lib/middleware/messages/member/macro-reply.js
@@ -1,21 +1,21 @@
 'use strict';
 
 const helpers = require('../../../helpers');
-const logger = require('../../../logger');
 
 module.exports = function replyMacro() {
   return async (req, res, next) => {
     try {
+      const macro = helpers.macro.getMacro(req.macro);
       // Handles macros that send a hardcoded reply template.
       // If this isn't a macro that returns a hardcoded reply, move on to next middleware.
-      const macroReplyText = helpers.macro.getReplyText(req.macro);
-      if (!macroReplyText) {
+      if (!macro.text) {
         return next();
       }
-      logger.debug('macro macroReplyText', { macroReplyText });
-      // TODO: Rename as updateTopicIfChanged?
-      await helpers.request.changeTopic(req, req.rivescriptReplyTopic);
-      return await helpers.replies.sendReply(req, res, macroReplyText, req.macro);
+      if (macro.topic && macro.topic.id) {
+        // TODO: Rename as updateTopicIfChanged?
+        await helpers.request.changeTopic(req, macro.topic);
+      }
+      return await helpers.replies.sendReply(req, res, macro.text, macro.name);
     } catch (err) {
       return helpers.sendErrorResponse(res, err);
     }

--- a/test/unit/lib/lib-helpers/macro.test.js
+++ b/test/unit/lib/lib-helpers/macro.test.js
@@ -32,15 +32,15 @@ test.afterEach(() => {
   sandbox.restore();
 });
 
-// getReplyText
-test('getReplyText should return text for given macro if defined', () => {
+// getMacro
+test('getMacro should return config for given macro if defined', () => {
   const macro = config.macros.subscriptionStatusStop;
-  const result = macroHelper.getReplyText(macro.name);
-  result.should.equal(macro.text);
+  const result = macroHelper.getMacro(macro.name);
+  result.should.deep.equal(macro);
 });
 
-test('getReply should return falsy for undefined macro reply', (t) => {
-  t.falsy(macroHelper.getReplyText(undefinedMacroName));
+test('getMacro should return falsy for undefined macro', (t) => {
+  t.falsy(macroHelper.getMacro(undefinedMacroName));
 });
 
 // getChangeTopicMacroFromTopic

--- a/test/unit/lib/lib-helpers/replies.test.js
+++ b/test/unit/lib/lib-helpers/replies.test.js
@@ -17,6 +17,7 @@ const Message = require('../../../../app/models/Message');
 const campaignFactory = require('../../../helpers/factories/campaign');
 const conversationFactory = require('../../../helpers/factories/conversation');
 const messageFactory = require('../../../helpers/factories/message');
+const userFactory = require('../../../helpers/factories/user');
 
 // setup "x.should.y" assertion style
 chai.should();
@@ -103,8 +104,9 @@ test('sendReply(): responds with the inbound and outbound messages', async (t) =
     inboundMessage,
     lastOutboundMessage,
   });
+  const updatedUser = userFactory.getValidUser();
   sandbox.stub(helpers.user, 'updateByMemberMessageReq')
-    .returns(Promise.resolve({}));
+    .returns(Promise.resolve(updatedUser));
   sandbox.stub(req.conversation, 'createAndSetLastOutboundMessage')
     .returns(resolvedPromise);
   sandbox.stub(req.conversation, 'postLastOutboundMessageToPlatform')
@@ -117,6 +119,8 @@ test('sendReply(): responds with the inbound and outbound messages', async (t) =
 
   // asserts
   t.context.res.send.should.have.been.called;
+  helpers.user.updateByMemberMessageReq.should.have.been.calledWith(req);
+  req.user.should.deep.equal(updatedUser);
   req.conversation.createAndSetLastOutboundMessage.should.have.been.called;
   req.conversation.postLastOutboundMessageToPlatform.should.have.been.called;
   responseMessages.inbound[0].should.be.equal(inboundMessage);


### PR DESCRIPTION
#### What's this PR do?

Modifies the `votingPlanStatusVoting` macro to change user's topic to the newly added `ask_voting_plan_method_of_transport` topic, and saves valid answers to the corresponding `voting_plan_method_of_transport` field.

Also:

* Adds a `topic` property into macro config, to define macro behavior in a single file (instead of defining within the hardcoded Rivescript in `brain/topics`)

* Refactors all `ask_subscription_status` replies as macros, to DRY sending the `newsUrl` link

* Adds new Rivescript substitutions for various voting plan method of transport values

* Shortcuts sending a completed voting plan confirmation after user selects method of transport -- still need to add topics to collect `voting_plan_time_of_day` and `voting_plan_attending_width` fields on the user profile 

#### How should this be reviewed?
* Text `make a plan` to enter the `ask_voting_plan_status` topic
* Text a yes response (or A) to enter the `ask_voting_plan_method_of_transport` topic
* Verify valid answer is saved your user's `voting_plan_method_of_transport` field

#### Any background context you want to provide?

There are still 2 more fields to save answers for (which will add about 8 more macros or so for each field+value combination) -- opening this as is help keep this PR readable and easier to manually test

#### Relevant tickets

* Hardcoding voting plan data collection: https://www.pivotaltracker.com/story/show/160822424
* Saving voting plan data to DS API: https://www.pivotaltracker.com/story/show/160824069

#### Checklist
- [ ] Tests added/updated for new features/bug fixes.
- [x] Tested on staging.
