### PR TITLE
Refactors as fetchOrCreateVotingPlan

### DIFF
--- a/brain/topics/askVotingPlanStatus.rive
+++ b/brain/topics/askVotingPlanStatus.rive
@@ -1,4 +1,4 @@
-+ make a plan
++ voting plan
 - askVotingPlanStatus
 
 // Current options are A) Yes B) No C) Already voted D) Can't vote

--- a/lib/helpers/user.js
+++ b/lib/helpers/user.js
@@ -16,12 +16,14 @@ const votingPlanPostConfig = config.posts.votingPlan;
  * @return {Promise}
  */
 function createVotingPlan(user, source) {
+  const details = JSON.stringify(module.exports.getVotingPlanValues(user));
   const payload = {
-    northstar_id: user.id,
-    type: votingPlanPostConfig.type,
-    text: JSON.stringify(module.exports.getVotingPlanValues(user)),
     campaign_id: votingPlanPostConfig.campaignId,
+    details,
+    northstar_id: user.id,
     source,
+    text: details,
+    type: votingPlanPostConfig.type,
   };
   logger.debug('rogue.createPost', { payload });
   return rogue.createPost(payload);
@@ -32,12 +34,12 @@ function createVotingPlan(user, source) {
  * @param {String} source
  * @return {Promise}
  */
-async function createVotingPlanIfDoesntExist(user, source) {
+async function fetchOrCreateVotingPlan(user, source) {
   const userId = user.id;
   const votingPlan = await module.exports.fetchVotingPlan(user);
   if (votingPlan) {
     logger.debug('voting plan exists', { userId });
-    return null;
+    return votingPlan;
   }
   logger.debug('creating voting plan', { userId });
   return module.exports.createVotingPlan(user, source);
@@ -104,7 +106,8 @@ async function updateByMemberMessageReq(req) {
     }
     const user = await northstar.updateUser(req.user.id, payload);
     if (helpers.macro.isCompletedVotingPlan(req.macro)) {
-      await module.exports.createVotingPlanIfDoesntExist(user, req.platform);
+      const votingPlan = await module.exports.fetchOrCreateVotingPlan(user, req.platform);
+      logger.debug('votingPlan', { votingPlan }, req);
     }
     return user;
   } catch (error) {
@@ -114,7 +117,7 @@ async function updateByMemberMessageReq(req) {
 
 module.exports = {
   createVotingPlan,
-  createVotingPlanIfDoesntExist,
+  fetchOrCreateVotingPlan,
   fetchVotingPlan,
   getFetchVotingPlanQuery,
   getVotingPlanValues,


### PR DESCRIPTION
#### What's this PR do?

Refactors `createVotingPlanIfDoesntExist` as `fetchOrCreateVotingPlan`, and logs the found-or-created voting plan for debugging.

#### How should this be reviewed?
Verify expected behavior for creating a new voting plan post (by deleting a previous voting plan if one exists already), and verify a second post is not created upon completing another voting plan flow.

#### Any background context you want to provide?

Also sends JSON to the [`details` property](https://github.com/DoSomething/rogue/blob/master/docs/endpoints/posts.md#create-a-post), although from what I can tell in the API responses, it's not returned regardless of a value set (cc @katiecrane)

#### Checklist
- [x] Tests added/updated for new features/bug fixes.
- [x] Tested on staging.
