### PR TITLE
Adds additional votingPlan topic triggers

### DIFF
--- a/brain/index.rive
+++ b/brain/index.rive
@@ -66,10 +66,11 @@
  *
  * Note: although Rivescript doesn't throw an error, using an array with underscore in its name in a 
  * trigger will fail to match... which is why some of these have names like 'publictransport'.
- * Rivescript does  throw an error if an uppercase letter appears within a trigger.
+ * Rivescript does throw an error if an uppercase letter appears within a trigger.
  * @see https://github.com/aichaos/rivescript-js/issues/118#issuecomment-220413307
  */
 ! array afternoon = afternoon lunch lunchtime noon
+! array alone     = alone|me|myself|self|solo
 ! array bike      = bicycle|bike|bikin|biking|cycling
 ! array bot       = bot robot machine computer
 ! array botname   = freddie freddi alicia alysa alysha
@@ -79,6 +80,16 @@
 ! array dosomething = dosomething|dosomethingorg|do something
 ! array drive     = car|driv|drive|drivin|driving|truck|whip
 ! array evening   = even eveni evenin evening night nighttime nite
+! array family    = abeula|abeulas|aunt|aunts|auntie|bro|bros|brother|brothers
+^ cousin|cousins|cuz|cuzzies
+^ dad|daddy|father|fam|family|fams|famz
+^ grandfather|grandpa|grandma|grandmother|grandma|grandmama|hermana|hermanas|hermano|hermanos
+^ ma|madre|mama|mom|mommy|mother|pa|padre|papi|stepdad|stepfather|stepmom|stepmother|uncle|uncles
+! array friends   = amigo|amgios|bf|bff|bffs|boi|bois|boiz|boo|boy|boyfriend|boyfriends|boys|boyz
+^ fiend|friend|friends
+^ gf|girl|girlfriend|girlfriends|girls|grl|grls|grrl|grrls|grlz
+^ homey|homeys|homie|homies
+^ man|mans|woman|women
 ! array greetings = hola|howdy
   ^ hi|hii|hiii|hiiii|hiiiii|hiiiiii
   ^ hello|helloo|hellooo|hellloooo

--- a/brain/index.rive
+++ b/brain/index.rive
@@ -71,12 +71,16 @@
 ! array dosomething = dosomething|dosomethingorg|do something
 ! array drive     = car|driv|drive|drivin|driving|truck|whip
 ! array evening   = even eveni evenin evening night nighttime nite
-! array family    = abeula|abeulas|aunt|aunts|auntie|bro|bros|brother|brothers
+! array family    = abeula|abeulas|abuelo|abeulos|aunt|aunts|auntie|aunties
+  ^ bro|bros|brother|brothers
   ^ cousin|cousins|cuz|cuzzies
   ^ dad|daddy|father|fam|family|fams|famz
   ^ grandfather|grandpa|grandma|grandmother|grandma|grandmama|hermana|hermanas|hermano|hermanos
-  ^ ma|madre|mama|mom|mommy|mother|pa|padre|papi|stepdad|stepfather|stepmom|stepmother|uncle|uncles
-! array friends   = amigo|amgios|bf|bff|bffs|boi|bois|boiz|boo|boy|boyfriend|boyfriends|boys|boyz
+  ^ ma|madre|mama|mom|mommy|mother
+  ^ pa|padre|papi|pop|poppy
+  ^ sis|sista|sistas|sister|stepdad|stepfather|stepmom|stepmother|uncle|uncles
+! array friends   = amigo|amigos
+  ^ bf|bff|bffs|boi|bois|boiz|boo|boy|boyfriend|boyfriends|boys|boyz|bud|buddies|buddy|buds
   ^ fiend|friend|friends
   ^ gf|girl|girlfriend|girlfriends|girls|grl|grls|grrl|grrls|grlz
   ^ homey|homeys|homie|homies

--- a/brain/index.rive
+++ b/brain/index.rive
@@ -61,11 +61,19 @@
 ! sub wut     = what
 ! sub wuts    = what is
 
