### PR TITLE
Check for alphanumeric text when getting Rivescript reply

### DIFF
--- a/lib/helpers/rivescript.js
+++ b/lib/helpers/rivescript.js
@@ -172,17 +172,24 @@ async function isRivescriptCurrent() {
  * @param {String} messageText
  * @return {Promise}
  */
-async function getBotReply(userId, topicId, messageText) {
+async function getBotReply(userId, topicId, messageText = '') {
   const isCurrent = await module.exports.isRivescriptCurrent();
   if (!isCurrent) {
     await module.exports.loadBot();
   }
-
+  /**
+   * If our inbound message doesn't contain anyything alphanumeric, by default we want to trigger
+   * the wildcard reply for whatever topic we're in. Passing an empty string while in a non-default
+   * Rivescript topic seems to trigger a topic change to the default topic, causing unwanted
+   * topic changes.
+   * @see https://www.pivotaltracker.com/n/projects/2092729/stories/158439950
+   */
+  const userMessageText = messageText.trim().match(/^[a-z0-9]+$/i) ? messageText : 'catchAll';
   // If Rivescript bot receives a message in a topic that it doesn't know about, it logs a
   // "User x was in an empty topic Y" message to the console. This avoids that message.
   const rivescriptTopicId = helpers.topic
     .isRivescriptTopicId(topicId) ? topicId : helpers.topic.getDefaultTopicId();
-  return rivescript.getBotReply(userId, rivescriptTopicId, messageText);
+  return rivescript.getBotReply(userId, rivescriptTopicId, userMessageText);
 }
 
 /**

--- a/lib/helpers/rivescript.js
+++ b/lib/helpers/rivescript.js
@@ -200,6 +200,7 @@ async function getBotReply(userId, topicId, messageText = '') {
  * @return {Promise}
  */
 function parseAskVotingPlanStatusResponse(messageText) {
+  // We call this helper's getBotReply to DRY checking that our messageText contains alphanumeric.
   // TODO: Grab these hardcoded id's from config.
   return module.exports.getBotReply('global', 'ask_voting_plan_status', messageText).then(res => res.text);
 }
@@ -209,6 +210,7 @@ function parseAskVotingPlanStatusResponse(messageText) {
  * @return {Promise}
  */
 function parseAskYesNoResponse(messageText) {
+  // We call this helper's getBotReply to DRY checking that our messageText contains alphanumeric.
   // TODO: Grab these hardcoded id's from config.
   return module.exports.getBotReply('global', 'ask_yes_no', messageText).then(res => res.text);
 }

--- a/lib/helpers/rivescript.js
+++ b/lib/helpers/rivescript.js
@@ -178,7 +178,7 @@ async function getBotReply(userId, topicId, messageText = '') {
     await module.exports.loadBot();
   }
   /**
-   * If our inbound message doesn't contain anyything alphanumeric, by default we want to trigger
+   * If our inbound message doesn't contain anything alphanumeric, by default we want to trigger
    * the wildcard reply for whatever topic we're in. Passing an empty strings or emoji while in a
    * non-default Rivescript topic seems to trigger a topic change to the default topic, causing
    * unwanted behavior.
@@ -187,7 +187,7 @@ async function getBotReply(userId, topicId, messageText = '') {
    * Note: this default we're using if not alphanumeric shouldn't potentially match any Rivescript
    * triggers, e.g. passing "no text found" could trigger a "no" trigger in an askYesNo.
    */
-  const userMessageText = helpers.util.isAlphanumeric(messageText) ? messageText : 'catchAll';
+  const userMessageText = helpers.util.containsAlphanumeric(messageText) ? messageText : 'catchAll';
   // If Rivescript bot receives a message in a topic that it doesn't know about, it logs a
   // "User x was in an empty topic Y" message to the console. This avoids that message.
   const rivescriptTopicId = helpers.topic

--- a/lib/helpers/rivescript.js
+++ b/lib/helpers/rivescript.js
@@ -200,6 +200,7 @@ async function getBotReply(userId, topicId, messageText = '') {
  * @return {Promise}
  */
 function parseAskVotingPlanStatusResponse(messageText) {
+  // TODO: Grab these hardcoded id's from config.
   return module.exports.getBotReply('global', 'ask_voting_plan_status', messageText).then(res => res.text);
 }
 
@@ -208,6 +209,7 @@ function parseAskVotingPlanStatusResponse(messageText) {
  * @return {Promise}
  */
 function parseAskYesNoResponse(messageText) {
+  // TODO: Grab these hardcoded id's from config.
   return module.exports.getBotReply('global', 'ask_yes_no', messageText).then(res => res.text);
 }
 

--- a/lib/helpers/rivescript.js
+++ b/lib/helpers/rivescript.js
@@ -179,12 +179,15 @@ async function getBotReply(userId, topicId, messageText = '') {
   }
   /**
    * If our inbound message doesn't contain anyything alphanumeric, by default we want to trigger
-   * the wildcard reply for whatever topic we're in. Passing an empty string while in a non-default
-   * Rivescript topic seems to trigger a topic change to the default topic, causing unwanted
-   * topic changes.
+   * the wildcard reply for whatever topic we're in. Passing an empty strings or emoji while in a
+   * non-default Rivescript topic seems to trigger a topic change to the default topic, causing
+   * unwanted behavior.
    * @see https://www.pivotaltracker.com/n/projects/2092729/stories/158439950
+   *
+   * Note: this default we're using if not alphanumeric shouldn't potentially match any Rivescript
+   * triggers, e.g. passing "no text found" could trigger a "no" trigger in an askYesNo.
    */
-  const userMessageText = messageText.trim().match(/^[a-z0-9]+$/i) ? messageText : 'catchAll';
+  const userMessageText = helpers.util.isAlphanumeric(messageText) ? messageText : 'catchAll';
   // If Rivescript bot receives a message in a topic that it doesn't know about, it logs a
   // "User x was in an empty topic Y" message to the console. This avoids that message.
   const rivescriptTopicId = helpers.topic

--- a/lib/helpers/rivescript.js
+++ b/lib/helpers/rivescript.js
@@ -200,7 +200,7 @@ async function getBotReply(userId, topicId, messageText = '') {
  * @return {Promise}
  */
 function parseAskVotingPlanStatusResponse(messageText) {
-  return rivescript.getBotReply('global', 'ask_voting_plan_status', messageText).then(res => res.text);
+  return module.exports.getBotReply('global', 'ask_voting_plan_status', messageText).then(res => res.text);
 }
 
 /**
@@ -208,7 +208,7 @@ function parseAskVotingPlanStatusResponse(messageText) {
  * @return {Promise}
  */
 function parseAskYesNoResponse(messageText) {
-  return rivescript.getBotReply('global', 'ask_yes_no', messageText).then(res => res.text);
+  return module.exports.getBotReply('global', 'ask_yes_no', messageText).then(res => res.text);
 }
 
 module.exports = {

--- a/lib/helpers/util.js
+++ b/lib/helpers/util.js
@@ -11,6 +11,17 @@ const UnprocessableEntityError = require('../../app/exceptions/UnprocessableEnti
 const phoneUtil = PhoneNumberUtil.getInstance();
 
 /**
+ * @param {String} string
+ * @return {Boolean}
+ */
+function isAlphanumeric(string = '') {
+  if (!string) {
+    return false;
+  }
+  return string.match(/^[a-z0-9]+$/i);
+}
+
+/**
  * @param {Object|Error}
  * @return {Object}
  */
@@ -91,5 +102,6 @@ module.exports = {
     logger.debug('formatMobileNumber return', { result });
     return result;
   },
+  isAlphanumeric,
   parseStatusAndMessageFromError,
 };

--- a/lib/helpers/util.js
+++ b/lib/helpers/util.js
@@ -14,11 +14,11 @@ const phoneUtil = PhoneNumberUtil.getInstance();
  * @param {String} string
  * @return {Boolean}
  */
-function isAlphanumeric(string = '') {
+function containsAlphanumeric(string = '') {
   if (!string) {
     return false;
   }
-  return string.match(/^[a-z0-9]+$/i);
+  return /\d/.test(string) || /[a-zA-Z]/.test(string);
 }
 
 /**
@@ -102,6 +102,6 @@ module.exports = {
     logger.debug('formatMobileNumber return', { result });
     return result;
   },
-  isAlphanumeric,
+  containsAlphanumeric,
   parseStatusAndMessageFromError,
 };

--- a/test/unit/lib/lib-helpers/rivescript.test.js
+++ b/test/unit/lib/lib-helpers/rivescript.test.js
@@ -299,6 +299,30 @@ test('loadBot calls getRivescripts and creates a new Rivescript bot with result'
     .calledWith(getRivescripts);
 });
 
+// parseAskVotingPlanStatusResponse
+test('parseAskVotingPlanStatusResponse should call rivescriptHelper.getBotReply', async () => {
+  const messageText = stubs.getRandomMessageText();
+  sandbox.stub(rivescriptHelper, 'getBotReply')
+    .returns(Promise.resolve(mockRivescriptReply));
+
+  const result = await rivescriptHelper.parseAskVotingPlanStatusResponse(messageText);
+  rivescriptHelper.getBotReply
+    .should.have.been.calledWith('global', 'ask_voting_plan_status', messageText);
+  result.should.deep.equal(mockRivescriptReply.text);
+});
+
+// parseAskYesNoResponse
+test('parseAskYesNoResponse should call rivescriptHelper.getBotReply', async () => {
+  const messageText = stubs.getRandomMessageText();
+  sandbox.stub(rivescriptHelper, 'getBotReply')
+    .returns(Promise.resolve(mockRivescriptReply));
+
+  const result = await rivescriptHelper.parseAskYesNoResponse(messageText);
+  rivescriptHelper.getBotReply
+    .should.have.been.calledWith('global', 'ask_yes_no', messageText);
+  result.should.deep.equal(mockRivescriptReply.text);
+});
+
 // parseRivescript
 test('parseRivescript should throw error if defaultTopicTrigger undefined', (t) => {
   t.throws(() => rivescriptHelper.parseRivescript());

--- a/test/unit/lib/lib-helpers/util.test.js
+++ b/test/unit/lib/lib-helpers/util.test.js
@@ -73,6 +73,7 @@ test('containsAlphanumeric should return when alphanumeric, false if not', (t) =
   t.truthy(utilHelper.containsAlphanumeric('Hey'));
   t.falsy(utilHelper.containsAlphanumeric('😎 😎'));
   t.truthy(utilHelper.containsAlphanumeric('This is neat 😎 😎'));
+  t.truthy(utilHelper.containsAlphanumeric('1'));
   t.falsy(utilHelper.containsAlphanumeric('  '));
   t.falsy(utilHelper.containsAlphanumeric(null));
 });

--- a/test/unit/lib/lib-helpers/util.test.js
+++ b/test/unit/lib/lib-helpers/util.test.js
@@ -68,6 +68,14 @@ test('formatMobileNumber should throw an UnprocessableEntityError if the mobile 
   expect(() => utilHelper.formatMobileNumber(mobile)).to.throw(UnprocessableEntityError);
 });
 
+// isAlphanumeric
+test('isAlphanumeric should return when alphanumeric, false if not', (t) => {
+  t.truthy(utilHelper.isAlphanumeric('Hey'));
+  t.falsy(utilHelper.isAlphanumeric('😎 😎'));
+  t.falsy(utilHelper.isAlphanumeric('  '));
+  t.falsy(utilHelper.isAlphanumeric(null));
+});
+
 // parseStatusAndMessageFromError
 test('parseStatusAndMessageFromError(anyString): should respond with error status 500 and anyString\'s value as message', () => {
   const errorString = 'omgError';

--- a/test/unit/lib/lib-helpers/util.test.js
+++ b/test/unit/lib/lib-helpers/util.test.js
@@ -68,12 +68,13 @@ test('formatMobileNumber should throw an UnprocessableEntityError if the mobile 
   expect(() => utilHelper.formatMobileNumber(mobile)).to.throw(UnprocessableEntityError);
 });
 
-// isAlphanumeric
-test('isAlphanumeric should return when alphanumeric, false if not', (t) => {
-  t.truthy(utilHelper.isAlphanumeric('Hey'));
-  t.falsy(utilHelper.isAlphanumeric('😎 😎'));
-  t.falsy(utilHelper.isAlphanumeric('  '));
-  t.falsy(utilHelper.isAlphanumeric(null));
+// containsAlphanumeric
+test('containsAlphanumeric should return when alphanumeric, false if not', (t) => {
+  t.truthy(utilHelper.containsAlphanumeric('Hey'));
+  t.falsy(utilHelper.containsAlphanumeric('😎 😎'));
+  t.truthy(utilHelper.containsAlphanumeric('This is neat 😎 😎'));
+  t.falsy(utilHelper.containsAlphanumeric('  '));
+  t.falsy(utilHelper.containsAlphanumeric(null));
 });
 
 // parseStatusAndMessageFromError


### PR DESCRIPTION
#### What's this PR do?

If an inbound message doesn't contain any alphanumeric characters (e.g. a photo, or emoji-only), pass a default `catchAll` string value when getting the Rivescript reply to the message.

#### How should this be reviewed?

Test sending photos, emojii replies to various questions while creating a voting plan, verify the "invalid" replies are returned (instead of exiting the voting plan topic)

#### Any background context you want to provide?

This should also prevent us from seeing the 404's to the Content API for hardcoded topic id's

#### Relevant tickets

Fixes https://www.pivotaltracker.com/story/show/158439950

#### Checklist

- [x] Tested on staging.
- [x] Pinged a PM if this is a larger PR that would benefit from some additional testing love.
