### PR TITLE
Adds user.votingPlan tag [pr]

### DIFF
--- a/config/lib/helpers/tags.js
+++ b/config/lib/helpers/tags.js
@@ -1,11 +1,47 @@
 'use strict';
 
+const userConfig = require('./user');
+
+const userFields = userConfig.fields;
+
 const pollingLocatorQuery = {
   source: 'sms',
   utm_campaign: 'sms_gotv',
   utm_medium: 'sms',
   utm_source: 'dosomething',
 };
+
+const votingPlanVarsByFieldValue = {
+  attendingWith: {},
+  methodOfTransport: {},
+  timeOfDay: {},
+};
+
+const votingPlanAttendingWithValues = userFields.votingPlanAttendingWith.values;
+Object.keys(votingPlanAttendingWithValues).forEach((attendingWithName) => {
+  const fieldValue = votingPlanAttendingWithValues[attendingWithName];
+  if (fieldValue === votingPlanAttendingWithValues.alone) {
+    votingPlanVarsByFieldValue.attendingWith[fieldValue] = 'by yourself';
+  } else if (fieldValue === votingPlanAttendingWithValues.coWorkers) {
+    votingPlanVarsByFieldValue.attendingWith[fieldValue] = 'with co-workers';
+  } else {
+    votingPlanVarsByFieldValue.attendingWith[fieldValue] = `with ${fieldValue}`;
+  }
+});
+
+const votingPlanMethodOfTransportValues = userFields.votingPlanMethodOfTransport.values;
+Object.keys(votingPlanMethodOfTransportValues).forEach((methodOfTransportName) => {
+  const fieldValue = votingPlanMethodOfTransportValues[methodOfTransportName];
+  if (fieldValue === votingPlanMethodOfTransportValues.publicTransport) {
+    votingPlanVarsByFieldValue.methodOfTransport[fieldValue] = 'take public transit';
+  } else {
+    votingPlanVarsByFieldValue.methodOfTransport[fieldValue] = fieldValue;
+  }
+});
+
+Object.keys(userFields.votingPlanTimeOfDay.values).forEach((timeOfDayName) => {
+  votingPlanVarsByFieldValue.timeOfDay[timeOfDayName] = timeOfDayName;
+});
 
 module.exports = {
   links: {
@@ -18,6 +54,12 @@ module.exports = {
         url: process.env.DS_GAMBIT_CONVERSATIONS_POLLING_LOCATOR_SHARE_URL || 'https://www.dosomething.org/us/campaigns/find-your-v-spot/blocks/5WuCqMMGre02mq8MqK4co6',
         query: pollingLocatorQuery,
       },
+    },
+  },
+  user: {
+    votingPlan: {
+      template: '{{methodOfTransport}} in the {{timeOfDay}} {{attendingWith}}',
+      vars: votingPlanVarsByFieldValue,
     },
   },
 };