-// Arrays
+/**
+ * Arrays
+ *
+ * Note: although Rivescript doesn't throw an error, using an array with underscore in its name in a 
+ * trigger will fail to match... which is why some of these have names like 'publictransport'.
+ * Rivescript does  throw an error if an uppercase letter appears within a trigger.
+ * @see https://github.com/aichaos/rivescript-js/issues/118#issuecomment-220413307
+ */
 ! array afternoon = afternoon lunch lunchtime noon
 ! array bike      = bicycle|bike|bikin|biking|cycling
 ! array bot       = bot robot machine computer
 ! array botname   = freddie freddi alicia alysa alysha
+! array coworkers = co-workers coworkers work
 ! array die       = die|kill myself|killing myself
   ^ commit suicide|committing suicide|commiting suicide
 ! array dosomething = dosomething|dosomethingorg|do something
@@ -93,8 +101,8 @@
 ! array no        = n no nah nope nay
 ! array photo     = photo photos mms pic pics pix image image img
 ! array please    = pls|plz|please|can you|will you
-! array publictransport = bart|bus|cable car|ferry
-   ^ lirr|metro|mta|muni|rail|subway|train|tram|trans|transport|transportation|trolley
+! array publictransport = bart|bus|cable car|ferry|lirr|public|mass|metro
+   ^ mta|muni|rail|subway|train|tram|trans|transit|transport|transportation|trolley
 ! array question  = is there|who|what|when|why|how
 ! array send      = send submit text
 ! array social    = social media|facebook|twitter|instagram|social

--- a/brain/index.rive
+++ b/brain/index.rive
@@ -62,6 +62,7 @@
 ! sub wuts    = what is
 
 // Arrays
+! array afternoon = afternoon lunch lunchtime noon
 ! array bike      = bicycle|bike|bikin|biking|cycling
 ! array bot       = bot robot machine computer
 ! array botname   = freddie freddi alicia alysa alysha
@@ -69,6 +70,7 @@
   ^ commit suicide|committing suicide|commiting suicide
 ! array dosomething = dosomething|dosomethingorg|do something
 ! array drive     = car|driv|drive|drivin|driving|truck|whip
+! array evening   = even eveni evenin evening night nighttime nite
 ! array greetings = hola|howdy
   ^ hi|hii|hiii|hiiii|hiiiii|hiiiiii
   ^ hello|helloo|hellooo|hellloooo
@@ -86,6 +88,7 @@
   ^ suicidal|suicidial|suicide
 ! array messaging = text|texts|txt|texting|txting|talking|talkign
   ^ messaging|contacting|sending|list|this list
+! array morning   = am morn morni mornin morning
 ! array my        = my this
 ! array no        = n no nah nope nay
 ! array photo     = photo photos mms pic pics pix image image img

--- a/brain/index.rive
+++ b/brain/index.rive
@@ -7,20 +7,11 @@
 ! var url  = DoSomething.org
 
 // Substitutions
-! sub bf      = someone
-! sub bff     = someone
-! sub brother = someone
-! sub boyfriend  = someone
 ! sub can't   = can not
 ! sub cant    = can not
-! sub dad     = someone
 ! sub dis     = this
 ! sub don't   = do not
 ! sub dont    = do not
-! sub father  = someone
-! sub friend  = someone
-! sub girlfriend = someone
-! sub gf      = someone
 ! sub gonna   = going to
 ! sub he      = someone
 ! sub he's    = someone is
@@ -81,15 +72,15 @@
 ! array drive     = car|driv|drive|drivin|driving|truck|whip
 ! array evening   = even eveni evenin evening night nighttime nite
 ! array family    = abeula|abeulas|aunt|aunts|auntie|bro|bros|brother|brothers
