### PR TITLE
Adds broadcast tag

### DIFF
--- a/config/lib/helpers/tags.js
+++ b/config/lib/helpers/tags.js
@@ -58,7 +58,7 @@ module.exports = {
   },
   user: {
     votingPlan: {
-      template: '{{methodOfTransport}} in the {{timeOfDay}} {{attendingWith}}',
+      template: process.env.DS_GAMBIT_CONVERSATIONS_VOTING_PLAN_DESCRIPTION_TEXT || '{{methodOfTransport}} to the polls in the {{timeOfDay}} {{attendingWith}}',
       vars: votingPlanVarsByFieldValue,
     },
   },

--- a/lib/helpers/tags.js
+++ b/lib/helpers/tags.js
@@ -44,8 +44,23 @@ function getBroadcastLinkQueryParams(req) {
  * @param {Object} req
  * @return {Object}
  */
+function getBroadcastTag(req) {
+  let broadcastId;
+  if (req.broadcast) {
+    broadcastId = req.broadcast.id;
+  } else if (req.conversation) {
+    broadcastId = req.conversation.lastReceivedBroadcastId;
+  }
+  return broadcastId ? { id: broadcastId } : {};
+}
+
+/**
+ * @param {Object} req
+ * @return {Object}
+ */
 function getTags(req) {
   return {
+    broadcast: module.exports.getBroadcastTag(req),
     links: module.exports.getLinksTag(req),
     user: req.user ? module.exports.getUserTag(req.user) : {},
   };
@@ -146,6 +161,7 @@ function render(string, req) {
 
 module.exports = {
   getBroadcastLinkQueryParams,
+  getBroadcastTag,
   getLink,
   getLinksTag,
   getTags,

--- a/test/helpers/factories/conversation.js
+++ b/test/helpers/factories/conversation.js
@@ -21,6 +21,7 @@ module.exports.getRawConversationData = function getRawConversationData(platform
     updatedAt: date,
     lastOutboundMessage: messageFactory.getValidMessage(),
     campaignId: stubs.getCampaignId(),
+    lastReceivedBroadcastId: stubs.getContentfulId(),
   };
 };
 

--- a/test/unit/lib/lib-helpers/tags.test.js
+++ b/test/unit/lib/lib-helpers/tags.test.js
@@ -95,10 +95,28 @@ test('render should replace user vars', (t) => {
 
 // getTags
 test('getTags should return an object', (t) => {
+  const broadcastTag = { id: stubs.getContentfulId() };
+  const linksTag = { url: stubs.getRandomMessageText() };
+  const userTag = { id: stubs.getContentfulId() };
+  sandbox.stub(tagsHelper, 'getBroadcastTag')
+    .returns(broadcastTag);
+  sandbox.stub(tagsHelper, 'getLinksTag')
+    .returns(linksTag);
+  sandbox.stub(tagsHelper, 'getUserTag')
+    .returns(userTag);
+  t.context.req.user = mockUser;
+
   const result = tagsHelper.getTags(t.context.req);
-  result.should.be.a('object');
-  result.should.have.property('links');
-  result.should.have.property('user');
+  result.should.deep.equal({
+    broadcast: broadcastTag,
+    links: linksTag,
+    user: userTag,
+  });
+});
+
+test('getTags should return empty object for user if req.user undefined', (t) => {
+  const result = tagsHelper.getTags(t.context.req);
+  result.user.should.deep.equal({});
 });
 
 // getBroadcastLinkQueryParams

--- a/test/unit/lib/lib-helpers/tags.test.js
+++ b/test/unit/lib/lib-helpers/tags.test.js
@@ -88,7 +88,7 @@ test('render should return a string', () => {
   sandbox.stub(tagsHelper, 'getTags')
     .returns(mockTags);
   const result = tagsHelper.render(mockText, {});
-  mustache.render.should.have.been.called;
+  mustache.render.should.have.been.calledWith(mockText, mockTags);
   result.should.equal(mockText);
 });
 
@@ -179,6 +179,11 @@ test('getVotingPlan returns an object with description, attendingWith, methodOfT
 
   const result = tagsHelper.getVotingPlan(mockUser);
   result.should.deep.equal({ attendingWith, methodOfTransport, timeOfDay, description });
+  mustache.render.should.have.been.calledWith(config.user.votingPlan.template, {
+    attendingWith,
+    methodOfTransport,
+    timeOfDay,
+  });
 });
 
 // getVotingPlanAttendingWith

--- a/test/unit/lib/lib-helpers/tags.test.js
+++ b/test/unit/lib/lib-helpers/tags.test.js
@@ -12,6 +12,7 @@ const queryString = require('query-string');
 const logger = require('../../../../lib/logger');
 const stubs = require('../../../helpers/stubs');
 const broadcastFactory = require('../../../helpers/factories/broadcast');
+const conversationFactory = require('../../../helpers/factories/conversation');
 const userFactory = require('../../../helpers/factories/user');
 
 const config = require('../../../../config/lib/helpers/tags');
@@ -45,6 +46,24 @@ test.beforeEach((t) => {
 test.afterEach((t) => {
   sandbox.restore();
   t.context.req = {};
+});
+
+// getBroadcastTag
+test('getBroadcastTag should return empty object when req.broadcast and req.conversation undefined', (t) => {
+  const result = tagsHelper.getBroadcastTag(t.context.req);
+  result.should.deep.equal({});
+});
+
+test('getBroadcastTag should return object with id if req.broadcast', (t) => {
+  t.context.req.broadcast = mockBroadcast;
+  const result = tagsHelper.getBroadcastTag(t.context.req);
+  result.should.deep.equal({ id: mockBroadcast.id });
+});
+
+test('getBroadcastTag should return object with id when req.broadcast undefined and req.converastion has broadcastId', (t) => {
+  t.context.req.conversation = conversationFactory.getValidConversation();
+  const result = tagsHelper.getBroadcastTag(t.context.req);
+  result.should.deep.equal({ id: t.context.req.conversation.lastReceivedBroadcastId });
 });
 
 // getLink


### PR DESCRIPTION
#### What's this PR do?

Adds support for a `{{broadcast.id}}` tag, so editors can avoid manually entering a Contentful ID in a query string.

#### How should this be reviewed?
I've edited the Dev test askYesNo broadcast ([5q56wA4uJ2SoAi6uAS4uYK](https://gambit-admin-staging.herokuapp.com/broadcasts/5q56wA4uJ2SoAi6uAS4uYK)) to include a `{{broadcast.id}}` tag in both the outbound message, and the saidYes reply -- where the conversation `lastReceivedBroadcastId` may be returned if user doesn't respond with a "yes" right away and gets an invalidAskYesNo

#### Any background context you want to provide?

Considered adding this during #426, but kept separate for easier review and testing.

#### Relevant tickets

Fixes https://www.pivotaltracker.com/story/show/161487094

#### Checklist
- [ ] Documentation added for new features/changed endpoints. - Will update Gambit Admin wiki upon deploy
- [x] Tests added/updated for new features/bug fixes.
- [x] Tested on staging.
