### PR TITLE
Voting plan description tweaks

### DIFF
--- a/config/lib/helpers/tags.js
+++ b/config/lib/helpers/tags.js
@@ -21,11 +21,11 @@ const votingPlanAttendingWithValues = userFields.votingPlanAttendingWith.values;
 Object.keys(votingPlanAttendingWithValues).forEach((attendingWithName) => {
   const fieldValue = votingPlanAttendingWithValues[attendingWithName];
   if (fieldValue === votingPlanAttendingWithValues.alone) {
-    votingPlanVarsByFieldValue.attendingWith[fieldValue] = 'by yourself';
+    votingPlanVarsByFieldValue.attendingWith[fieldValue] = '';
   } else if (fieldValue === votingPlanAttendingWithValues.coWorkers) {
-    votingPlanVarsByFieldValue.attendingWith[fieldValue] = 'with your co-workers';
+    votingPlanVarsByFieldValue.attendingWith[fieldValue] = ' with your co-workers';
   } else {
-    votingPlanVarsByFieldValue.attendingWith[fieldValue] = `with your ${fieldValue}`;
+    votingPlanVarsByFieldValue.attendingWith[fieldValue] = ` with your ${fieldValue}`;
   }
 });
 
@@ -58,7 +58,7 @@ module.exports = {
   },
   user: {
     votingPlan: {
-      template: process.env.DS_GAMBIT_CONVERSATIONS_VOTING_PLAN_DESCRIPTION_TEXT || '{{methodOfTransport}} to the polls in the {{timeOfDay}} {{attendingWith}}',
+      template: process.env.DS_GAMBIT_CONVERSATIONS_VOTING_PLAN_DESCRIPTION_TEXT || '{{methodOfTransport}} to the polls in the {{timeOfDay}}{{attendingWith}}',
       vars: votingPlanVarsByFieldValue,
     },
   },

--- a/lib/helpers/tags.js
+++ b/lib/helpers/tags.js
@@ -2,7 +2,6 @@
 
 const mustache = require('mustache');
 const queryString = require('query-string');
-const logger = require('../logger');
 const config = require('../../config/lib/helpers/tags');
 const userConfig = require('../../config/lib/helpers/user');
 
@@ -102,9 +101,7 @@ function getVotingPlan(user) {
     timeOfDay: module.exports.getVotingPlanTimeOfDay(user),
   };
   const description = mustache.render(config.user.votingPlan.template, vars);
-  const result = Object.assign({ description }, vars);
-  logger.debug('getVotingPlan', { result });
-  return result;
+  return Object.assign({ description }, vars);
 }
 
 /**


### PR DESCRIPTION
#### What's this PR do?
Removes the "by yourself" description from `alone` values for `attendingWith` per [Slack request](https://dosomething.slack.com/archives/C03T8SDMS/p1541178487005900?thread_ts=1541172872.001400&cid=C03T8SDMS)

#### How should this be reviewed?

Verify expected following results by creating a voting plan (e.g. text `voting plan`), and then sending a reminder broadcast (e.g.`broadcast 3PAKFvB9wcMCkK4Y6qgYwc`) to verify the `{{user.votingPlan.description}}` is correct.


#### Checklist

- [ ] Tested on staging.