-^ cousin|cousins|cuz|cuzzies
-^ dad|daddy|father|fam|family|fams|famz
-^ grandfather|grandpa|grandma|grandmother|grandma|grandmama|hermana|hermanas|hermano|hermanos
-^ ma|madre|mama|mom|mommy|mother|pa|padre|papi|stepdad|stepfather|stepmom|stepmother|uncle|uncles
+  ^ cousin|cousins|cuz|cuzzies
+  ^ dad|daddy|father|fam|family|fams|famz
+  ^ grandfather|grandpa|grandma|grandmother|grandma|grandmama|hermana|hermanas|hermano|hermanos
+  ^ ma|madre|mama|mom|mommy|mother|pa|padre|papi|stepdad|stepfather|stepmom|stepmother|uncle|uncles
 ! array friends   = amigo|amgios|bf|bff|bffs|boi|bois|boiz|boo|boy|boyfriend|boyfriends|boys|boyz
-^ fiend|friend|friends
-^ gf|girl|girlfriend|girlfriends|girls|grl|grls|grrl|grrls|grlz
-^ homey|homeys|homie|homies
-^ man|mans|woman|women
+  ^ fiend|friend|friends
+  ^ gf|girl|girlfriend|girlfriends|girls|grl|grls|grrl|grrls|grlz
+  ^ homey|homeys|homie|homies
+  ^ man|mans|woman|women
 ! array greetings = hola|howdy
   ^ hi|hii|hiii|hiiii|hiiiii|hiiiiii
   ^ hello|helloo|hellooo|hellloooo

--- a/brain/index.rive
+++ b/brain/index.rive
@@ -74,11 +74,11 @@
 ! array family    = abeula|abeulas|abuelo|abeulos|aunt|aunts|auntie|aunties
   ^ bro|bros|brother|brothers
   ^ cousin|cousins|cuz|cuzzies
-  ^ dad|daddy|father|fam|family|fams|famz
+  ^ dad|daddy|father|fam|famil|famili|familia|family|fams|famz
   ^ grandfather|grandpa|grandma|grandmother|grandma|grandmama|hermana|hermanas|hermano|hermanos
   ^ ma|madre|mama|mom|mommy|mother
   ^ pa|padre|papi|pop|poppy
-  ^ sis|sista|sistas|sister|stepdad|stepfather|stepmom|stepmother|uncle|uncles
+  ^ sis|sista|sistas|sister|stepdad|stepfather|stepmom|stepmother|tia|tias|tio|tios|uncle|uncles
 ! array friends   = amigo|amigos
   ^ bf|bff|bffs|boi|bois|boiz|boo|boy|boyfriend|boyfriends|boys|boyz|bud|buddies|buddy|buds
   ^ fiend|friend|friends

--- a/brain/macros.rive
+++ b/brain/macros.rive
@@ -75,6 +75,12 @@
 + [*] (i|someone|who) [@is] @hurting [me] [*]
 @ crisis
 
++ [*] @family [@is] @hurting [me] [*]
+@ crisis
+
++ [*] @friends [@is] @hurting [me] [*]
+@ crisis
+
 + [*] kill myself [*]
 @ crisis
 

--- a/brain/topics/askVotingPlanStatus.rive
+++ b/brain/topics/askVotingPlanStatus.rive
@@ -4,26 +4,42 @@
 // Current options are A) Yes B) No C) Already voted D) Can't vote
 // @see config/lib/helpers/macro
 
-// TODO: Add more substitutions and triggers for each option
-
 > topic ask_voting_plan_status includes random
 
 + a
 - votingPlanStatusVoting
 
-+ [*] @yes [*]
-@ a
-
 + b
 - votingPlanStatusNotVoting
-
-+ @no [*]
-@ b
 
 + c
 - votingPlanStatusVoted
 
 + d
+- votingPlanStatusCantVote
+
++ @no [*]
+- votingPlanStatusNotVoting
+
++ [*] am voting [*]
+- votingPlanStatusVoting
+
++ [*] can not vote [*]
+- votingPlanStatusCantVote
+
++ [*] not old [*]
+- votingPlanStatusCantVote
+
++ [*] not voting [*]
+- votingPlanStatusNotVoting
+
++ [*] voted [*]
+- votingPlanStatusVoted
+
++ [*] @yes [*]
+- votingPlanStatusVoting
+
++ [*] young [*]
 - votingPlanStatusCantVote
 
 + [*]