--- a/config/lib/helpers/tags.js
+++ b/config/lib/helpers/tags.js
@@ -8,11 +8,6 @@ const pollingLocatorQuery = {
 };
 
 module.exports = {
-  // Tags used in message templates.
-  tags: {
-    links: 'links',
-    user: 'user',
-  },
   links: {
     pollingLocator: {
       find: {

--- a/config/lib/helpers/tags.js
+++ b/config/lib/helpers/tags.js
@@ -23,9 +23,9 @@ Object.keys(votingPlanAttendingWithValues).forEach((attendingWithName) => {
   if (fieldValue === votingPlanAttendingWithValues.alone) {
     votingPlanVarsByFieldValue.attendingWith[fieldValue] = 'by yourself';
   } else if (fieldValue === votingPlanAttendingWithValues.coWorkers) {
-    votingPlanVarsByFieldValue.attendingWith[fieldValue] = 'with co-workers';
+    votingPlanVarsByFieldValue.attendingWith[fieldValue] = 'with your co-workers';
   } else {
-    votingPlanVarsByFieldValue.attendingWith[fieldValue] = `with ${fieldValue}`;
+    votingPlanVarsByFieldValue.attendingWith[fieldValue] = `with your ${fieldValue}`;
   }
 });
 

--- a/lib/helpers/tags.js
+++ b/lib/helpers/tags.js
@@ -32,6 +32,16 @@ function getBroadcastLinkQueryParams(req) {
   return result;
 }
 
+/**
+ * @param {Object} req
+ * @return {Object}
+ */
+function getTags(req) {
+  return {
+    links: module.exports.getLinksTag(req),
+    user: req.user ? module.exports.getUserTag(req.user) : {},
+  };
+}
 
 /**
  * @param {Object} req
@@ -48,10 +58,55 @@ function getUserLinkQueryParams(req) {
 }
 
 /**
+ * @param {Object} user
+ * @return {Object}
+ */
+function getUserTag(user) {
+  return {
+    id: user.id,
+    votingPlan: module.exports.getVotingPlanDescription(user),
+  };
+}
+
+/**
+ * @param {Object} user
+ * @return {String}
+ */
+function getVotingPlanDescription(user) {
+  const attendingWith = module.exports
+    .getVotingPlanAttendingWithDescription(user.voting_plan_attending_with);
+  const methodOfTransport = module.exports
+    .getVotingPlanMethodOfTransportDescription(user.voting_plan_method_of_transport);
+  return `${methodOfTransport} in the ${user.voting_plan_time_of_day} ${attendingWith}`;
+}
+
+/**
+ * @param {String} value
+ * @return {String}
+ */
+function getVotingPlanAttendingWithDescription(value) {
+  if (value === 'co_workers') {
+    return 'with your co-workers';
+  }
+  if (value === 'alone') {
+    return 'by yourself';
+  }
+  return `with your ${value}`;
+}
+
+/**
+ * @param {String} value
+ * @return {String}
+ */
+function getVotingPlanMethodOfTransportDescription(value) {
+  return value === 'public_transport' ? 'take public transport' : value;
+}
+
+/**
  * @param {Object} req
  * @return {Object}
  */
-function getLinks(req) {
+function getLinksTag(req) {
   return {
     pollingLocator: {
       find: module.exports.getLink(config.links.pollingLocator.find, req),
@@ -60,18 +115,24 @@ function getLinks(req) {
   };
 }
 
+/**
+ * @param {String} string
+ * @param {Object} req
+ * @return {String}
+ */
+function render(string, req) {
+  return mustache.render(string, module.exports.getTags(req));
+}
+
 module.exports = {
   getBroadcastLinkQueryParams,
   getLink,
-  getLinks,
+  getLinksTag,
+  getTags,
   getUserLinkQueryParams,
-  getVarsForTags: function getVarsForTags(req) {
-    const vars = {};
-    vars[config.tags.links] = module.exports.getLinks(req);
-    vars[config.tags.user] = req.user || {};
-    return vars;
-  },
-  render: function render(string, req) {
-    return mustache.render(string, module.exports.getVarsForTags(req));
-  },
+  getUserTag,
+  getVotingPlanAttendingWithDescription,
+  getVotingPlanDescription,
+  getVotingPlanMethodOfTransportDescription,
+  render,
 };

--- a/lib/helpers/tags.js
+++ b/lib/helpers/tags.js
@@ -2,7 +2,11 @@
 
 const mustache = require('mustache');
 const queryString = require('query-string');
+const logger = require('../logger');
 const config = require('../../config/lib/helpers/tags');
+const userConfig = require('../../config/lib/helpers/user');
+
+const votingPlanVars = config.user.votingPlan.vars;
 
 /**
  * @param {Object} linkConfig
@@ -64,7 +68,7 @@ function getUserLinkQueryParams(req) {
 function getUserTag(user) {
   return {
     id: user.id,
-    votingPlan: module.exports.getVotingPlanDescription(user),
+    votingPlan: module.exports.getVotingPlan(user),
   };
 }
 
@@ -72,34 +76,46 @@ function getUserTag(user) {
  * @param {Object} user
  * @return {String}
  */
-function getVotingPlanDescription(user) {
-  const attendingWith = module.exports
-    .getVotingPlanAttendingWithDescription(user.voting_plan_attending_with);
-  const methodOfTransport = module.exports
-    .getVotingPlanMethodOfTransportDescription(user.voting_plan_method_of_transport);
-  return `${methodOfTransport} in the ${user.voting_plan_time_of_day} ${attendingWith}`;
+function getVotingPlan(user) {
+  const vars = {
+    attendingWith: module.exports.getVotingPlanAttendingWith(user),
+    methodOfTransport: module.exports.getVotingPlanMethodOfTransport(user),
+    timeOfDay: module.exports.getVotingPlanTimeOfDay(user),
+  };
+  const description = mustache.render(config.user.votingPlan.template, vars);
+  const result = Object.assign({ description }, vars);
+  logger.debug('getVotingPlan', { result });
+  return result;
 }
 
 /**
- * @param {String} value
+ * @param {Object} user
  * @return {String}
  */
-function getVotingPlanAttendingWithDescription(value) {
-  if (value === 'co_workers') {
-    return 'with your co-workers';
-  }
-  if (value === 'alone') {
-    return 'by yourself';
-  }
-  return `with your ${value}`;
+function getVotingPlanAttendingWith(user) {
+  const fieldName = userConfig.fields.votingPlanAttendingWith.name;
+  const fieldValue = user[fieldName];
+  return votingPlanVars.attendingWith[fieldValue];
 }
 
 /**
- * @param {String} value
+ * @param {Object} user
  * @return {String}
  */
-function getVotingPlanMethodOfTransportDescription(value) {
-  return value === 'public_transport' ? 'take public transport' : value;
+function getVotingPlanMethodOfTransport(user) {
+  const fieldName = userConfig.fields.votingPlanMethodOfTransport.name;
+  const fieldValue = user[fieldName];
+  return votingPlanVars.methodOfTransport[fieldValue];
+}
+
+/**
+ * @param {Object} user
+ * @return {String}
+ */
+function getVotingPlanTimeOfDay(user) {
+  const fieldName = userConfig.fields.votingPlanTimeOfDay.name;
+  const fieldValue = user[fieldName];
+  return votingPlanVars.timeOfDay[fieldValue];
 }
 
 /**
@@ -131,8 +147,9 @@ module.exports = {
   getTags,
   getUserLinkQueryParams,
   getUserTag,
-  getVotingPlanAttendingWithDescription,
-  getVotingPlanDescription,
-  getVotingPlanMethodOfTransportDescription,
+  getVotingPlan,
+  getVotingPlanAttendingWith,
+  getVotingPlanMethodOfTransport,
+  getVotingPlanTimeOfDay,
   render,
 };

--- a/test/unit/lib/lib-helpers/tags.test.js
+++ b/test/unit/lib/lib-helpers/tags.test.js
@@ -33,7 +33,7 @@ const sandbox = sinon.sandbox.create();
 const mockBroadcast = broadcastFactory.getValidAutoReplyBroadcast();
 const mockText = stubs.getRandomMessageText();
 const mockUser = userFactory.getValidUser();
-const mockVars = { season: 'winter' };
+const mockTags = { season: 'winter' };
 
 test.beforeEach((t) => {
   stubs.stubLogger(sandbox, logger);
@@ -54,9 +54,9 @@ test('getLink should return a string with linkConfig values', (t) => {
   result.should.equal(`${findPollingLocatorConfig.url}?${query}`);
 });
 
-// getLinks
-test('getLinks should return an object', (t) => {
-  const result = tagsHelper.getLinks(t.context.req);
+// getLinksTag
+test('getLinksTag should return an object', (t) => {
+  const result = tagsHelper.getLinksTag(t.context.req);
   result.pollingLocator.should.have.property('find');
   result.pollingLocator.should.have.property('share');
 });
@@ -65,8 +65,8 @@ test('getLinks should return an object', (t) => {
 test('render should return a string', () => {
   sandbox.stub(mustache, 'render')
     .returns(mockText);
-  sandbox.stub(tagsHelper, 'getVarsForTags')
-    .returns(mockVars);
+  sandbox.stub(tagsHelper, 'getTags')
+    .returns(mockTags);
   const result = tagsHelper.render(mockText, {});
   mustache.render.should.have.been.called;
   result.should.equal(mockText);
@@ -75,15 +75,15 @@ test('render should return a string', () => {
 test('render should throw if mustache.render fails', () => {
   sandbox.stub(mustache, 'render')
     .returns(new Error());
-  sandbox.stub(tagsHelper, 'getVarsForTags')
-    .returns(mockVars);
-  tagsHelper.render(mockText, mockVars).should.throw;
+  sandbox.stub(tagsHelper, 'getTags')
+    .returns(mockTags);
+  tagsHelper.render(mockText, mockTags).should.throw;
 });
 
-test('render should throw if getVarsForTags fails', () => {
-  sandbox.stub(tagsHelper, 'getVarsForTags')
+test('render should throw if mockTags fails', () => {
+  sandbox.stub(tagsHelper, 'getTags')
     .returns(new Error());
-  tagsHelper.render(mockText, mockVars).should.throw;
+  tagsHelper.render(mockText, mockTags).should.throw;
 });
 
 test('render should replace user vars', (t) => {
@@ -92,9 +92,9 @@ test('render should replace user vars', (t) => {
   result.should.equal(mockUser.id);
 });
 
-// getVarsForTags
-test('getVarsForTags should return an object', (t) => {
-  const result = tagsHelper.getVarsForTags(t.context.req);
+// getTags
+test('getTags should return an object', (t) => {
+  const result = tagsHelper.getTags(t.context.req);
   result.should.be.a('object');
   result.should.have.property('links');
   result.should.have.property('user');

--- a/test/unit/lib/lib-helpers/tags.test.js
+++ b/test/unit/lib/lib-helpers/tags.test.js
@@ -15,6 +15,7 @@ const broadcastFactory = require('../../../helpers/factories/broadcast');
 const userFactory = require('../../../helpers/factories/user');
 
 const config = require('../../../../config/lib/helpers/tags');
+const userConfig = require('../../../../config/lib/helpers/user');
 
 // setup "x.should.y" assertion style
 chai.should();
@@ -80,7 +81,7 @@ test('render should throw if mustache.render fails', () => {
   tagsHelper.render(mockText, mockTags).should.throw;
 });
 
-test('render should throw if mockTags fails', () => {
+test('render should throw if getTags fails', () => {
   sandbox.stub(tagsHelper, 'getTags')
     .returns(new Error());
   tagsHelper.render(mockText, mockTags).should.throw;
@@ -122,4 +123,40 @@ test('getUserLinkQueryParams should return object with user_id set if user exist
 test('getUserLinkQueryParams returns empty object if req.user undefined', (t) => {
   const result = tagsHelper.getUserLinkQueryParams(t.context.req);
   result.should.deep.equal({});
+});
+
+// getVotingPlanAttendingWith
+test('getVotingPlanAttendingWith returns votingPlan.attendingWith config for user votingPlanAttendingWith value', () => {
+  const fieldConfig = userConfig.fields.votingPlanAttendingWith;
+  Object.keys(fieldConfig.values).forEach((value) => {
+    const user = userFactory.getValidUser();
+    const fieldValue = fieldConfig.values[value];
+    user[fieldConfig.name] = fieldValue;
+    const result = tagsHelper.getVotingPlanAttendingWith(user);
+    result.should.equal(config.user.votingPlan.vars.attendingWith[fieldValue]);
+  });
+});
+
+// getVotingPlanMethodOfTransport
+test('getVotingPlanMethodOfTransport returns votingPlan.methodOfTransport config for user votingPlanMethodOfTransport value', () => {
+  const fieldConfig = userConfig.fields.votingPlanMethodOfTransport;
+  Object.keys(fieldConfig.values).forEach((value) => {
+    const user = userFactory.getValidUser();
+    const fieldValue = fieldConfig.values[value];
+    user[fieldConfig.name] = fieldValue;
+    const result = tagsHelper.getVotingPlanMethodOfTransport(user);
+    result.should.equal(config.user.votingPlan.vars.methodOfTransport[fieldValue]);
+  });
+});
+
+// getVotingPlanTimeOfDay
+test('getVotingPlanTimeOfDay returns votingPlan.timeOfDay config for user votingPlanTimeOfDay value', () => {
+  const fieldConfig = userConfig.fields.votingPlanTimeOfDay;
+  Object.keys(fieldConfig.values).forEach((value) => {
+    const user = userFactory.getValidUser();
+    const fieldValue = fieldConfig.values[value];
+    user[fieldConfig.name] = fieldValue;
+    const result = tagsHelper.getVotingPlanTimeOfDay(user);
+    result.should.equal(config.user.votingPlan.vars.timeOfDay[fieldValue]);
+  });
 });

--- a/test/unit/lib/lib-helpers/tags.test.js
+++ b/test/unit/lib/lib-helpers/tags.test.js
@@ -125,6 +125,25 @@ test('getUserLinkQueryParams returns empty object if req.user undefined', (t) =>
   result.should.deep.equal({});
 });
 
+// getVotingPlan
+test('getVotingPlan returns an object with description, attendingWith, methodOfTransport, and timeOfDay string properties', () => {
+  const attendingWith = stubs.getRandomWord();
+  const methodOfTransport = stubs.getRandomWord();
+  const timeOfDay = stubs.getRandomWord();
+  const description = stubs.getRandomMessageText();
+  sandbox.stub(tagsHelper, 'getVotingPlanAttendingWith')
+    .returns(attendingWith);
+  sandbox.stub(tagsHelper, 'getVotingPlanMethodOfTransport')
+    .returns(methodOfTransport);
+  sandbox.stub(tagsHelper, 'getVotingPlanTimeOfDay')
+    .returns(timeOfDay);
+  sandbox.stub(mustache, 'render')
+    .returns(description);
+
+  const result = tagsHelper.getVotingPlan(mockUser);
+  result.should.deep.equal({ attendingWith, methodOfTransport, timeOfDay, description });
+});
+
 // getVotingPlanAttendingWith
 test('getVotingPlanAttendingWith returns votingPlan.attendingWith config for user votingPlanAttendingWith value', () => {
   const fieldConfig = userConfig.fields.votingPlanAttendingWith;


### PR DESCRIPTION
#### What's this PR do?

Refactors the `user` tag to support an `id` string property, and a `votingPlan` object property, to be used for rendering the user's voting plan information in a message. The `votingPlan` has 4 properties:

* `description` - Text to be used within a reminder message, e.g. `take public transport in the morning by yourself`

* `attendingWith` - returns a readable user `voting_plan_attending_with` field value used in the description (e.g. `with friends`, `with co-workers`, `by yourself`) 

* `methodOfTransport` - returns a readable user `voting_plan_method_of_transport` field value used in the description (e.g. `take public transport`, `walk`, `drive`) 

* `timeOfDay` - returns the user `voting_plan_time_of_day` field value (raw value is already readable)

#### How should this be reviewed?
I've set up a test reminder broadcast, [`3PAKFvB9wcMCkK4Y6qgYwc`](https://gambit-admin-staging.herokuapp.com/broadcasts/3PAKFvB9wcMCkK4Y6qgYwc) that includes a `{{user.votingPlan.description}}` tag. Test this broadcast after completing a voting plan and verify expected description is rendered.

Message content:

> `Remember to {{user.votingPlan.description}}.`

Message sent:

> `Remember to walk in the afternoon with friends.`

#### Any background context you want to provide?

This should eliminate a lot of manual work previously required to handle edge-case messaging that doesn't read correctly ("don't forget to public_transport with alone")  

#### Relevant tickets

https://www.pivotaltracker.com/story/show/161248059

#### Checklist
- [x] Documentation added for new features/changed endpoints -- https://github.com/DoSomething/gambit-admin/wiki/Tags#user
- [ ] Tests added/updated for new features/bug fixes.
- [x] Tested on staging.
- [ ] Pinged a PM if this is a larger PR that would benefit from some additional testing love.
