### PR TITLE
Adds check for macroName value

### DIFF
--- a/lib/helpers/macro.js
+++ b/lib/helpers/macro.js
@@ -49,7 +49,7 @@ function isChangeTopic(macroName) {
  * @return {Boolean}
  */
 function isCompletedVotingPlan(macroName) {
-  return macroName.includes(config.completedVotingPlanMacro);
+  return macroName && macroName.includes(config.completedVotingPlanMacro);
 }
 
 /**

--- a/test/unit/lib/lib-helpers/macro.test.js
+++ b/test/unit/lib/lib-helpers/macro.test.js
@@ -107,6 +107,7 @@ test('isSaidNo should return boolean', (t) => {
 
 // isVotingPlanStatusVoting
 test('isVotingPlanStatusVoting should return boolean', (t) => {
+  t.falsy(macroHelper.isVotingPlanStatusVoting(null));
   t.true(macroHelper.isVotingPlanStatusVoting(macros.votingPlanStatusVoting.name));
   t.falsy(macroHelper.isVotingPlanStatusVoting(undefinedMacroName));
 });


### PR DESCRIPTION
#### What's this PR do?

Returns false when falsy value is passed to the `isCompletedVotingPlan` function in the macro helper.

#### How should this be reviewed?
- 👀 
- working on replicating, seems to be happening to [this user](https://gambit-admin.herokuapp.com/users/58b7fa59a0bfad4f864bd7f2)

#### Any background context you want to provide?
Should fix the `Cannot read property 'includes' of undefined` error we're seeing per today's [https://github.com/DoSomething/gambit-conversations/releases/tag/3.7.0](3.7.0) release.


#### Checklist
- [ ] Tests added/updated for new features/bug fixes.
- [ ] Tested on staging.
