### PR TITLE
Default topic trigger transitions - part 1 [pr]

### DIFF
--- a/config/lib/helpers/rivescript.js
+++ b/config/lib/helpers/rivescript.js
@@ -6,10 +6,13 @@
 module.exports = {
   cacheKey: 'contentApi',
   commands: {
-    trigger: '+',
+    // A continuinuation is needed if a reply contains line breaks.
+    // @see https://www.rivescript.com/docs/tutorial#line-breaking
+    continuation: '^',
     // @see https://www.rivescript.com/docs/tutorial#redirections
     redirect: '@',
     reply: '-',
+    trigger: '+',
   },
   separators: {
     command: ' ',

--- a/lib/helpers/replies.js
+++ b/lib/helpers/replies.js
@@ -75,8 +75,7 @@ function replaceQuantity(string, signup) {
 module.exports.sendReplyWithTopicTemplate = function (req, res, messageTemplate) {
   let messageText;
   try {
-    messageText = helpers.topic
-      .getRenderedTextFromTopicAndTemplateName(req.topic, messageTemplate);
+    messageText = helpers.topic.getTopicTemplateText(req.topic, messageTemplate);
     if (req.signup) {
       messageText = replaceQuantity(messageText, req.signup);
     }

--- a/lib/helpers/rivescript.js
+++ b/lib/helpers/rivescript.js
@@ -11,6 +11,14 @@ const cacheKey = config.cacheKey;
 
 /**
  * @param {String} text
+ * @return {String}
+ */
+function appendEscapedLinebreak(text) {
+  return `${text}\\n`;
+}
+
+/**
+ * @param {String} text
  * @param {String} topicId
  * @return {String}
  */
@@ -158,7 +166,7 @@ function parseReplyRivescriptLines(replyText, newTopicId) {
 
     const isLastLine = index === replyTextByLine.length - 1;
     // If this isn't the last line, escape the line separator to add a double newline.
-    const content = isLastLine ? text : `${text}\\n`;
+    const content = isLastLine ? text : module.exports.appendEscapedLinebreak(text);
     // If trigger contains a topic, append a topic tag to the end of our return Rivescript.
     // @see https://www.rivescript.com/docs/tutorial#topics
     const needsTopicTag = newTopicId && isLastLine;
@@ -261,6 +269,7 @@ function parseAskYesNoResponse(messageText) {
 }
 
 module.exports = {
+  appendEscapedLinebreak,
   appendTopicTag,
   fetchRivescripts,
   formatRedirectRivescript,

--- a/lib/helpers/rivescript.js
+++ b/lib/helpers/rivescript.js
@@ -155,15 +155,12 @@ function parseReplyRivescriptLines(replyText, newTopicId) {
    *
    * NOTE: We're assuming each line break should be a double line, as we consistently use this to
    * add a "paragraph" for the longer messages we send (eg. a startPhotoPost).
+   * Because we're splitting by the newline character, we want to remove any empty strings from the
+   * result, we'll account for this by appending an escaped line break to the previous non-empty
+   * line (as long as it's not the last line, where we don't need a trailing linebreak).
    */
-  const replyTextByLine = replyText.split(config.separators.line);
-  const lines = replyTextByLine.map((text, index) => {
-    // If null, it's from a double line separator, which we accounted for in the previous item by
-    // appending an escaped line separator.
-    if (!text) {
-      return null;
-    }
-
+  const replyTextByLine = underscore.without(replyText.split(config.separators.line), '');
+  return replyTextByLine.map((text, index) => {
     const isLastLine = index === replyTextByLine.length - 1;
     // If this isn't the last line, escape the line separator to add a double newline.
     const content = isLastLine ? text : module.exports.appendEscapedLinebreak(text);
@@ -176,9 +173,6 @@ function parseReplyRivescriptLines(replyText, newTopicId) {
       value: needsTopicTag ? module.exports.appendTopicTag(content, newTopicId) : content,
     };
   });
-
-  // Remove null array items.
-  return underscore.without(lines, null);
 }
 
 /**

--- a/lib/helpers/rivescript.js
+++ b/lib/helpers/rivescript.js
@@ -67,8 +67,17 @@ function parseRivescript(defaultTopicTrigger) {
     return module.exports.joinRivescriptLines(lines);
   }
 
+  const topic = defaultTopicTrigger.topic;
+  const topicId = topic && topic.id ? topic.id : null;
+  let replyText = defaultTopicTrigger.reply;
+  // Triggers that directly reference a topic entry won't have a reply set.
+  // TODO: Remove this logic once they are updated to reference transition entries instead.
+  if (!replyText && topicId) {
+    replyText = helpers.topic.getStartTemplateText(topic);
+  }
+
   return module.exports.joinRivescriptLines(lines
-    .concat(module.exports.formatReplyRivescript(defaultTopicTrigger)));
+    .concat(module.exports.formatReplyRivescript(replyText, topicId)));
 }
 
 /**
@@ -104,26 +113,14 @@ function formatRedirectRivescript(text) {
 }
 
 /**
- * Note: We're passing defaultTopicTrigger object as a parameter to support triggers that reference
- * a topic directly on the response field. We'll eventually backfill these triggers with transition
- * entries saved instead.
- * TODO: After backfill, refactor this function to accept a String arg for the reply text.
+ * Returns text as an array with a reply command, and continuation commands if the text contains
+ * linebreak characters.
  *
- * @param {Object} defaultTopicTrigger
- * @param {String} redirectText
+ * @param {String} text
+ * @param {String} newTopicId
  * @return {Array}
  */
-function formatReplyRivescript(defaultTopicTrigger) {
-  let replyText = defaultTopicTrigger.reply;
-  const topic = defaultTopicTrigger.topic;
-  const hasTopic = topic && topic.id;
-
-  // Support triggers that directly reference a topic instead of a transition.
-  // TODO: Remove this once all defaultTopicTriggers are backfilled with transitions.
-  if (!replyText && hasTopic) {
-    replyText = helpers.topic.getStartTemplateText(topic);
-  }
-
+function formatReplyRivescript(replyText, newTopicId) {
   /**
    * We can't stream strings that contain newline characters, as the parser complains that we're
    * sending invalid Rivescript. Handle line breaks by split by newline and parsing as reply and
@@ -145,7 +142,7 @@ function formatReplyRivescript(defaultTopicTrigger) {
     const content = isLastLine ? text : `${text}\\n`;
     // If trigger contains a topic, append a topic tag to the end of our return Rivescript.
     // @see https://www.rivescript.com/docs/tutorial#topics
-    const replyLine = hasTopic && isLastLine ? `${content}{topic=${topic.id}}` : content;
+    const replyLine = newTopicId && isLastLine ? `${content}{topic=${newTopicId}}` : content;
     const command = index === 0 ? config.commands.reply : config.commands.continuation;
 
     return module.exports.formatRivescriptLine(command, replyLine);

--- a/lib/helpers/rivescript.js
+++ b/lib/helpers/rivescript.js
@@ -81,6 +81,9 @@ function parseRivescript(defaultTopicTrigger) {
 }
 
 /**
+ * Returns an array of Rivescript lines to be used in tandem with a Rivescript trigger line.
+ * @see parseRivescript
+ *
  * @param {String} replyText
  * @param {String} topicId
  * @return {Array}

--- a/lib/helpers/rivescript.js
+++ b/lib/helpers/rivescript.js
@@ -10,6 +10,15 @@ const config = require('../../config/lib/helpers/rivescript');
 const cacheKey = config.cacheKey;
 
 /**
+ * @param {String} text
+ * @param {String} topicId
+ * @return {String}
+ */
+function appendTopicTag(text, topicId) {
+  return `${text}{topic=${topicId}}`;
+}
+
+/**
  * @return {Object}
  */
 function getDeparsedRivescript() {
@@ -152,10 +161,14 @@ function parseReplyRivescriptLines(replyText, newTopicId) {
     const content = isLastLine ? text : `${text}\\n`;
     // If trigger contains a topic, append a topic tag to the end of our return Rivescript.
     // @see https://www.rivescript.com/docs/tutorial#topics
-    const value = newTopicId && isLastLine ? `${content}{topic=${newTopicId}}` : content;
-    const operator = index === 0 ? config.commands.reply : config.commands.continuation;
-    return { operator, value };
+    const needsTopicTag = newTopicId && isLastLine;
+
+    return {
+      operator: index === 0 ? config.commands.reply : config.commands.continuation,
+      value: needsTopicTag ? module.exports.appendTopicTag(content, newTopicId) : content,
+    };
   });
+
   // Remove null array items.
   return underscore.without(lines, null);
 }
@@ -248,6 +261,7 @@ function parseAskYesNoResponse(messageText) {
 }
 
 module.exports = {
+  appendTopicTag,
   fetchRivescripts,
   formatRedirectRivescript,
   formatReplyRivescript,

--- a/lib/helpers/rivescript.js
+++ b/lib/helpers/rivescript.js
@@ -91,16 +91,13 @@ function formatReplyRivescript(replyText, topicId) {
 }
 
 /**
- *  Returns a string to be used as a line of Rivescript.
+ * Returns a string to be used as a line of Rivescript.
  *
  * @param {String} operator
  * @param {String} value
  * @return {String}
  */
 function formatRivescriptLine(operator, value) {
-  if (!value) {
-    return null;
-  }
   const rivescriptText = `${operator}${config.separators.command}${value.trim()}`;
   return `${rivescriptText}${config.separators.line}`;
 }
@@ -118,7 +115,6 @@ function formatTriggerRivescript(text) {
  * @return {String}
  */
 function formatRedirectRivescript(text) {
-  logger.debug('formatRedirectRivescript', { text });
   return module.exports.formatRivescriptLine(config.commands.redirect, text);
 }
 

--- a/lib/helpers/rivescript.js
+++ b/lib/helpers/rivescript.js
@@ -75,9 +75,20 @@ function parseRivescript(defaultTopicTrigger) {
   if (!replyText && topicId) {
     replyText = helpers.topic.getStartTemplateText(topic);
   }
+  const replyLines = module.exports.formatReplyRivescript(replyText, topicId);
 
-  return module.exports.joinRivescriptLines(lines
-    .concat(module.exports.formatReplyRivescript(replyText, topicId)));
+  return module.exports.joinRivescriptLines(lines.concat(replyLines));
+}
+
+/**
+ * @param {String} replyText
+ * @param {String} topicId
+ * @return {Array}
+ */
+function formatReplyRivescript(replyText, topicId) {
+  const lineParams = module.exports.parseReplyRivescriptLines(replyText, topicId);
+  return underscore.without(lineParams, null)
+    .map(data => module.exports.formatRivescriptLine(data.operator, data.value));
 }
 
 /**
@@ -120,7 +131,7 @@ function formatRedirectRivescript(text) {
  * @param {String} newTopicId
  * @return {Array}
  */
-function formatReplyRivescript(replyText, newTopicId) {
+function parseReplyRivescriptLines(replyText, newTopicId) {
   /**
    * We can't stream strings that contain newline characters, as the parser complains that we're
    * sending invalid Rivescript. Handle line breaks by split by newline and parsing as reply and
@@ -132,7 +143,8 @@ function formatReplyRivescript(replyText, newTopicId) {
    */
   const replyTextByLine = replyText.split(config.separators.line);
   return replyTextByLine.map((text, index) => {
-    // If null, it's from a double line separator, which we account for below.
+    // If null, it's from a double line separator, which we accounted for in the previous item by
+    // appending an escaped line separator.
     if (!text) {
       return null;
     }
@@ -142,10 +154,9 @@ function formatReplyRivescript(replyText, newTopicId) {
     const content = isLastLine ? text : `${text}\\n`;
     // If trigger contains a topic, append a topic tag to the end of our return Rivescript.
     // @see https://www.rivescript.com/docs/tutorial#topics
-    const replyLine = newTopicId && isLastLine ? `${content}{topic=${newTopicId}}` : content;
-    const command = index === 0 ? config.commands.reply : config.commands.continuation;
-
-    return module.exports.formatRivescriptLine(command, replyLine);
+    const value = newTopicId && isLastLine ? `${content}{topic=${newTopicId}}` : content;
+    const operator = index === 0 ? config.commands.reply : config.commands.continuation;
+    return { operator, value };
   });
 }
 
@@ -251,5 +262,6 @@ module.exports = {
   loadBot,
   parseAskVotingPlanStatusResponse,
   parseAskYesNoResponse,
+  parseReplyRivescriptLines,
   parseRivescript,
 };

--- a/lib/helpers/rivescript.js
+++ b/lib/helpers/rivescript.js
@@ -50,20 +50,25 @@ function fetchRivescripts() {
 }
 
 /**
- * Modifies the reply property if given defaultTopicTrigger is a changeTopic macro.
+ * Returns Rivescript commands from defaultTopicTrigger.
  *
  * @param {Object} defaultTopicTrigger
- * @return {Object}
+ * @return {String}
  */
 function parseRivescript(defaultTopicTrigger) {
   if (!defaultTopicTrigger) {
     throw new Error('parseRivescript cannot parse falsy defaultTopicTrigger');
   }
-  const data = Object.assign({}, defaultTopicTrigger);
-  if (data.topic && data.topic.id) {
-    data.reply = helpers.macro.getChangeTopicMacroFromTopicId(data.topic.id);
+
+  const lines = [module.exports.formatTriggerRivescript(defaultTopicTrigger.trigger)];
+
+  if (defaultTopicTrigger.redirect) {
+    lines.push(module.exports.formatRedirectRivescript(defaultTopicTrigger.redirect));
+    return module.exports.joinRivescriptLines(lines);
   }
-  return module.exports.getRivescriptFromDefaultTopicTrigger(data);
+
+  return module.exports.joinRivescriptLines(lines
+    .concat(module.exports.formatReplyRivescript(defaultTopicTrigger)));
 }
 
 /**
@@ -77,55 +82,74 @@ function formatRivescriptLine(operator, value) {
   if (!value) {
     return null;
   }
-  const trimmedValue = value.trim();
-  const rivescriptText = `${operator}${config.separators.command}${trimmedValue}`;
+  const rivescriptText = `${operator}${config.separators.command}${value.trim()}`;
   return `${rivescriptText}${config.separators.line}`;
 }
 
 /**
- * @param {String} triggerText
- * @return {Array}
- */
-function getRivescriptFromTriggerTextAndRivescriptLine(triggerText, rivescriptLine) {
-  const triggerLine = module.exports.formatRivescriptLine(config.commands.trigger, triggerText);
-  return module.exports.joinRivescriptLines([triggerLine, rivescriptLine]);
-}
-
-/**
- * @param {String} triggerText
- * @param {String} redirectText
- * @return {Array}
- */
-function getRedirectRivescript(triggerText, redirectText) {
-  const redirectLine = module.exports.formatRivescriptLine(config.commands.redirect, redirectText);
-  return module.exports.getRivescriptFromTriggerTextAndRivescriptLine(triggerText, redirectLine);
-}
-
-/**
- * @param {String} triggerText
- * @param {String} redirectText
- * @return {Array}
- */
-function getReplyRivescript(triggerText, replyText) {
-  const replyLine = module.exports.formatRivescriptLine(config.commands.reply, replyText);
-  return module.exports.getRivescriptFromTriggerTextAndRivescriptLine(triggerText, replyLine);
-}
-
-/**
- * Returns given array of objects as a string with Rivescript definitions of triggers on the
- * default topic.
- *
- * @param {Object} defaultTopicTrigger
+ * @param {String} text
  * @return {String}
  */
-function getRivescriptFromDefaultTopicTrigger(defaultTopicTrigger) {
-  if (defaultTopicTrigger.redirect) {
-    return module.exports
-      .getRedirectRivescript(defaultTopicTrigger.trigger, defaultTopicTrigger.redirect);
+function formatTriggerRivescript(text) {
+  return module.exports.formatRivescriptLine(config.commands.trigger, text);
+}
+
+/**
+ * @param {String} text
+ * @return {String}
+ */
+function formatRedirectRivescript(text) {
+  logger.debug('formatRedirectRivescript', { text });
+  return module.exports.formatRivescriptLine(config.commands.redirect, text);
+}
+
+/**
+ * Note: We're passing defaultTopicTrigger object as a parameter to support triggers that reference
+ * a topic directly on the response field. We'll eventually change the content type to only allow
+ * transition entries as an reference, when that happens we can pass the defaultTopicTrigger.reply
+ * as a String parameter instead.
+ *
+ * @param {Object} defaultTopicTrigger
+ * @param {String} redirectText
+ * @return {Array}
+ */
+function formatReplyRivescript(defaultTopicTrigger) {
+  let replyText = defaultTopicTrigger.reply;
+  const topic = defaultTopicTrigger.topic;
+  const hasTopic = topic && topic.id;
+
+  // Support triggers that directly reference a topic instead of a transition.
+  // TODO: Remove this once all defaultTopicTriggers are backfilled with transitions.
+  if (!replyText && hasTopic) {
+    replyText = helpers.topic.getStartTemplateText(topic);
   }
 
-  return module.exports
-    .getReplyRivescript(defaultTopicTrigger.trigger, defaultTopicTrigger.reply);
+  /**
+   * We can't stream strings that contain newline characters, as the parser complains that we're
+   * sending invalid Rivescript. Handle line breaks by split by newline and parsing as reply and
+   * newline commands.
+   * @see https://www.rivescript.com/docs/tutorial#line-breaking
+   *
+   * NOTE: We're assuming each line break should be a double line, as we consistently use this to
+   * add a "paragraph" for the longer messages we send (eg. a startPhotoPost).
+   */
+  const replyTextByLine = replyText.split(config.separators.line);
+  return replyTextByLine.map((text, index) => {
+    // If null, it's from a double line separator, which we account for below.
+    if (!text) {
+      return null;
+    }
+
+    const isLastLine = index === replyTextByLine.length - 1;
+    // If this isn't the last line, escape the line separator to add a double newline.
+    const content = isLastLine ? text : `${text}\\n`;
+    // If trigger contains a topic, append a topic tag to the end of our return Rivescript.
+    // @see https://www.rivescript.com/docs/tutorial#topics
+    const replyLine = hasTopic && isLastLine ? `${content}{topic=${topic.id}}` : content;
+    const command = index === 0 ? config.commands.reply : config.commands.continuation;
+
+    return module.exports.formatRivescriptLine(command, replyLine);
+  });
 }
 
 /**
@@ -217,13 +241,12 @@ function parseAskYesNoResponse(messageText) {
 
 module.exports = {
   fetchRivescripts,
+  formatRedirectRivescript,
+  formatReplyRivescript,
   formatRivescriptLine,
+  formatTriggerRivescript,
   getBotReply,
   getDeparsedRivescript,
-  getRedirectRivescript,
-  getReplyRivescript,
-  getRivescriptFromDefaultTopicTrigger,
-  getRivescriptFromTriggerTextAndRivescriptLine,
   getRivescripts,
   isBotReady,
   isRivescriptCurrent,

--- a/lib/helpers/rivescript.js
+++ b/lib/helpers/rivescript.js
@@ -67,7 +67,8 @@ function fetchRivescripts() {
 }
 
 /**
- * Returns Rivescript commands from defaultTopicTrigger.
+ * Parses given defaultTopicTrigger as Rivescript code to be streamed by the bot.
+ * @see https://github.com/aichaos/rivescript-js/blob/master/docs/rivescript.md#bool-stream-string-code-func-onerror
  *
  * @param {Object} defaultTopicTrigger
  * @return {String}
@@ -77,21 +78,54 @@ function parseRivescript(defaultTopicTrigger) {
     throw new Error('parseRivescript cannot parse falsy defaultTopicTrigger');
   }
 
+  /**
+   * Initialize array of Rivescript lines to be joined. The first line is a trigger command, e.g.
+   * + hello
+   *
+   * @see https://www.rivescript.com/docs/tutorial#the-code-explained
+   */
   const lines = [module.exports.formatTriggerRivescript(defaultTopicTrigger.trigger)];
 
+  /**
+   * If this is a redirect, the last line should be a redirect command, e.g.
+   * @ greetings
+   *
+   * @see https://www.rivescript.com/docs/tutorial#redirections
+   */
   if (defaultTopicTrigger.redirect) {
     lines.push(module.exports.formatRedirectRivescript(defaultTopicTrigger.redirect));
     return module.exports.joinRivescriptLines(lines);
   }
 
+  /**
+   * If defaultTopicTrigger isn't a redirect, the next line should be a reply command, e.g.
+   * - Hey, how are you today?
+   */
+  let replyText = defaultTopicTrigger.reply;
+
+  /*
+   * If defaultTopicTrigger has a topic, the reply command should contain a topic tag, e.g.
+   * - Hey, how are you today?{topic=parse_mood}
+   *
+   * @see https://www.rivescript.com/docs/tutorial#topics
+   */
   const topic = defaultTopicTrigger.topic;
   const topicId = topic && topic.id ? topic.id : null;
-  let replyText = defaultTopicTrigger.reply;
+
   // Triggers that directly reference a topic entry won't have a reply set.
   // TODO: Remove this logic once they are updated to reference transition entries instead.
   if (!replyText && topicId) {
     replyText = helpers.topic.getStartTemplateText(topic);
   }
+
+  /**
+   * The next line should be the reply command, followed by continuation commands if the replyText
+   * contains line breaks, e.g.:
+   * - Hey how are you today, it's so good to see you.\n
+   * ^ Seriously, it's been a pleasure. Thanks again!
+   *
+   * @see https://www.rivescript.com/docs/tutorial#line-breaking
+   */
   const replyLines = module.exports.formatReplyRivescript(replyText, topicId);
 
   return module.exports.joinRivescriptLines(lines.concat(replyLines));

--- a/lib/helpers/rivescript.js
+++ b/lib/helpers/rivescript.js
@@ -105,9 +105,9 @@ function formatRedirectRivescript(text) {
 
 /**
  * Note: We're passing defaultTopicTrigger object as a parameter to support triggers that reference
- * a topic directly on the response field. We'll eventually change the content type to only allow
- * transition entries as an reference, when that happens we can pass the defaultTopicTrigger.reply
- * as a String parameter instead.
+ * a topic directly on the response field. We'll eventually backfill these triggers with transition
+ * entries saved instead.
+ * TODO: After backfill, refactor this function to accept a String arg for the reply text.
  *
  * @param {Object} defaultTopicTrigger
  * @param {String} redirectText

--- a/lib/helpers/rivescript.js
+++ b/lib/helpers/rivescript.js
@@ -173,10 +173,10 @@ function formatRedirectRivescript(text) {
 }
 
 /**
- * Returns text as an array with a reply command, and continuation commands if the text contains
- * linebreak characters.
+ * Returns array with a reply command, and continuation commands if the replyText contains any
+ * linebreaks. Includes topic tag when newTopicId is passed.
  *
- * @param {String} text
+ * @param {String} replyText
  * @param {String} newTopicId
  * @return {Array}
  */

--- a/lib/helpers/rivescript.js
+++ b/lib/helpers/rivescript.js
@@ -86,8 +86,7 @@ function parseRivescript(defaultTopicTrigger) {
  * @return {Array}
  */
 function formatReplyRivescript(replyText, topicId) {
-  const lineParams = module.exports.parseReplyRivescriptLines(replyText, topicId);
-  return underscore.without(lineParams, null)
+  return module.exports.parseReplyRivescriptLines(replyText, topicId)
     .map(data => module.exports.formatRivescriptLine(data.operator, data.value));
 }
 
@@ -142,7 +141,7 @@ function parseReplyRivescriptLines(replyText, newTopicId) {
    * add a "paragraph" for the longer messages we send (eg. a startPhotoPost).
    */
   const replyTextByLine = replyText.split(config.separators.line);
-  return replyTextByLine.map((text, index) => {
+  const lines = replyTextByLine.map((text, index) => {
     // If null, it's from a double line separator, which we accounted for in the previous item by
     // appending an escaped line separator.
     if (!text) {
@@ -158,6 +157,8 @@ function parseReplyRivescriptLines(replyText, newTopicId) {
     const operator = index === 0 ? config.commands.reply : config.commands.continuation;
     return { operator, value };
   });
+  // Remove null array items.
+  return underscore.without(lines, null);
 }
 
 /**

--- a/lib/helpers/topic.js
+++ b/lib/helpers/topic.js
@@ -62,10 +62,8 @@ function getRivescriptTopicById(topicId) {
  * @param {Object} topic
  * @param {String} templateName
  */
-function getRenderedTextFromTopicAndTemplateName(topic, templateName) {
-  const template = topic.templates[templateName];
-  // This rendered property will eventually get phased out, always query by text.
-  return template.rendered || template.text;
+function getTopicTemplateText(topic, templateName) {
+  return topic.templates[templateName].text;
 }
 
 /**
@@ -168,7 +166,7 @@ module.exports = {
   getAskSubscriptionStatusTopic,
   getDefaultTopic,
   getDefaultTopicId,
-  getRenderedTextFromTopicAndTemplateName,
+  getTopicTemplateText,
   getRivescriptTopicById,
   getStartTemplateText,
   getSupportTopic,

--- a/lib/helpers/topic.js
+++ b/lib/helpers/topic.js
@@ -69,6 +69,28 @@ function getRenderedTextFromTopicAndTemplateName(topic, templateName) {
 }
 
 /**
+ * TODO: Remove this function once all default topic triggers are backfilled with transitions.
+ * @see lib/helpers/rivescript.getReplyRivescript
+ *
+ * @param {Object} topic
+ * @return {String}
+ */
+function getStartTemplateText(topic) {
+  const type = topic.type;
+  const templates = topic.templates;
+  if (type === 'photoPostConfig') {
+    return templates.startPhotoPost.text;
+  }
+  if (type === 'textPostConfig') {
+    return templates.askText.text;
+  }
+  if (type === 'externalPostConfig') {
+    return templates.startExternalPost.text;
+  }
+  return null;
+}
+
+/**
  * @return {Object}
  */
 function getSupportTopic() {
@@ -148,6 +170,7 @@ module.exports = {
   getDefaultTopicId,
   getRenderedTextFromTopicAndTemplateName,
   getRivescriptTopicById,
+  getStartTemplateText,
   getSupportTopic,
   hasCampaign,
   isAskSubscriptionStatus,

--- a/test/helpers/factories/defaultTopicTrigger.js
+++ b/test/helpers/factories/defaultTopicTrigger.js
@@ -2,7 +2,7 @@
 
 const stubs = require('../stubs');
 
-function getValidChangeTopicDefaultTopicTrigger() {
+function getLegacyChangeTopicDefaultTopicTrigger() {
   return {
     trigger: stubs.getRandomWord(),
     topic: {
@@ -26,7 +26,7 @@ function getValidReplyDefaultTopicTrigger() {
 }
 
 module.exports = {
-  getValidChangeTopicDefaultTopicTrigger,
+  getLegacyChangeTopicDefaultTopicTrigger,
   getValidRedirectDefaultTopicTrigger,
   getValidReplyDefaultTopicTrigger,
 };

--- a/test/helpers/factories/topic.js
+++ b/test/helpers/factories/topic.js
@@ -3,26 +3,30 @@
 const stubs = require('../stubs');
 const config = require('../../../config/lib/helpers/topic');
 
-
-function getValidTopic(type = 'photoPostConfig') {
-  const result = {
+function getTemplate(newTopic) {
+  return {
+    text: stubs.getRandomMessageText(),
+    topic: newTopic || {},
+  };
+}
+/**
+ * These topic stubs correspond to data returned from Gambit Content GET /topics/:id requests.
+ * @see https://github.com/DoSomething/gambit-campaigns/blob/master/documentation/endpoints/topics.md#retrieve-topic
+ *
+ * @param {String} type
+ * @return {Object}
+ */
+function getValidTopic(type = 'photoPostConfig', templates) {
+  return {
     id: stubs.getContentfulId(),
     name: stubs.getRandomName(),
     type,
     postType: stubs.getPostType(),
-    templates: {},
     campaign: {
       id: stubs.getCampaignId(),
     },
+    templates,
   };
-  const templateName = stubs.getTemplate();
-  result.templates[templateName] = {
-    raw: stubs.getRandomMessageText(),
-    rendered: stubs.getRandomMessageText(),
-    text: stubs.getRandomMessageText(),
-    override: true,
-  };
-  return result;
 }
 
 function getValidTopicWithoutCampaign() {
@@ -32,15 +36,42 @@ function getValidTopicWithoutCampaign() {
 }
 
 function getValidAutoReply() {
-  return getValidTopic(config.types.autoReply);
+  return getValidTopic(config.types.autoReply, { autoReply: getTemplate() });
+}
+
+// TODO: Remove this function once we deprecate externalPostConfig type entirely.
+function getValidExternalPostConfig() {
+  return getValidTopic(config.types.externalPostConfig, { startExternalPost: getTemplate() });
+}
+
+function getValidPhotoPostConfig() {
+  const templates = {
+    // TODO: Remove startPhotoPost once deprecated by defaultTopicTrigger transitions.
+    startPhotoPost: getTemplate(),
+    startPhotoPostAutoReply: getTemplate(),
+    askQuantity: getTemplate(),
+    invalidQuantity: getTemplate(),
+    // TODO: Cleanup config/lib/helpers/template, possibly move into config/lib/helpers/topic
+    // and use it to define the various templates per topic here.
+  };
+  return getValidTopic(config.types.photoPostConfig, templates);
 }
 
 function getValidTextPostConfig() {
-  return getValidTopic(config.types.textPostConfig);
+  const templates = {
+    // TODO: Remove askText once deprecated by defaultTopicTrigger transitions.
+    askText: getTemplate(),
+    invalidAskText: getTemplate(),
+    completedTextPost: getTemplate(),
+    completedTextPostAutoReply: getTemplate(),
+  };
+  return getValidTopic(config.types.textPostConfig, templates);
 }
 
 module.exports = {
   getValidAutoReply,
+  getValidExternalPostConfig,
+  getValidPhotoPostConfig,
   getValidTextPostConfig,
   getValidTopic,
   getValidTopicWithoutCampaign,

--- a/test/unit/lib/lib-helpers/rivescript.test.js
+++ b/test/unit/lib/lib-helpers/rivescript.test.js
@@ -251,7 +251,7 @@ test('parseRivescript returns redirectRivescript if defaultTopicTrigger.redirect
   result.should.equal(mockRivescript);
 });
 
-test('parseRivescript returns replyRivescript if defaultTopicTrigger.reply is set', () => {
+test('parseRivescript calls replyRivescript with defaultTopicTrigger.reply if set', () => {
   const trigger = stubs.getRandomWord();
   const reply = stubs.getRandomWord();
   sandbox.stub(rivescriptHelper, 'formatTriggerRivescript')
@@ -271,6 +271,33 @@ test('parseRivescript returns replyRivescript if defaultTopicTrigger.reply is se
     .calledWith(replyDefaultTopicTrigger.trigger);
   rivescriptHelper.formatReplyRivescript.should.have.been
     .calledWith(replyDefaultTopicTrigger.reply, null);
+  rivescriptHelper.joinRivescriptLines.should.have.been.calledWith([trigger, reply]);
+  result.should.equal(mockRivescript);
+});
+
+test('parseRivescript calls replyRivescript with getStartTemplateText if reply is not set', () => {
+  const trigger = stubs.getRandomWord();
+  const startText = stubs.getRandomWord();
+  const reply = stubs.getRandomMessageText();
+  sandbox.stub(rivescriptHelper, 'formatRedirectRivescript')
+    .returns(null);
+  sandbox.stub(rivescriptHelper, 'formatTriggerRivescript')
+    .returns(trigger);
+  sandbox.stub(rivescriptHelper, 'formatReplyRivescript')
+    .returns(reply);
+  sandbox.stub(helpers.topic, 'getStartTemplateText')
+    .returns(startText);
+  sandbox.stub(rivescriptHelper, 'joinRivescriptLines')
+    .returns(mockRivescript);
+  const legacyDefaultTopicTrigger = defaultTopicTriggerFactory
+    .getLegacyChangeTopicDefaultTopicTrigger();
+
+  const result = rivescriptHelper.parseRivescript(legacyDefaultTopicTrigger);
+  rivescriptHelper.formatRedirectRivescript.should.not.have.been.called;
+  rivescriptHelper.formatTriggerRivescript.should.have.been
+    .calledWith(legacyDefaultTopicTrigger.trigger);
+  rivescriptHelper.formatReplyRivescript.should.have.been
+    .calledWith(startText);
   rivescriptHelper.joinRivescriptLines.should.have.been.calledWith([trigger, reply]);
   result.should.equal(mockRivescript);
 });

--- a/test/unit/lib/lib-helpers/rivescript.test.js
+++ b/test/unit/lib/lib-helpers/rivescript.test.js
@@ -40,6 +40,15 @@ test.afterEach(() => {
   sandbox.restore();
 });
 
+// appendTopicTag
+test('appendTopicTag should append Rivescript topic tag to string with given topicId', () => {
+  const text = stubs.getRandomMessageText();
+  const topicId = stubs.getContentfulId();
+
+  const result = rivescriptHelper.appendTopicTag(text, topicId);
+  result.should.equal(`${text}{topic=${topicId}}`);
+});
+
 // getBotReply
 test('getBotReply should call loadBot if Rivescript is not current', async () => {
   sandbox.stub(rivescriptHelper, 'isRivescriptCurrent')

--- a/test/unit/lib/lib-helpers/rivescript.test.js
+++ b/test/unit/lib/lib-helpers/rivescript.test.js
@@ -210,7 +210,7 @@ test('parseRivescript returns replyRivescript if defaultTopicTrigger.reply is se
   rivescriptHelper.formatTriggerRivescript.should.have.been
     .calledWith(replyDefaultTopicTrigger.trigger);
   rivescriptHelper.formatReplyRivescript.should.have.been
-    .calledWith(replyDefaultTopicTrigger);
+    .calledWith(replyDefaultTopicTrigger.reply, null);
   rivescriptHelper.joinRivescriptLines.should.have.been.calledWith([trigger, reply]);
   result.should.equal(mockRivescript);
 });

--- a/test/unit/lib/lib-helpers/rivescript.test.js
+++ b/test/unit/lib/lib-helpers/rivescript.test.js
@@ -228,6 +228,18 @@ test('parseReplyRivescriptLines should return an array with one reply command if
   ]);
 });
 
+test('parseReplyRivescriptLines should return an array with one reply command if replyText leads with a line break', () => {
+  const text = stubs.getRandomMessageText();
+  let result = rivescriptHelper.parseReplyRivescriptLines(`\n${text}`);
+  result.should.deep.equal([
+    { operator: config.commands.reply, value: text },
+  ]);
+  result = rivescriptHelper.parseReplyRivescriptLines(`\n\n${text}`);
+  result.should.deep.equal([
+    { operator: config.commands.reply, value: text },
+  ]);
+});
+
 test('parseReplyRivescriptLines should return an array with reply command and 2 continuation commands if replyText has 2 repeating linebreaks', () => {
   const firstParagraphText = stubs.getRandomMessageText();
   const secondParagraphText = stubs.getRandomMessageText();

--- a/test/unit/lib/lib-helpers/rivescript.test.js
+++ b/test/unit/lib/lib-helpers/rivescript.test.js
@@ -149,6 +149,17 @@ test('fetchRivescripts should throw on gambitCampaigns.fetchDefaultTopicTriggers
   result.should.deep.equal(mockError);
 });
 
+// formatRedirectRivescript
+test('formatRedirectRivescript should return redirect command with text arg as rs line', () => {
+  sandbox.stub(rivescriptHelper, 'formatRivescriptLine')
+    .returns(mockRivescriptLine);
+
+  const result = rivescriptHelper.formatRedirectRivescript(mockWord);
+  rivescriptHelper.formatRivescriptLine
+    .should.have.been.calledWith(config.commands.redirect, mockWord);
+  result.should.equal(mockRivescriptLine);
+});
+
 // formatReplyRivescript
 test('formatReplyRivescript return array of Rivescript lines', () => {
   const data = [

--- a/test/unit/lib/lib-helpers/rivescript.test.js
+++ b/test/unit/lib/lib-helpers/rivescript.test.js
@@ -149,6 +149,34 @@ test('fetchRivescripts should throw on gambitCampaigns.fetchDefaultTopicTriggers
   result.should.deep.equal(mockError);
 });
 
+// formatReplyRivescript
+test('parseReplyRivescriptLines should throw if replyText undefined', (t) => {
+  t.throws(() => rivescriptHelper.parseReplyRivescriptLines());
+});
+
+test('parseReplyRivescriptLines should return an array with one reply command if replyText does not have linebreaks', () => {
+  const text = stubs.getRandomMessageText();
+  const result = rivescriptHelper.parseReplyRivescriptLines(text);
+  result.should.deep.equal([
+    { operator: config.commands.reply, value: text },
+  ]);
+});
+
+test('parseReplyRivescriptLines should return an array with reply command and 2 continuation commands if replyText has 2 repeating linebreaks', () => {
+  const firstParagraphText = stubs.getRandomMessageText();
+  const secondParagraphText = stubs.getRandomMessageText();
+  const lastParagraphText = stubs.getRandomMessageText();
+  const text = `${firstParagraphText}\n\n${secondParagraphText}\n\n${lastParagraphText}`;
+  const result = rivescriptHelper.parseReplyRivescriptLines(text);
+  result.should.deep.equal([
+    { operator: config.commands.reply, value: `${firstParagraphText}\\n` },
+    null,
+    { operator: config.commands.continuation, value: `${secondParagraphText}\\n` },
+    null,
+    { operator: config.commands.continuation, value: lastParagraphText },
+  ]);
+});
+
 // formatRivescriptLine
 test('formatRivescriptLine should return a trimmed concat of operator and value args', () => {
   const result = rivescriptHelper.formatRivescriptLine(config.commands.trigger, `${mockWord}   `);

--- a/test/unit/lib/lib-helpers/rivescript.test.js
+++ b/test/unit/lib/lib-helpers/rivescript.test.js
@@ -150,6 +150,46 @@ test('fetchRivescripts should throw on gambitCampaigns.fetchDefaultTopicTriggers
 });
 
 // formatReplyRivescript
+test('formatReplyRivescript return array of Rivescript lines', () => {
+  const data = [
+    { operator: '+', value: 'Beginning' },
+    { operator: '+', value: 'Middle' },
+    { operator: '^', value: 'The end' },
+  ];
+  const line = stubs.getRandomWord();
+  sandbox.stub(rivescriptHelper, 'parseReplyRivescriptLines')
+    .returns(data);
+  sandbox.stub(rivescriptHelper, 'formatRivescriptLine')
+    .returns(line);
+  const replyText = stubs.getRandomMessageText();
+  const topicId = null;
+
+  const result = rivescriptHelper.formatReplyRivescript(replyText, topicId);
+  rivescriptHelper.parseReplyRivescriptLines.should.have.been.calledWith(replyText, topicId);
+  data.forEach((item) => {
+    rivescriptHelper.formatRivescriptLine.should.have.been.calledWith(item.operator, item.value);
+  });
+  result.should.deep.equal([line, line, line]);
+});
+
+// formatRivescriptLine
+test('formatRivescriptLine should return a trimmed concat of operator and value args', () => {
+  const result = rivescriptHelper.formatRivescriptLine(config.commands.trigger, `${mockWord}   `);
+  result.should.equal(mockRivescriptLine);
+});
+
+// formatTriggerRivescript
+test('formatTriggerRivescript should return trigger command with triggerText as rs line', () => {
+  sandbox.stub(rivescriptHelper, 'formatRivescriptLine')
+    .returns(mockRivescriptLine);
+
+  const result = rivescriptHelper.formatTriggerRivescript(mockWord);
+  rivescriptHelper.formatRivescriptLine
+    .should.have.been.calledWith(config.commands.trigger, mockWord);
+  result.should.equal(mockRivescriptLine);
+});
+
+// parseReplyRivescriptLines
 test('parseReplyRivescriptLines should throw if replyText undefined', (t) => {
   t.throws(() => rivescriptHelper.parseReplyRivescriptLines());
 });
@@ -170,28 +210,9 @@ test('parseReplyRivescriptLines should return an array with reply command and 2 
   const result = rivescriptHelper.parseReplyRivescriptLines(text);
   result.should.deep.equal([
     { operator: config.commands.reply, value: `${firstParagraphText}\\n` },
-    null,
     { operator: config.commands.continuation, value: `${secondParagraphText}\\n` },
-    null,
     { operator: config.commands.continuation, value: lastParagraphText },
   ]);
-});
-
-// formatRivescriptLine
-test('formatRivescriptLine should return a trimmed concat of operator and value args', () => {
-  const result = rivescriptHelper.formatRivescriptLine(config.commands.trigger, `${mockWord}   `);
-  result.should.equal(mockRivescriptLine);
-});
-
-// formatTriggerRivescript
-test('formatTriggerRivescript should return trigger command with triggerText as rs line', () => {
-  sandbox.stub(rivescriptHelper, 'formatRivescriptLine')
-    .returns(mockRivescriptLine);
-
-  const result = rivescriptHelper.formatTriggerRivescript(mockWord);
-  rivescriptHelper.formatRivescriptLine
-    .should.have.been.calledWith(config.commands.trigger, mockWord);
-  result.should.equal(mockRivescriptLine);
 });
 
 // parseRivescript

--- a/test/unit/lib/lib-helpers/rivescript.test.js
+++ b/test/unit/lib/lib-helpers/rivescript.test.js
@@ -40,11 +40,17 @@ test.afterEach(() => {
   sandbox.restore();
 });
 
+// appendEscapedLinebreak
+test('appendEscapedLinebreak should append escaped linebreak character to text', () => {
+  const text = stubs.getRandomMessageText();
+  const result = rivescriptHelper.appendEscapedLinebreak(text);
+  result.should.equal(`${text}\\n`);
+});
+
 // appendTopicTag
 test('appendTopicTag should append Rivescript topic tag to string with given topicId', () => {
   const text = stubs.getRandomMessageText();
   const topicId = stubs.getContentfulId();
-
   const result = rivescriptHelper.appendTopicTag(text, topicId);
   result.should.equal(`${text}{topic=${topicId}}`);
 });

--- a/test/unit/lib/lib-helpers/topic.test.js
+++ b/test/unit/lib/lib-helpers/topic.test.js
@@ -144,16 +144,41 @@ test('isDefaultTopicId should return whether topicId is config.defaultTopicId', 
   t.falsy(topicHelper.isDefaultTopicId(stubs.getContentfulId()));
 });
 
-// getRenderedTextFromTopicAndTemplateName
-test('getRenderedTextFromTopicAndTemplateName returns a string when template exists', () => {
-  const topic = topicFactory.getValidTopic();
-  const templateName = stubs.getTemplate();
-  const result = topicHelper.getRenderedTextFromTopicAndTemplateName(topic, templateName);
-  result.should.equal(topic.templates[templateName].rendered);
+// getTopicTemplateText
+test('getTopicTemplateText returns a string when template exists', () => {
+  const topic = topicFactory.getValidPhotoPostConfig();
+  const templateName = 'startPhotoPostAutoReply';
+  const result = topicHelper.getTopicTemplateText(topic, templateName);
+  result.should.equal(topic.templates[templateName].text);
 });
 
-test('getRenderedTextFromTopicAndTemplateName throws when template undefined', (t) => {
-  const topic = topicFactory.getValidTopic();
+test('getTopicTemplateText throws when template undefined', (t) => {
+  const topic = topicFactory.getValidPhotoPostConfig();
   const templateName = 'winterfell';
-  t.throws(() => topicHelper.getRenderedTextFromTopicAndTemplateName(topic, templateName));
+  t.throws(() => topicHelper.getTopicTemplateText(topic, templateName));
+});
+
+// getStartTemplateText
+test('getStartTemplateText returns askText text for textPostConfig topics ', () => {
+  const topic = topicFactory.getValidTextPostConfig();
+  const result = topicHelper.getStartTemplateText(topic);
+  result.should.equal(topic.templates.askText.text);
+});
+
+test('getStartTemplateText returns startExternalPost text for externalPostConfig topics ', () => {
+  const topic = topicFactory.getValidExternalPostConfig();
+  const result = topicHelper.getStartTemplateText(topic);
+  result.should.equal(topic.templates.startExternalPost.text);
+});
+
+test('getStartTemplateText returns startPhotoPost text for photoPostConfig topics ', () => {
+  const topic = topicFactory.getValidPhotoPostConfig();
+  const result = topicHelper.getStartTemplateText(topic);
+  result.should.equal(topic.templates.startPhotoPost.text);
+});
+
+test('getStartTemplateText returns null if topic type not externalPostConfig, photoPostConfig, or textPostConfig', (t) => {
+  const topic = topicFactory.getValidAutoReply();
+  const result = topicHelper.getStartTemplateText(topic);
+  t.is(result, null);
 });


### PR DESCRIPTION
#### What's this PR do?

Cherry picks some of #425 into a part 1 PR for supporting the newer transition content types in https://github.com/DoSomething/gambit-campaigns/pull/1094 as a `response` references on a `defaultTopicTrigger` entries.

* Refactors parsing a `defaultTopicTrigger` as Rivescript, so editors no longer need to include a `^` character as hack for[ Rivescript continuation commands.](https://www.rivescript.com/docs/tutorial#line-breaking). We'll need to update this message copy once we go live, but that can't happen until Part 2 coming soon. Part 2 fixes the topic changes that part 1 breaks -- as we no longer need to fetch the new topic Id in order to determine the message to send if a topic change happens via keyword.


#### How should this be reviewed?

This branch gets things almost-working. It creates functional Rivescript triggers on the default topic by either using the transition text field, or the topic's relevant start template field (which will be deprecated once we backfill all triggers with transition entries). We aim to manually swap them out 1 by 1 when this is ready to go live, as part 2 will need to support topic changes for both `response` types (transition entires and topic entries) during the migration.

This shouldn't be merged into master without a working part 2, but I'm opening as is to help keep this refactoring reviewable. Part 2's PR will be opened up against this branch .

#### Any background context you want to provide?
We aim to make this change so the help text per start message can be edited per the topic change. Examples:

* For a `photoPostTransition` entry, the `text` field description reads as: "Should prompt user to send START to begin a photo post"

* For a `textPostTransition` entry, the `text` field description reads as: "Should ask user to send text to create a post from"

<img width="1109" alt="screen shot 2018-11-05 at 1 07 31 pm" src="https://user-images.githubusercontent.com/1236811/48026792-e2b92e00-e0fb-11e8-8ae2-c8ea8015f854.png">


#### Relevant tickets
https://www.pivotaltracker.com/story/show/157369418

#### Checklist
- [ ] Tests added/updated for new features/bug fixes.
