### PR TITLE
Updates webSignup as topic template

### DIFF
--- a/config/lib/helpers/template.js
+++ b/config/lib/helpers/template.js
@@ -47,9 +47,7 @@ const templatesMap = {
     votingPlanStatusCantVote: 'votingPlanStatusCantVote',
     votingPlanStatusNotVoting: 'votingPlanStatusNotVoting',
     votingPlanStatusVoted: 'votingPlanStatusVoted',
-    webAskText: 'webAskText',
-    webStartExternalPost: 'webStartExternalPost',
-    webStartPhotoPost: 'webStartPhotoPost',
+    webSignup: 'webSignup',
   },
   // TODO: Move these into the replies helper config, or set on config via middleware that checks
   // for each condition.


### PR DESCRIPTION
#### What's this PR do?

Fixes bug in #423, updating the topic templates config with `webSignup` and removing the deprecated `webStart` templates.

#### How should this be reviewed?
Via DM with [gambit-slack](https://github.com/dosomething/gambit-slack):
* Send a `web` command for a list of campaign id's configured with a `webSignup` template
* Click a "Send test" button to trigger the signup confirmation message
* Reply to the signup confirmation message. Verify that Gambit responds with the expected topic template per your message, and does not reply with a "Did you want to get back to [campaign title]"? 

#### Any background context you want to provide?

Another good example of where some lengthy integration tests could have caught this... which is perhaps a good project to start when things slow down around the holidays later this year ☃️ 

#### Checklist
- [x] Tested on staging.
