### PR TITLE
Include signup details

### DIFF
--- a/lib/helpers/request.js
+++ b/lib/helpers/request.js
@@ -66,7 +66,7 @@ async function executeRivescriptTopicChange(req) {
     await helpers.user.fetchOrCreateSignup(req.user, {
       campaignId: topic.campaign.id,
       source: req.platform,
-      sourceDetail: `keyword/${req.rivescriptMatch}`,
+      details: `keyword/${req.rivescriptMatch}`,
     });
   }
 
@@ -115,7 +115,7 @@ async function executeSaidYesMacro(req, res) {
     await helpers.user.fetchOrCreateSignup(req.user, {
       campaignId: saidYesTemplate.topic.campaign.id,
       source: req.platform,
-      sourceDetail: `broadcast/${broadcastId}`,
+      details: `broadcast/${broadcastId}`,
     });
   }
 

--- a/lib/helpers/request.js
+++ b/lib/helpers/request.js
@@ -63,8 +63,12 @@ async function executeRivescriptTopicChange(req) {
   logger.debug('helpers.topic.getById success', { topicId }, req);
 
   if (helpers.topic.hasCampaign(topic)) {
-    const signup = await helpers.user.createSignup(req.user, topic.campaign.id, req.platform);
-    logger.debug('createdSignup', { signup }, req);
+    const signup = await helpers.user.createSignup(req.user, {
+      campaignId: topic.campaign.id,
+      source: req.platform,
+      sourceDetail: `keyword/${req.rivescriptReplyMatch}`,
+    });
+    logger.debug('signup created', { signup }, req);
   }
 
   return module.exports.changeTopic(req, topic);

--- a/lib/helpers/request.js
+++ b/lib/helpers/request.js
@@ -63,12 +63,12 @@ async function executeRivescriptTopicChange(req) {
   logger.debug('helpers.topic.getById success', { topicId }, req);
 
   if (helpers.topic.hasCampaign(topic)) {
-    const signup = await helpers.user.createSignup(req.user, {
+    const signup = await helpers.user.fetchOrCreateSignup(req.user, {
       campaignId: topic.campaign.id,
       source: req.platform,
-      sourceDetail: `keyword/${req.rivescriptReplyMatch}`,
+      sourceDetail: `keyword/${req.rivescriptMatch}`,
     });
-    logger.debug('signup created', { signup }, req);
+    logger.debug('signup', { signup });
   }
 
   return module.exports.changeTopic(req, topic);
@@ -112,14 +112,16 @@ async function executeSaidYesMacro(req, res) {
     throw new UnprocessableEntityError('saidYes topic is undefined');
   }
 
-  // TODO: We need to postCampaignActivity before we change topic. If postCampaignActivity fails and
-  // request is retried, we're not in the correct topic that returns a saidYesTemplate below.
-  await module.exports.changeTopic(req, saidYesTemplate.topic);
-
-  // If our new topic contains a campaign, post activity to create a signup.
-  if (module.exports.hasCampaign(req)) {
-    await module.exports.postCampaignActivity(req, broadcastId);
+  if (helpers.topic.hasCampaign(saidYesTemplate.topic)) {
+    const signup = await helpers.user.fetchOrCreateSignup(req.user, {
+      campaignId: saidYesTemplate.topic.campaign.id,
+      source: req.platform,
+      sourceDetail: `broadcast/${broadcastId}`,
+    });
+    logger.debug('signup', { signup });
   }
+
+  await module.exports.changeTopic(req, saidYesTemplate.topic);
 
   return helpers.replies.saidYes(req, res, saidYesTemplate.text);
 }

--- a/lib/helpers/request.js
+++ b/lib/helpers/request.js
@@ -63,12 +63,11 @@ async function executeRivescriptTopicChange(req) {
   logger.debug('helpers.topic.getById success', { topicId }, req);
 
   if (helpers.topic.hasCampaign(topic)) {
-    const signup = await helpers.user.fetchOrCreateSignup(req.user, {
+    await helpers.user.fetchOrCreateSignup(req.user, {
       campaignId: topic.campaign.id,
       source: req.platform,
       sourceDetail: `keyword/${req.rivescriptMatch}`,
     });
-    logger.debug('signup', { signup });
   }
 
   return module.exports.changeTopic(req, topic);
@@ -113,12 +112,11 @@ async function executeSaidYesMacro(req, res) {
   }
 
   if (helpers.topic.hasCampaign(saidYesTemplate.topic)) {
-    const signup = await helpers.user.fetchOrCreateSignup(req.user, {
+    await helpers.user.fetchOrCreateSignup(req.user, {
       campaignId: saidYesTemplate.topic.campaign.id,
       source: req.platform,
       sourceDetail: `broadcast/${broadcastId}`,
     });
-    logger.debug('signup', { signup });
   }
 
   await module.exports.changeTopic(req, saidYesTemplate.topic);

--- a/lib/helpers/user.js
+++ b/lib/helpers/user.js
@@ -63,6 +63,54 @@ async function fetchOrCreateVotingPlan(user, source) {
 
 /**
  * @param {Object} user
+ * @param {Number} campaignId
+ * @param {String} sourceDetail
+ * @return {Promise}
+ */
+async function fetchOrCreateSignup(user, args) {
+  const userId = user.id;
+  const campaignId = args.campaignId;
+  if (!campaignId) {
+    throw new Error('fetchOrCreateSignup missing campaignId param');
+  }
+  const signup = await module.exports.fetchSignup(user, campaignId);
+  if (signup) {
+    logger.debug('signup exists', { userId, campaignId });
+    return signup;
+  }
+  logger.debug('creating signup', { userId, campaignId });
+  return module.exports.createSignup(user, args);
+}
+
+/**
+ * @param {Object} user
+ * @param {Number} campaignId
+ * @return {Promise}
+ */
+async function fetchSignup(user, campaignId) {
+  const query = module.exports.getFetchSignupQuery(user, campaignId);
+  logger.debug('rogue.getSignups', { query });
+  const res = await rogue.getSignups(query);
+  if (res.data && res.data[0]) {
+    return res.data[0];
+  }
+  return null;
+}
+
+/**
+ * @param {Object} user
+ * @param {Number} campaignId
+ * @return {Object}
+ */
+function getFetchSignupQuery(user, campaignId) {
+  const query = {};
+  query['filter[northstar_id]'] = user.id;
+  query['filter[campaign_id]'] = campaignId;
+  return query;
+}
+
+/**
+ * @param {Object} user
  * @return {Object}
  */
 function getFetchVotingPlanQuery(user) {
@@ -84,6 +132,7 @@ function getVotingPlanValues(user) {
     time_of_day: user[config.fields.votingPlanTimeOfDay.name],
   };
 }
+
 
 /**
  * @param {Object} user
@@ -134,8 +183,11 @@ async function updateByMemberMessageReq(req) {
 module.exports = {
   createSignup,
   createVotingPlan,
+  fetchOrCreateSignup,
   fetchOrCreateVotingPlan,
+  fetchSignup,
   fetchVotingPlan,
+  getFetchSignupQuery,
   getFetchVotingPlanQuery,
   getVotingPlanValues,
   unauthenticatedFetchById(userId) {

--- a/lib/helpers/user.js
+++ b/lib/helpers/user.js
@@ -63,8 +63,7 @@ async function fetchOrCreateVotingPlan(user, source) {
 
 /**
  * @param {Object} user
- * @param {Number} campaignId
- * @param {String} sourceDetail
+ * @param {Object} args
  * @return {Promise}
  */
 async function fetchOrCreateSignup(user, args) {

--- a/lib/helpers/user.js
+++ b/lib/helpers/user.js
@@ -127,7 +127,6 @@ function getVotingPlanValues(user) {
   };
 }
 
-
 /**
  * @param {Object} user
  * @return {Promise}

--- a/lib/helpers/user.js
+++ b/lib/helpers/user.js
@@ -20,7 +20,7 @@ async function createSignup(user, args) {
     northstar_id: user.id,
     campaign_id: args.campaignId,
     source: args.source,
-    source_detail: args.sourceDetail,
+    details: args.details,
   };
   logger.debug('rogue.createSignup post', { payload });
   const signup = await rogue.createSignup(payload);
@@ -34,13 +34,12 @@ async function createSignup(user, args) {
  * @return {Promise}
  */
 function createVotingPlan(user, source) {
-  const details = JSON.stringify(module.exports.getVotingPlanValues(user));
+  const text = JSON.stringify(module.exports.getVotingPlanValues(user));
   const payload = {
     campaign_id: votingPlanPostConfig.campaignId,
-    details,
     northstar_id: user.id,
     source,
-    text: details,
+    text,
     type: votingPlanPostConfig.type,
   };
   logger.debug('rogue.createPost', { payload });

--- a/lib/helpers/user.js
+++ b/lib/helpers/user.js
@@ -15,15 +15,17 @@ const votingPlanPostConfig = config.posts.votingPlan;
  * @param {Object} args
  * @return {Promise}
  */
-function createSignup(user, args) {
+async function createSignup(user, args) {
   const payload = {
     northstar_id: user.id,
     campaign_id: args.campaignId,
     source: args.source,
     source_detail: args.sourceDetail,
   };
-  logger.debug('rogue.createSignup', { payload });
-  return rogue.createSignup(payload);
+  logger.debug('rogue.createSignup post', { payload });
+  const signup = await rogue.createSignup(payload);
+  logger.debug('rogue.createSignup success', { signup });
+  return signup;
 }
 
 /**
@@ -74,7 +76,7 @@ async function fetchOrCreateSignup(user, args) {
   }
   const signup = await module.exports.fetchSignup(user, campaignId);
   if (signup) {
-    logger.debug('signup exists', { userId, campaignId });
+    logger.debug('signup exists', { signup });
     return signup;
   }
   logger.debug('creating signup', { userId, campaignId });
@@ -87,25 +89,11 @@ async function fetchOrCreateSignup(user, args) {
  * @return {Promise}
  */
 async function fetchSignup(user, campaignId) {
-  const query = module.exports.getFetchSignupQuery(user, campaignId);
-  logger.debug('rogue.getSignups', { query });
-  const res = await rogue.getSignups(query);
+  const res = await rogue.fetchSignups(user.id, campaignId);
   if (res.data && res.data[0]) {
     return res.data[0];
   }
   return null;
-}
-
-/**
- * @param {Object} user
- * @param {Number} campaignId
- * @return {Object}
- */
-function getFetchSignupQuery(user, campaignId) {
-  const query = {};
-  query['filter[northstar_id]'] = user.id;
-  query['filter[campaign_id]'] = campaignId;
-  return query;
 }
 
 /**
@@ -186,7 +174,6 @@ module.exports = {
   fetchOrCreateVotingPlan,
   fetchSignup,
   fetchVotingPlan,
-  getFetchSignupQuery,
   getFetchVotingPlanQuery,
   getVotingPlanValues,
   unauthenticatedFetchById(userId) {

--- a/lib/helpers/user.js
+++ b/lib/helpers/user.js
@@ -12,14 +12,15 @@ const votingPlanPostConfig = config.posts.votingPlan;
 
 /**
  * @param {Object} user
- * @param {Number} campaignId
+ * @param {Object} args
  * @return {Promise}
  */
-function createSignup(user, campaignId, source) {
+function createSignup(user, args) {
   const payload = {
     northstar_id: user.id,
-    campaign_id: campaignId,
-    source,
+    campaign_id: args.campaignId,
+    source: args.source,
+    source_detail: args.sourceDetail,
   };
   logger.debug('rogue.createSignup', { payload });
   return rogue.createSignup(payload);

--- a/lib/helpers/user.js
+++ b/lib/helpers/user.js
@@ -89,23 +89,30 @@ async function fetchOrCreateSignup(user, args) {
  * @return {Promise}
  */
 async function fetchSignup(user, campaignId) {
-  const res = await rogue.fetchSignups(user.id, campaignId);
-  if (res.data && res.data[0]) {
-    return res.data[0];
-  }
-  return null;
+  const res = await rogue.fetchSignups(module.exports.getFetchSignupsQuery(user.id, campaignId));
+  return res.data && res.data[0] ? res.data[0] : null;
 }
 
 /**
- * @param {Object} user
+ * @param {String} userId
+ * @param {Number} campaignId
  * @return {Object}
  */
-function getFetchVotingPlanQuery(user) {
+function getFetchSignupsQuery(userId, campaignId) {
   const query = {};
-  query['filter[northstar_id]'] = user.id;
-  query['filter[campaign_id]'] = votingPlanPostConfig.campaignId;
-  query['filter[type]'] = votingPlanPostConfig.type;
+  query['filter[northstar_id]'] = userId;
+  query['filter[campaign_id]'] = campaignId;
   return query;
+}
+
+/**
+ * @param {String} userId
+ * @return {Object}
+ */
+function getFetchVotingPlanQuery(userId) {
+  const postTypeQuery = { 'filter[type]': votingPlanPostConfig.type };
+  return Object.assign(module.exports
+    .getFetchSignupsQuery(userId, votingPlanPostConfig.campaignId), postTypeQuery);
 }
 
 /**
@@ -126,13 +133,8 @@ function getVotingPlanValues(user) {
  * @return {Promise}
  */
 async function fetchVotingPlan(user) {
-  const query = module.exports.getFetchVotingPlanQuery(user);
-  logger.debug('rogue.getPosts', { query });
-  const res = await rogue.getPosts(query);
-  if (res.data && res.data[0]) {
-    return res.data[0];
-  }
-  return null;
+  const res = await rogue.fetchPosts(module.exports.getFetchVotingPlanQuery(user.id));
+  return res.data && res.data[0] ? res.data[0] : null;
 }
 
 /**
@@ -174,6 +176,7 @@ module.exports = {
   fetchOrCreateVotingPlan,
   fetchSignup,
   fetchVotingPlan,
+  getFetchSignupsQuery,
   getFetchVotingPlanQuery,
   getVotingPlanValues,
   unauthenticatedFetchById(userId) {

--- a/lib/rogue.js
+++ b/lib/rogue.js
@@ -41,9 +41,20 @@ function getPosts(query) {
   return module.exports.getClient().Posts.index(query);
 }
 
+/**
+ * getSignups
+ *
+ * @param {object} query
+ * @return {Promise}
+ */
+function getSignups(query) {
+  return module.exports.getClient().Signups.index(query);
+}
+
 module.exports = {
   getClient,
   createPost,
   createSignup,
   getPosts,
+  getSignups,
 };

--- a/lib/rogue.js
+++ b/lib/rogue.js
@@ -11,6 +11,13 @@ function getClient() {
   return rogueClient;
 }
 
+function getQueryByUserIdAndCampaignId(userId, campaignId) {
+  const query = {};
+  query['filter[northstar_id]'] = userId;
+  query['filter[campaign_id]'] = campaignId;
+  return query;
+}
+
 /**
  * createPost
  *
@@ -32,6 +39,18 @@ function createSignup(data) {
 }
 
 /**
+ * fetchSignups
+ *
+ * @param {String} userId
+ * @param {Number} campaignId
+ * @return {Promise}
+ */
+function fetchSignups(userId, campaignId) {
+  const query = getQueryByUserIdAndCampaignId(userId, campaignId);
+  return module.exports.getClient().Signups.index(query);
+}
+
+/**
  * getPosts
  *
  * @param {object} query
@@ -41,20 +60,10 @@ function getPosts(query) {
   return module.exports.getClient().Posts.index(query);
 }
 
-/**
- * getSignups
- *
- * @param {object} query
- * @return {Promise}
- */
-function getSignups(query) {
-  return module.exports.getClient().Signups.index(query);
-}
-
 module.exports = {
   getClient,
   createPost,
   createSignup,
+  fetchSignups,
   getPosts,
-  getSignups,
 };

--- a/lib/rogue.js
+++ b/lib/rogue.js
@@ -11,13 +11,6 @@ function getClient() {
   return rogueClient;
 }
 
-function getQueryByUserIdAndCampaignId(userId, campaignId) {
-  const query = {};
-  query['filter[northstar_id]'] = userId;
-  query['filter[campaign_id]'] = campaignId;
-  return query;
-}
-
 /**
  * createPost
  *
@@ -41,12 +34,10 @@ function createSignup(data) {
 /**
  * fetchSignups
  *
- * @param {String} userId
- * @param {Number} campaignId
+ * @param {Object} query
  * @return {Promise}
  */
-function fetchSignups(userId, campaignId) {
-  const query = getQueryByUserIdAndCampaignId(userId, campaignId);
+function fetchSignups(query) {
   return module.exports.getClient().Signups.index(query);
 }
 
@@ -56,7 +47,7 @@ function fetchSignups(userId, campaignId) {
  * @param {object} query
  * @return {Promise}
  */
-function getPosts(query) {
+function fetchPosts(query) {
   return module.exports.getClient().Posts.index(query);
 }
 
@@ -64,6 +55,6 @@ module.exports = {
   getClient,
   createPost,
   createSignup,
+  fetchPosts,
   fetchSignups,
-  getPosts,
 };

--- a/test/unit/lib/lib-helpers/request.test.js
+++ b/test/unit/lib/lib-helpers/request.test.js
@@ -175,7 +175,7 @@ test('executeRivescriptTopicChange get topic, create signup if topic has campaig
     .should.have.been.calledWith(t.context.req.user, {
       campaignId: topic.campaign.id,
       source: t.context.req.platform,
-      sourceDetail: `keyword/${keyword}`,
+      details: `keyword/${keyword}`,
     });
   requestHelper.changeTopic
     .should.have.been.calledWith(t.context.req, topic);
@@ -218,7 +218,7 @@ test('executeSaidYesMacro should call post campaign activity if new topic has ca
   helpers.user.fetchOrCreateSignup.should.have.been.calledWith(t.context.req.user, {
     campaignId: saidYesTemplate.topic.campaign.id,
     source: t.context.req.platform,
-    sourceDetail: `broadcast/${askYesNo.id}`,
+    details: `broadcast/${askYesNo.id}`,
   });
   helpers.replies.sendReply
     .should.have.been.calledWith(t.context.req, t.context.res, saidYesTemplate.text, 'saidYes');

--- a/test/unit/lib/lib-helpers/user.test.js
+++ b/test/unit/lib/lib-helpers/user.test.js
@@ -28,6 +28,7 @@ const conversationFactory = require('../../../helpers/factories/conversation');
 const messageFactory = require('../../../helpers/factories/message');
 const userFactory = require('../../../helpers/factories/user');
 
+const campaignId = stubs.getCampaignId();
 const mockPost = { id: stubs.getCampaignRunId() };
 const mockSignup = { id: stubs.getCampaignRunId() };
 const mockUser = userFactory.getValidUser();
@@ -50,7 +51,6 @@ test.afterEach((t) => {
 
 // createSignup
 test('createSignup passes user.id, campaignId and source args to rogue.createSignup', async () => {
-  const campaignId = stubs.getCampaignId();
   const signup = { id: campaignId, campaign_id: campaignId };
   const sourceDetail = 'test';
   sandbox.stub(rogue, 'createSignup')
@@ -224,14 +224,24 @@ test('getDefaultUpdatePayloadFromReq should return object', () => {
   result.sms_paused.should.equal(isSupportTopic);
 });
 
-// getFetchVotingPlanQuery
-test('getFetchVotingPlanQuery should return object for querying by userId and voting plan campaign/type', () => {
-  const result = userHelper.getFetchVotingPlanQuery(mockUser.id);
+// getFetchSignupsQuery
+test('getFetchSignupsQuery should return object for querying by userId and campaignId', () => {
+  const result = userHelper.getFetchSignupsQuery(mockUser.id, campaignId);
   result.should.deep.equal({
     'filter[northstar_id]': mockUser.id,
-    'filter[campaign_id]': config.posts.votingPlan.campaignId,
-    'filter[type]': config.posts.votingPlan.type,
+    'filter[campaign_id]': campaignId,
   });
+});
+
+// getFetchVotingPlanQuery
+test('getFetchVotingPlanQuery should return getFetchSignupsQuery result with type filter property', () => {
+  const mockQuery = { test: stubs.getRandomWord() };
+  sandbox.stub(userHelper, 'getFetchSignupsQuery')
+    .returns(mockQuery);
+  const result = userHelper.getFetchVotingPlanQuery(mockUser.id);
+  result.should.deep.equal(Object.assign(mockQuery, {
+    'filter[type]': config.posts.votingPlan.type,
+  }));
 });
 
 // getVotingPlanValues

--- a/test/unit/lib/lib-helpers/user.test.js
+++ b/test/unit/lib/lib-helpers/user.test.js
@@ -52,16 +52,16 @@ test.afterEach((t) => {
 // createSignup
 test('createSignup passes user.id, campaignId and source args to rogue.createSignup', async () => {
   const signup = { id: campaignId, campaign_id: campaignId };
-  const sourceDetail = 'test';
+  const details = 'test';
   sandbox.stub(rogue, 'createSignup')
     .returns(Promise.resolve(signup));
 
-  const result = await userHelper.createSignup(mockUser, { campaignId, source, sourceDetail });
+  const result = await userHelper.createSignup(mockUser, { campaignId, source, details });
   rogue.createSignup.should.have.been.calledWith({
     campaign_id: campaignId,
     northstar_id: mockUser.id,
     source,
-    source_detail: sourceDetail,
+    details,
   });
   result.should.deep.equal(signup);
 });
@@ -76,7 +76,6 @@ test('createVotingPlan passes user voting plan info to rogue.createPost', async 
   const result = await userHelper.createVotingPlan(mockUser, source);
   rogue.createPost.should.have.been.calledWith({
     campaign_id: config.posts.votingPlan.campaignId,
-    details,
     northstar_id: mockUser.id,
     source,
     text: details,

--- a/test/unit/lib/lib-helpers/user.test.js
+++ b/test/unit/lib/lib-helpers/user.test.js
@@ -159,11 +159,11 @@ test('fetchVotingPlan should call rogue.getPosts with query for user voting plan
   const mockQuery = { test: '123' };
   sandbox.stub(userHelper, 'getFetchVotingPlanQuery')
     .returns(mockQuery);
-  sandbox.stub(rogue, 'getPosts')
+  sandbox.stub(rogue, 'fetchPosts')
     .returns(Promise.resolve({ data: [mockPost] }));
 
   const result = await userHelper.fetchVotingPlan(mockUser);
-  rogue.getPosts.should.have.been.calledWith(mockQuery);
+  rogue.fetchPosts.should.have.been.calledWith(mockQuery);
   result.should.deep.equal(mockPost);
 });
 
@@ -197,8 +197,8 @@ test('getDefaultUpdatePayloadFromReq should return object', () => {
 });
 
 // getFetchVotingPlanQuery
-test('getFetchVotingPlanQuery should return object with user id and voting plan campaign/type', () => {
-  const result = userHelper.getFetchVotingPlanQuery(mockUser);
+test('getFetchVotingPlanQuery should return object for querying by userId and voting plan campaign/type', () => {
+  const result = userHelper.getFetchVotingPlanQuery(mockUser.id);
   result.should.deep.equal({
     'filter[northstar_id]': mockUser.id,
     'filter[campaign_id]': config.posts.votingPlan.campaignId,

--- a/test/unit/lib/lib-helpers/user.test.js
+++ b/test/unit/lib/lib-helpers/user.test.js
@@ -51,14 +51,16 @@ test.afterEach((t) => {
 test('createSignup passes user.id, campaignId and source args to rogue.createSignup', async () => {
   const campaignId = stubs.getCampaignId();
   const signup = { id: campaignId, campaign_id: campaignId };
+  const sourceDetail = 'test';
   sandbox.stub(rogue, 'createSignup')
     .returns(Promise.resolve(signup));
 
-  const result = await userHelper.createSignup(mockUser, campaignId, source);
+  const result = await userHelper.createSignup(mockUser, { campaignId, source, sourceDetail });
   rogue.createSignup.should.have.been.calledWith({
     campaign_id: campaignId,
     northstar_id: mockUser.id,
     source,
+    source_detail: sourceDetail,
   });
   result.should.deep.equal(signup);
 });

--- a/test/unit/lib/lib-helpers/user.test.js
+++ b/test/unit/lib/lib-helpers/user.test.js
@@ -29,6 +29,7 @@ const messageFactory = require('../../../helpers/factories/message');
 const userFactory = require('../../../helpers/factories/user');
 
 const mockPost = { id: stubs.getCampaignRunId() };
+const mockSignup = { id: stubs.getCampaignRunId() };
 const mockUser = userFactory.getValidUser();
 const userLookupStub = () => Promise.resolve(mockUser);
 const platformUserAddressStub = {
@@ -84,19 +85,34 @@ test('createVotingPlan passes user voting plan info to rogue.createPost', async 
   result.should.deep.equal(mockPost);
 });
 
-// fetchOrCreateVotingPlan
-test('fetchOrCreateVotingPlan returns fetchVotingPlan result if exists', async () => {
-  sandbox.stub(userHelper, 'fetchVotingPlan')
-    .returns(Promise.resolve(mockPost));
-  sandbox.stub(userHelper, 'createVotingPlan')
-    .returns(Promise.resolve({ id: stubs.getRandomWord() }));
+// fetchOrCreateSignup
+test('fetchOrCreateSignup returns createSignup result if fetchSignup result is null', async () => {
+  sandbox.stub(userHelper, 'fetchSignup')
+    .returns(Promise.resolve(null));
+  sandbox.stub(userHelper, 'createSignup')
+    .returns(Promise.resolve(mockSignup));
+  const args = { campaignId: stubs.getCampaignId() };
 
-  const result = await userHelper.fetchOrCreateVotingPlan(mockUser, source);
-  userHelper.fetchVotingPlan.should.have.been.calledWith(mockUser);
-  userHelper.createVotingPlan.should.not.have.been.called;
-  result.should.deep.equal(mockPost);
+  const result = await userHelper.fetchOrCreateSignup(mockUser, args);
+  userHelper.fetchSignup.should.have.calledWith(mockUser, args.campaignId);
+  userHelper.createSignup.should.have.calledWith(mockUser, args);
+  result.should.deep.equal(mockSignup);
 });
 
+test('fetchOrCreateSignup returns fetchSignup result if exists', async () => {
+  sandbox.stub(userHelper, 'fetchSignup')
+    .returns(Promise.resolve(mockSignup));
+  sandbox.stub(userHelper, 'createSignup')
+    .returns(Promise.resolve({ id: stubs.getRandomWord() }));
+  const args = { campaignId: stubs.getCampaignId() };
+
+  const result = await userHelper.fetchOrCreateSignup(mockUser, args);
+  userHelper.fetchSignup.should.have.been.calledWith(mockUser, args.campaignId);
+  userHelper.createSignup.should.not.have.been.called;
+  result.should.deep.equal(mockSignup);
+});
+
+// fetchOrCreateVotingPlan
 test('fetchOrCreateVotingPlan returns createVotingPlan result if fetchVotingPlan result is null', async () => {
   sandbox.stub(userHelper, 'fetchVotingPlan')
     .returns(Promise.resolve(null));
@@ -106,6 +122,18 @@ test('fetchOrCreateVotingPlan returns createVotingPlan result if fetchVotingPlan
   const result = await userHelper.fetchOrCreateVotingPlan(mockUser, source);
   userHelper.fetchVotingPlan.should.have.been.calledWith(mockUser);
   userHelper.createVotingPlan.should.have.been.calledWith(mockUser, source);
+  result.should.deep.equal(mockPost);
+});
+
+test('fetchOrCreateVotingPlan returns fetchVotingPlan result if exists', async () => {
+  sandbox.stub(userHelper, 'fetchVotingPlan')
+    .returns(Promise.resolve(mockPost));
+  sandbox.stub(userHelper, 'createVotingPlan')
+    .returns(Promise.resolve({ id: stubs.getRandomWord() }));
+
+  const result = await userHelper.fetchOrCreateVotingPlan(mockUser, source);
+  userHelper.fetchVotingPlan.should.have.been.calledWith(mockUser);
+  userHelper.createVotingPlan.should.not.have.been.called;
   result.should.deep.equal(mockPost);
 });
 

--- a/test/unit/lib/middleware/messages/member/catchAll-askYesNo.test.js
+++ b/test/unit/lib/middleware/messages/member/catchAll-askYesNo.test.js
@@ -13,6 +13,7 @@ const helpers = require('../../../../../../lib/helpers');
 const logger = require('../../../../../../lib/logger');
 const broadcastFactory = require('../../../../../helpers/factories/broadcast');
 const topicFactory = require('../../../../../helpers/factories/topic');
+const userFactory = require('../../../../../helpers/factories/user');
 
 chai.should();
 chai.use(sinonChai);
@@ -39,6 +40,7 @@ test.beforeEach((t) => {
     .returns(underscore.noop);
   t.context.req = httpMocks.createRequest();
   t.context.res = httpMocks.createResponse();
+  t.context.req.user = userFactory.getValidUser();
 });
 
 test.afterEach((t) => {
@@ -85,19 +87,15 @@ test('askYesNoCatchAll should changeTopic and send saidYes template if askYesNo 
     .returns(Promise.resolve());
   sandbox.stub(helpers.request, 'isSaidYesMacro')
     .returns(true);
-  sandbox.stub(helpers.request, 'changeTopic')
+  sandbox.stub(helpers.request, 'executeSaidYesMacro')
     .returns(Promise.resolve());
 
   // test
   await middleware(t.context.req, t.context.res, next);
 
   helpers.request.parseAskYesNoResponse.should.have.been.calledWith(t.context.req);
-  const saidYesTemplate = askYesNoBroadcast.templates.saidYes;
   next.should.not.have.been.called;
-  helpers.request.changeTopic
-    .should.have.been.calledWith(t.context.req, saidYesTemplate.topic);
-  helpers.replies.sendReply
-    .should.have.been.calledWith(t.context.req, t.context.res, saidYesTemplate.text, 'saidYes');
+  helpers.request.executeSaidYesMacro.should.have.been.calledWith(t.context.req);
   helpers.sendErrorResponse.should.not.been.called;
 });
 

--- a/test/unit/lib/rogue.test.js
+++ b/test/unit/lib/rogue.test.js
@@ -19,6 +19,7 @@ const userFactory = require('../../helpers/factories/user');
 
 const rogueApiStub = RogueClient.getNewInstance();
 const mockPost = { id: stubs.getCampaignRunId() };
+const mockSignup = { id: stubs.getCampaignRunId() };
 const mockUser = userFactory.getValidUser();
 
 // Module to test
@@ -58,8 +59,8 @@ test('createSignup should call rogue.getClient.Signup.create', async () => {
   result.should.deep.equal(mockRogueResponse);
 });
 
-// getPosts
-test('getPosts should call rogue.getClient.Posts.index', async () => {
+// fetchPosts
+test('fetchPosts should call rogue.getClient.Posts.index', async () => {
   const mockQuery = { 'filter[northstar_id]': mockUser.id };
   const mockRogueResponse = { data: [mockPost] };
   sandbox.stub(rogueApiStub.Posts, 'index')
@@ -67,8 +68,23 @@ test('getPosts should call rogue.getClient.Posts.index', async () => {
   sandbox.stub(rogue, 'getClient')
     .returns(rogueApiStub);
 
-  const result = await rogue.getPosts(mockQuery);
+  const result = await rogue.fetchPosts(mockQuery);
   rogue.getClient.should.have.been.called;
   rogueApiStub.Posts.index.should.have.been.calledWith(mockQuery);
+  result.should.deep.equal(mockRogueResponse);
+});
+
+// fetchSignups
+test('fetchSignups should call rogue.getClient.Signups.index', async () => {
+  const mockQuery = { 'filter[northstar_id]': mockUser.id };
+  const mockRogueResponse = { data: [mockSignup] };
+  sandbox.stub(rogueApiStub.Signups, 'index')
+    .returns(Promise.resolve(mockRogueResponse));
+  sandbox.stub(rogue, 'getClient')
+    .returns(rogueApiStub);
+
+  const result = await rogue.fetchSignups(mockQuery);
+  rogue.getClient.should.have.been.called;
+  rogueApiStub.Signups.index.should.have.been.calledWith(mockQuery);
   result.should.deep.equal(mockRogueResponse);
 });


### PR DESCRIPTION
#### What's this PR do?

Passes a `details` parameter when creating a Rogue signup, sending either the entry keyword or broadcast id, along with a few extras: 

* Resolves TODO of fixing replies for retried `saidYes` macros, allowing us to deprecate the `askText` and `startPhotoPost` topic templates once all default topic triggers are backfilled with transition entries (vs topic entries) -- refs #434 

* Checks if a signup exists before creating it (also refs #434)

* Excludes passing a campaign run id when creating a signup for `saidYes` responses in `askYesNo` broadcasts.

#### How should this be reviewed?

Can verify `source_detail` via Rogue API request upon creating a signup via keyword or askYesNo response, but will open a PR in Gambit Admin to make it easier to verify.

#### Any background context you want to provide?

This is another step toward deprecating passing a campaign run id to the Rogue API, and ideally scaling down the functionality in the Gambit Campaigns `POST /campaignActivity` resource to handle draft photo post submissions.

#### Relevant tickets
* #170 
* https://www.pivotaltracker.com/story/show/161494958

#### Checklist
- [ ] Tests added/updated for new features/bug fixes.
- [ ] Tested on staging.