--- a/brain/topics/votingPlan/askAttendingWith.rive
+++ b/brain/topics/votingPlan/askAttendingWith.rive
@@ -1,8 +1,6 @@
 // Current options are A) Alone B) Friends C) Family D) Co-workers
 // @see config/lib/helpers/macro
 
-// TODO: Add more substitutions and triggers for each option
-
 > topic ask_voting_plan_attending_with includes random
 
 + a
@@ -16,6 +14,18 @@
 
 + d
 - votingPlanAttendingWithCoWorkers
+
++ [*] @alone [*]
+- votingPlanAttendingWithAlone
+
++ [*] @coworkers [*]
+- votingPlanAttendingWithCoWorkers
+
++ [*] @family [*]
+- votingPlanAttendingWithFamily
+
++ [*] @friends [*]
+- votingPlanAttendingWithFriends
 
 + [*]
 - invalidVotingPlanAttendingWith

--- a/brain/topics/votingPlan/askMethodOfTransport.rive
+++ b/brain/topics/votingPlan/askMethodOfTransport.rive
@@ -6,29 +6,26 @@
 + a
 - votingPlanMethodOfTransportDrive
 
-+ [*] @drive [*]
-@ a
-
 + b
 - votingPlanMethodOfTransportWalk
-
-+ [*] @walk [*]
-@ b
 
 + c
 - votingPlanMethodOfTransportBike
 
-+ [*] @bike [*]
-@ c
-
 + d
 - votingPlanMethodOfTransportPublicTransport
 
-+ [*] @publictransport [*]
-@ d
++ [*] @bike [*]
+- votingPlanMethodOfTransportBike
 
-+ [*] (mass|public) [*]
-@ d
++ [*] @drive [*]
+- votingPlanMethodOfTransportDrive
+
++ [*] @publictransport [*]
+- votingPlanMethodOfTransportPublicTransport
+
++ [*] @walk [*]
+- votingPlanMethodOfTransportWalk
 
 + [*]
 - invalidVotingPlanMethodOfTransport

--- a/brain/topics/votingPlan/askTimeOfDay.rive
+++ b/brain/topics/votingPlan/askTimeOfDay.rive
@@ -1,8 +1,6 @@
 // Current options are A) Morning B) Afternoon C) Evening
 // @see config/lib/helpers/macro
 
-// TODO: Add more substitutions and triggers for each option
-
 > topic ask_voting_plan_time_of_day includes random
 
 + a
@@ -13,6 +11,15 @@
 
 + c
 - votingPlanTimeOfDayEvening
+
++ [*] @afternooon [*]
+- votingPlanTimeOfDayAfternoon
+
++ [*] @evening [*]
+- votingPlanTimeOfDayEvening
+
++ [*] @morning [*]
+- votingPlanTimeOfDayMorning
 
 + [*]
 - invalidVotingPlanTimeOfDay


### PR DESCRIPTION
#### What's this PR do?

Branching from #420, this PR adds additional Rivescript triggers and arrays to parse the option values within the multiple choice questions in the Voting Plan topics as valid responses (e.g. If user responds with "my aunt", execute the `votingPlanStatusAttendingWithFamily` macro.

Also cleans up voting plan trigger definitions, grouping the multiple choice `a`, `b`, `c` triggers separately and removing redirects, to make it easier to switch around the a/b/c values if necessary.

#### How should this be reviewed?

I've been spot checking by manually testing an `askVotingPlanStatus` and answering with values that appear within the question (or with substitutions I've been adding).  Ideally we should be adding integration tests for `POST /messages?origin=twilio` that verify the message macros set as expected in the `response.data.messages`.

#### Any background context you want to provide?

I've been wondering whether Rivescript trigger is less cumbersome than a regex for some of these arrays like `family` and `friends` that have a lot of values between the singular and plurals, but think it's safe to keep this as is now as we're looking to QA with staff early next week.

#### Relevant tickets

Fixes https://www.pivotaltracker.com/story/show/161248123

#### Checklist
- [x] Tested on staging.
