### PR TITLE
Rogue voting plans part 2: one per user [pr]

### DIFF
--- a/lib/helpers/user.js
+++ b/lib/helpers/user.js
@@ -17,9 +17,9 @@ const votingPlanPostConfig = config.posts.votingPlan;
  */
 function createVotingPlan(user, source) {
   const votingPlan = {
-    attending_with: user.voting_plan_attending_with,
-    method_of_transport: user.voting_plan_method_of_transport,
-    time_of_day: user.voting_plan_time_of_day,
+    attending_with: user[config.fields.votingPlanAttendingWith.name],
+    method_of_transport: user[config.fields.votingPlanMethodOfTransport.name],
+    time_of_day: user[config.fields.votingPlanTimeOfDay.name],
   };
   const payload = {
     northstar_id: user.id,

--- a/lib/helpers/user.js
+++ b/lib/helpers/user.js
@@ -40,7 +40,7 @@ function createVotingPlan(user, source) {
  */
 async function createVotingPlanIfDoesntExist(user, source) {
   const userId = user.id;
-  const votingPlan = await module.exports.getVotingPlan(user);
+  const votingPlan = await module.exports.fetchVotingPlan(user);
   if (votingPlan) {
     logger.debug('voting plan exists', { userId });
     return null;
@@ -53,7 +53,7 @@ async function createVotingPlanIfDoesntExist(user, source) {
  * @param {Object} user
  * @return {Promise}
  */
-function getVotingPlan(user) {
+function fetchVotingPlan(user) {
   const query = {};
   query['filter[northstar_id]'] = user.id;
   query['filter[campaign_id]'] = votingPlanPostConfig.campaignId;
@@ -96,7 +96,7 @@ async function updateByMemberMessageReq(req) {
 module.exports = {
   createVotingPlan,
   createVotingPlanIfDoesntExist,
-  getVotingPlan,
+  fetchVotingPlan,
   unauthenticatedFetchById(userId) {
     return northstar.unauthenticatedFetchUserById(userId);
   },

--- a/lib/helpers/user.js
+++ b/lib/helpers/user.js
@@ -8,7 +8,7 @@ const helpers = require('../helpers');
 const statuses = require('./subscription').statuses;
 const config = require('../../config/lib/helpers/user');
 
-const votingPlanCampaignId = config.posts.votingPlan.campaignId;
+const votingPlanPostConfig = config.posts.votingPlan;
 
 /**
  * @param {Object} user
@@ -23,9 +23,9 @@ function createVotingPlan(user, source) {
   };
   const payload = {
     northstar_id: user.id,
-    type: config.posts.votingPlan.type,
+    type: votingPlanPostConfig.type,
     text: JSON.stringify(votingPlan),
-    campaign_id: votingPlanCampaignId,
+    campaign_id: votingPlanPostConfig.campaignId,
     source,
   };
   logger.debug('rogue.createPost', { payload });
@@ -56,7 +56,9 @@ async function createVotingPlanIfDoesntExist(user, source) {
 function getVotingPlanByUserId(userId) {
   const query = {};
   query['filter[northstar_id]'] = userId;
-  query['filter[campaign_id]'] = votingPlanCampaignId;
+  query['filter[campaign_id]'] = votingPlanPostConfig.campaignId;
+  query['filter[type]'] = votingPlanPostConfig.type;
+  logger.debug('rogue.getPosts', { query });
   return rogue.getPosts(query);
 }
 

--- a/lib/helpers/user.js
+++ b/lib/helpers/user.js
@@ -1,13 +1,14 @@
 'use strict';
 
 const underscore = require('underscore');
-
 const logger = require('../logger');
 const northstar = require('../northstar');
 const rogue = require('../rogue');
 const helpers = require('../helpers');
 const statuses = require('./subscription').statuses;
 const config = require('../../config/lib/helpers/user');
+
+const votingPlanCampaignId = config.posts.votingPlan.campaignId;
 
 /**
  * @param {Object} user
@@ -20,17 +21,43 @@ function createVotingPlan(user, source) {
     method_of_transport: user.voting_plan_method_of_transport,
     time_of_day: user.voting_plan_time_of_day,
   };
-  const votingPlanPostConfig = config.posts.votingPlan;
   const payload = {
     northstar_id: user.id,
-    type: votingPlanPostConfig.type,
+    type: config.posts.votingPlan.type,
     text: JSON.stringify(votingPlan),
-    campaign_id: votingPlanPostConfig.campaignId,
+    campaign_id: votingPlanCampaignId,
     source,
   };
   logger.debug('rogue.createPost', { payload });
   // TODO: If text post already exists for our campaignId, update it instead of creating a new one.
   return rogue.createPost(payload);
+}
+
+/**
+ * @param {Object} user
+ * @param {String} source
+ * @return {Promise}
+ */
+async function createVotingPlanIfDoesntExist(user, source) {
+  const userId = user.id;
+  const res = await module.exports.getVotingPlan(user);
+  if (!res.data.length) {
+    logger.debug('creating voting plan', { userId });
+    return createVotingPlan(user, source);
+  }
+  logger.debug('voting plan exists', { userId });
+  return null;
+}
+
+/**
+ * @param {Object} user
+ * @return {Promise}
+ */
+function getVotingPlan(user) {
+  const query = {};
+  query['filter[northstar_id]'] = user.id;
+  query['filter[campaign_id]'] = votingPlanCampaignId;
+  return rogue.getPosts(query);
 }
 
 /**
@@ -56,7 +83,7 @@ async function updateByMemberMessageReq(req) {
     }
     const user = await northstar.updateUser(req.user.id, payload);
     if (helpers.macro.isCompletedVotingPlan(req.macro)) {
-      await module.exports.createVotingPlan(user, req.platform);
+      await module.exports.createVotingPlanIfDoesntExist(user, req.platform);
     }
     return user;
   } catch (error) {
@@ -66,6 +93,8 @@ async function updateByMemberMessageReq(req) {
 
 module.exports = {
   createVotingPlan,
+  createVotingPlanIfDoesntExist,
+  getVotingPlan,
   unauthenticatedFetchById(userId) {
     return northstar.unauthenticatedFetchUserById(userId);
   },

--- a/lib/helpers/user.js
+++ b/lib/helpers/user.js
@@ -40,26 +40,26 @@ function createVotingPlan(user, source) {
  */
 async function createVotingPlanIfDoesntExist(user, source) {
   const userId = user.id;
-  const res = await module.exports.getVotingPlanByUserId(userId);
-  if (!res.data.length) {
-    logger.debug('creating voting plan', { userId });
-    return createVotingPlan(user, source);
+  const votingPlan = await module.exports.getVotingPlan(user);
+  if (votingPlan) {
+    logger.debug('voting plan exists', { userId });
+    return null;
   }
-  logger.debug('voting plan exists', { userId });
-  return null;
+  logger.debug('creating voting plan', { userId });
+  return module.exports.createVotingPlan(user, source);
 }
 
 /**
- * @param {String} userId
+ * @param {Object} user
  * @return {Promise}
  */
-function getVotingPlanByUserId(userId) {
+function getVotingPlan(user) {
   const query = {};
-  query['filter[northstar_id]'] = userId;
+  query['filter[northstar_id]'] = user.id;
   query['filter[campaign_id]'] = votingPlanPostConfig.campaignId;
   query['filter[type]'] = votingPlanPostConfig.type;
   logger.debug('rogue.getPosts', { query });
-  return rogue.getPosts(query);
+  return rogue.getPosts(query).then(res => res.data[0]);
 }
 
 /**
@@ -96,7 +96,7 @@ async function updateByMemberMessageReq(req) {
 module.exports = {
   createVotingPlan,
   createVotingPlanIfDoesntExist,
-  getVotingPlanByUserId,
+  getVotingPlan,
   unauthenticatedFetchById(userId) {
     return northstar.unauthenticatedFetchUserById(userId);
   },

--- a/lib/helpers/user.js
+++ b/lib/helpers/user.js
@@ -19,12 +19,11 @@ function createVotingPlan(user, source) {
   const payload = {
     northstar_id: user.id,
     type: votingPlanPostConfig.type,
-    text: module.exports.getVotingPlanDescription(user),
+    text: JSON.stringify(module.exports.getVotingPlanValues(user)),
     campaign_id: votingPlanPostConfig.campaignId,
     source,
   };
   logger.debug('rogue.createPost', { payload });
-  // TODO: If text post already exists for our campaignId, update it instead of creating a new one.
   return rogue.createPost(payload);
 }
 
@@ -58,25 +57,28 @@ function getFetchVotingPlanQuery(user) {
 
 /**
  * @param {Object} user
- * @return {String}
+ * @return {Object}
  */
-function getVotingPlanDescription(user) {
-  const votingPlan = {
+function getVotingPlanValues(user) {
+  return {
     attending_with: user[config.fields.votingPlanAttendingWith.name],
     method_of_transport: user[config.fields.votingPlanMethodOfTransport.name],
     time_of_day: user[config.fields.votingPlanTimeOfDay.name],
   };
-  return JSON.stringify(votingPlan);
 }
 
 /**
  * @param {Object} user
  * @return {Promise}
  */
-function fetchVotingPlan(user) {
+async function fetchVotingPlan(user) {
   const query = module.exports.getFetchVotingPlanQuery(user);
   logger.debug('rogue.getPosts', { query });
-  return rogue.getPosts(query).then(res => res.data[0]);
+  const res = await rogue.getPosts(query);
+  if (res.data && res.data[0]) {
+    return res.data[0];
+  }
+  return null;
 }
 
 /**
@@ -115,7 +117,7 @@ module.exports = {
   createVotingPlanIfDoesntExist,
   fetchVotingPlan,
   getFetchVotingPlanQuery,
-  getVotingPlanDescription,
+  getVotingPlanValues,
   unauthenticatedFetchById(userId) {
     return northstar.unauthenticatedFetchUserById(userId);
   },

--- a/lib/helpers/user.js
+++ b/lib/helpers/user.js
@@ -40,7 +40,7 @@ function createVotingPlan(user, source) {
  */
 async function createVotingPlanIfDoesntExist(user, source) {
   const userId = user.id;
-  const res = await module.exports.getVotingPlan(user);
+  const res = await module.exports.getVotingPlanByUserId(userId);
   if (!res.data.length) {
     logger.debug('creating voting plan', { userId });
     return createVotingPlan(user, source);
@@ -50,12 +50,12 @@ async function createVotingPlanIfDoesntExist(user, source) {
 }
 
 /**
- * @param {Object} user
+ * @param {String} userId
  * @return {Promise}
  */
-function getVotingPlan(user) {
+function getVotingPlanByUserId(userId) {
   const query = {};
-  query['filter[northstar_id]'] = user.id;
+  query['filter[northstar_id]'] = userId;
   query['filter[campaign_id]'] = votingPlanCampaignId;
   return rogue.getPosts(query);
 }
@@ -94,7 +94,7 @@ async function updateByMemberMessageReq(req) {
 module.exports = {
   createVotingPlan,
   createVotingPlanIfDoesntExist,
-  getVotingPlan,
+  getVotingPlanByUserId,
   unauthenticatedFetchById(userId) {
     return northstar.unauthenticatedFetchUserById(userId);
   },

--- a/lib/helpers/user.js
+++ b/lib/helpers/user.js
@@ -16,15 +16,10 @@ const votingPlanPostConfig = config.posts.votingPlan;
  * @return {Promise}
  */
 function createVotingPlan(user, source) {
-  const votingPlan = {
-    attending_with: user[config.fields.votingPlanAttendingWith.name],
-    method_of_transport: user[config.fields.votingPlanMethodOfTransport.name],
-    time_of_day: user[config.fields.votingPlanTimeOfDay.name],
-  };
   const payload = {
     northstar_id: user.id,
     type: votingPlanPostConfig.type,
-    text: JSON.stringify(votingPlan),
+    text: module.exports.getVotingPlanDescription(user),
     campaign_id: votingPlanPostConfig.campaignId,
     source,
   };
@@ -51,13 +46,35 @@ async function createVotingPlanIfDoesntExist(user, source) {
 
 /**
  * @param {Object} user
- * @return {Promise}
+ * @return {Object}
  */
-function fetchVotingPlan(user) {
+function getFetchVotingPlanQuery(user) {
   const query = {};
   query['filter[northstar_id]'] = user.id;
   query['filter[campaign_id]'] = votingPlanPostConfig.campaignId;
   query['filter[type]'] = votingPlanPostConfig.type;
+  return query;
+}
+
+/**
+ * @param {Object} user
+ * @return {String}
+ */
+function getVotingPlanDescription(user) {
+  const votingPlan = {
+    attending_with: user[config.fields.votingPlanAttendingWith.name],
+    method_of_transport: user[config.fields.votingPlanMethodOfTransport.name],
+    time_of_day: user[config.fields.votingPlanTimeOfDay.name],
+  };
+  return JSON.stringify(votingPlan);
+}
+
+/**
+ * @param {Object} user
+ * @return {Promise}
+ */
+function fetchVotingPlan(user) {
+  const query = module.exports.getFetchVotingPlanQuery(user);
   logger.debug('rogue.getPosts', { query });
   return rogue.getPosts(query).then(res => res.data[0]);
 }
@@ -97,6 +114,8 @@ module.exports = {
   createVotingPlan,
   createVotingPlanIfDoesntExist,
   fetchVotingPlan,
+  getFetchVotingPlanQuery,
+  getVotingPlanDescription,
   unauthenticatedFetchById(userId) {
     return northstar.unauthenticatedFetchUserById(userId);
   },

--- a/lib/rogue.js
+++ b/lib/rogue.js
@@ -18,7 +18,7 @@ function getClient() {
  * @return {Promise}
  */
 function createPost(data) {
-  return getClient().Posts.create(data);
+  return module.exports.getClient().Posts.create(data);
 }
 
 /**
@@ -28,7 +28,7 @@ function createPost(data) {
  * @return {Promise}
  */
 function getPosts(query) {
-  return getClient().Posts.index(query);
+  return module.exports.getClient().Posts.index(query);
 }
 
 module.exports = {

--- a/lib/rogue.js
+++ b/lib/rogue.js
@@ -21,7 +21,18 @@ function createPost(data) {
   return getClient().Posts.create(data);
 }
 
+/**
+ * getPosts
+ *
+ * @param {object} query
+ * @return {Promise}
+ */
+function getPosts(query) {
+  return getClient().Posts.index(query);
+}
+
 module.exports = {
   getClient,
   createPost,
+  getPosts,
 };

--- a/test/helpers/factories/user.js
+++ b/test/helpers/factories/user.js
@@ -3,16 +3,22 @@
 const Chance = require('chance');
 const ObjectID = require('mongoose').Types.ObjectId;
 const stubs = require('../stubs');
+const config = require('../../../config/lib/helpers/user');
 
+const userFields = config.fields;
 const chance = new Chance();
 
 module.exports.getValidUser = function getValidUser(phoneNumber) {
-  return {
+  const user = {
     id: new ObjectID().toString(),
     mobile: phoneNumber || stubs.getMobileNumber(),
     sms_status: 'active',
     sms_paused: false,
   };
+  user[userFields.votingPlanAttendingWith.name] = chance.syllable();
+  user[userFields.votingPlanMethodOfTransport.name] = chance.syllable();
+  user[userFields.votingPlanTimeOfDay.name] = chance.syllable();
+  return user;
 };
 
 module.exports.getValidUserWithAddress = function getValidUserWithAddress(phoneNumber) {

--- a/test/unit/lib/lib-helpers/user.test.js
+++ b/test/unit/lib/lib-helpers/user.test.js
@@ -136,6 +136,19 @@ test('fetchFromReq calls fetchByMobile if req.platformUserId', async (t) => {
   userHelper.fetchById.should.not.have.been.called;
 });
 
+// fetchVotingPlan
+test('fetchVotingPlan should call rogue.getPosts with query for user voting plan', async () => {
+  const mockQuery = { test: '123' };
+  sandbox.stub(userHelper, 'getFetchVotingPlanQuery')
+    .returns(mockQuery);
+  sandbox.stub(rogue, 'getPosts')
+    .returns(Promise.resolve({ data: [mockPost] }));
+
+  const result = await userHelper.fetchVotingPlan(mockUser);
+  rogue.getPosts.should.have.been.calledWith(mockQuery);
+  result.should.deep.equal(mockPost);
+});
+
 // getCreatePayloadFromReq
 test('getCreatePayloadFromReq should return object', () => {
   const req = {
@@ -163,6 +176,16 @@ test('getDefaultUpdatePayloadFromReq should return object', () => {
   });
   result.last_messaged_at.should.equal(inboundMessage.createdAt.toISOString());
   result.sms_paused.should.equal(isSupportTopic);
+});
+
+// getFetchVotingPlanQuery
+test('getFetchVotingPlanQuery should return object with user id and voting plan campaign/type', () => {
+  const result = userHelper.getFetchVotingPlanQuery(mockUser);
+  result.should.deep.equal({
+    'filter[northstar_id]': mockUser.id,
+    'filter[campaign_id]': config.posts.votingPlan.campaignId,
+    'filter[type]': config.posts.votingPlan.type,
+  });
 });
 
 // hasAddress

--- a/test/unit/lib/lib-helpers/user.test.js
+++ b/test/unit/lib/lib-helpers/user.test.js
@@ -49,15 +49,12 @@ test.afterEach((t) => {
 
 // createVotingPlan
 test('createVotingPlan passes user voting plan info to rogue.createPost', async () => {
-  const votingPlan = {
-    attending_with: mockUser[config.fields.votingPlanAttendingWith.name],
-    method_of_transport: mockUser[config.fields.votingPlanMethodOfTransport.name],
-    time_of_day: mockUser[config.fields.votingPlanTimeOfDay.name],
-  };
-
+  const description = stubs.getRandomWord();
+  sandbox.stub(userHelper, 'getVotingPlanDescription')
+    .returns(description);
   const result = await userHelper.createVotingPlan(mockUser, source);
   rogue.createPost.should.have.been.calledWith({
-    text: JSON.stringify(votingPlan),
+    text: description,
     campaign_id: config.posts.votingPlan.campaignId,
     northstar_id: mockUser.id,
     type: config.posts.votingPlan.type,
@@ -186,6 +183,17 @@ test('getFetchVotingPlanQuery should return object with user id and voting plan 
     'filter[campaign_id]': config.posts.votingPlan.campaignId,
     'filter[type]': config.posts.votingPlan.type,
   });
+});
+
+// getVotingPlanDescription
+test('getVotingPlanDescription should return string with voting plan field values', () => {
+  const votingPlan = {
+    attending_with: mockUser[config.fields.votingPlanAttendingWith.name],
+    method_of_transport: mockUser[config.fields.votingPlanMethodOfTransport.name],
+    time_of_day: mockUser[config.fields.votingPlanTimeOfDay.name],
+  };
+  const result = userHelper.getVotingPlanDescription(mockUser);
+  result.should.deep.equal(JSON.stringify(votingPlan));
 });
 
 // hasAddress

--- a/test/unit/lib/lib-helpers/user.test.js
+++ b/test/unit/lib/lib-helpers/user.test.js
@@ -49,12 +49,12 @@ test.afterEach((t) => {
 
 // createVotingPlan
 test('createVotingPlan passes user voting plan info to rogue.createPost', async () => {
-  const description = stubs.getRandomWord();
-  sandbox.stub(userHelper, 'getVotingPlanDescription')
-    .returns(description);
+  const mockValues = { test: stubs.getRandomWord() };
+  sandbox.stub(userHelper, 'getVotingPlanValues')
+    .returns(mockValues);
   const result = await userHelper.createVotingPlan(mockUser, source);
   rogue.createPost.should.have.been.calledWith({
-    text: description,
+    text: JSON.stringify(mockValues),
     campaign_id: config.posts.votingPlan.campaignId,
     northstar_id: mockUser.id,
     type: config.posts.votingPlan.type,
@@ -185,15 +185,15 @@ test('getFetchVotingPlanQuery should return object with user id and voting plan 
   });
 });
 
-// getVotingPlanDescription
-test('getVotingPlanDescription should return string with voting plan field values', () => {
+// getVotingPlanValues
+test('getVotingPlanValues should return object with voting plan field values', () => {
   const votingPlan = {
     attending_with: mockUser[config.fields.votingPlanAttendingWith.name],
     method_of_transport: mockUser[config.fields.votingPlanMethodOfTransport.name],
     time_of_day: mockUser[config.fields.votingPlanTimeOfDay.name],
   };
-  const result = userHelper.getVotingPlanDescription(mockUser);
-  result.should.deep.equal(JSON.stringify(votingPlan));
+  const result = userHelper.getVotingPlanValues(mockUser);
+  result.should.deep.equal(votingPlan);
 });
 
 // hasAddress

--- a/test/unit/lib/lib-helpers/user.test.js
+++ b/test/unit/lib/lib-helpers/user.test.js
@@ -68,25 +68,25 @@ test('createVotingPlan passes user voting plan info to rogue.createPost', async 
 
 // createVotingPlanIfDoesntExist
 test('createVotingPlanIfDoesntExist returns null if voting plan exists for user', async (t) => {
-  sandbox.stub(userHelper, 'getVotingPlan')
+  sandbox.stub(userHelper, 'fetchVotingPlan')
     .returns(Promise.resolve(mockPost));
   sandbox.stub(userHelper, 'createVotingPlan')
     .returns(Promise.resolve(mockPost));
 
   const result = await userHelper.createVotingPlanIfDoesntExist(mockUser, source);
-  userHelper.getVotingPlan.should.have.been.calledWith(mockUser);
+  userHelper.fetchVotingPlan.should.have.been.calledWith(mockUser);
   userHelper.createVotingPlan.should.not.have.been.called;
   t.is(result, null);
 });
 
 test('createVotingPlanIfDoesntExist creates voting plan if voting plan does not exist for user', async () => {
-  sandbox.stub(userHelper, 'getVotingPlan')
+  sandbox.stub(userHelper, 'fetchVotingPlan')
     .returns(Promise.resolve(null));
   sandbox.stub(userHelper, 'createVotingPlan')
     .returns(Promise.resolve(mockPost));
 
   const result = await userHelper.createVotingPlanIfDoesntExist(mockUser, source);
-  userHelper.getVotingPlan.should.have.been.calledWith(mockUser);
+  userHelper.fetchVotingPlan.should.have.been.calledWith(mockUser);
   userHelper.createVotingPlan.should.have.been.calledWith(mockUser, source);
   result.should.deep.equal(mockPost);
 });

--- a/test/unit/lib/lib-helpers/user.test.js
+++ b/test/unit/lib/lib-helpers/user.test.js
@@ -35,7 +35,7 @@ const platformUserAddressStub = {
 
 test.beforeEach((t) => {
   t.context.req = httpMocks.createRequest();
-  sandbox.stub(helpers.user, 'createVotingPlan')
+  sandbox.stub(helpers.user, 'createVotingPlanIfDoesntExist')
     .returns(Promise.resolve(mockUser));
 });
 
@@ -181,13 +181,10 @@ test('updateByMemberMessageReq should return northstar.updateUser', async (t) =>
   sandbox.stub(userHelper, 'hasAddress')
     .returns(false);
   t.context.req.macro = stubs.getMacro();
-  sandbox.stub(helpers.macro, 'isCompletedVotingPlan')
-    .returns(false);
 
   const result = await userHelper.updateByMemberMessageReq(t.context.req);
   northstar.updateUser.should.have.been.calledWith(mockUser.id, { abc: 1, def: 2 });
   userHelper.hasAddress.should.not.have.been.called;
-  helpers.user.createVotingPlan.should.not.have.been.called;
   result.should.deep.equal(mockUser);
 });
 
@@ -203,13 +200,10 @@ test('updateByMemberMessageReq should not send req.platformUserAddress if user h
   sandbox.stub(userHelper, 'hasAddress')
     .returns(true);
   t.context.req.macro = stubs.getMacro();
-  sandbox.stub(helpers.macro, 'isCompletedVotingPlan')
-    .returns(false);
 
   const result = await userHelper.updateByMemberMessageReq(t.context.req);
   northstar.updateUser.should.have.been.calledWith(mockUser.id, { abc: 1, def: 2 });
   userHelper.hasAddress.should.have.been.calledWith(t.context.req.user);
-  helpers.user.createVotingPlan.should.not.have.been.called;
   result.should.deep.equal(mockUser);
 });
 
@@ -225,13 +219,10 @@ test('updateByMemberMessageReq should not send req.platformUserAddress if user d
   sandbox.stub(userHelper, 'hasAddress')
     .returns(false);
   t.context.req.macro = stubs.getMacro();
-  sandbox.stub(helpers.macro, 'isCompletedVotingPlan')
-    .returns(false);
 
   const result = await userHelper.updateByMemberMessageReq(t.context.req);
   northstar.updateUser.should.have.been.calledWith(mockUser.id, { abc: 1, def: 2, ghi: 3 });
   userHelper.hasAddress.should.have.been.calledWith(t.context.req.user);
-  helpers.user.createVotingPlan.should.not.have.been.called;
   result.should.deep.equal(mockUser);
 });
 
@@ -253,6 +244,6 @@ test('updateByMemberMessageReq should call createVotingPlan if macro isCompleted
   const result = await userHelper.updateByMemberMessageReq(t.context.req);
   northstar.updateUser.should.have.been.calledWith(mockUser.id, { abc: 1, def: 2, ghi: 3 });
   userHelper.hasAddress.should.have.been.calledWith(t.context.req.user);
-  helpers.user.createVotingPlan.should.have.been.calledWith(t.context.req.user);
+  helpers.user.createVotingPlanIfDoesntExist.should.have.been.calledWith(t.context.req.user);
   result.should.deep.equal(mockUser);
 });

--- a/test/unit/lib/rogue.test.js
+++ b/test/unit/lib/rogue.test.js
@@ -1,0 +1,59 @@
+'use strict';
+
+// libs
+require('dotenv').config();
+const test = require('ava');
+const chai = require('chai');
+const sinon = require('sinon');
+const sinonChai = require('sinon-chai');
+const rewire = require('rewire');
+const { RogueClient } = require('@dosomething/gateway/server');
+
+chai.should();
+chai.use(sinonChai);
+
+const sandbox = sinon.sandbox.create();
+
+const stubs = require('../../helpers/stubs');
+const userFactory = require('../../helpers/factories/user');
+
+const rogueApiStub = RogueClient.getNewInstance();
+const mockPost = { id: stubs.getCampaignRunId() };
+const mockUser = userFactory.getValidUser();
+
+// Module to test
+const rogue = rewire('../../../lib/rogue');
+
+test.afterEach(() => {
+  sandbox.restore();
+});
+
+// createPost
+test('createPost should call rogue.getClient.Posts.create', async () => {
+  const mockPayload = { northstar_id: mockUser.id };
+  const mockRogueResponse = { data: mockPost };
+  sandbox.stub(rogueApiStub.Posts, 'create')
+    .returns(Promise.resolve(mockRogueResponse));
+  sandbox.stub(rogue, 'getClient')
+    .returns(rogueApiStub);
+
+  const result = await rogue.createPost(mockPayload);
+  rogue.getClient.should.have.been.called;
+  rogueApiStub.Posts.create.should.have.been.calledWith(mockPayload);
+  result.should.deep.equal(mockRogueResponse);
+});
+
+// getPosts
+test('getPosts should call rogue.getClient.Posts.index', async () => {
+  const mockQuery = { 'filter[northstar_id]': mockUser.id };
+  const mockRogueResponse = { data: [mockPost] };
+  sandbox.stub(rogueApiStub.Posts, 'index')
+    .returns(Promise.resolve(mockRogueResponse));
+  sandbox.stub(rogue, 'getClient')
+    .returns(rogueApiStub);
+
+  const result = await rogue.getPosts(mockQuery);
+  rogue.getClient.should.have.been.called;
+  rogueApiStub.Posts.index.should.have.been.calledWith(mockQuery);
+  result.should.deep.equal(mockRogueResponse);
+});


### PR DESCRIPTION
#### What's this PR do?

Checks whether a voting plan post exists in Rogue before creating, to prevent creating multiple Rogue voting posts for a user.

#### How should this be reviewed?
Verify that another round of "yes" response to a `askVotingStatusPlan` broadcast (e.g. `4LJn0P1LeoUauC0CkESYKE`) does not result in an additional Rogue post (can 👀 your user's Gambit Admin signups tab to verify)

#### Any background context you want to provide?

A future iteration could execute a `PATCH /posts/:id` request to update the voting plan post with the user's latest voting plan responses -- but we don't have any current plans to send users multiple `askVotingPlanStatus` broadcasts in production. This PR goes for minimal changes, as implementing this would require updating [gateway-js](https://github.com/dosomething/gateway-js) to additionally support patch requests for Rogue posts.

#### Relevant tickets

Completes final dev task in https://www.pivotaltracker.com/story/show/160824069

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [x] Tests added/updated for new features/bug fixes.
- [x] Tested on staging.
