### PR TITLE
Fixes bug when topic changes to random

### DIFF
--- a/config/lib/helpers/template.js
+++ b/config/lib/helpers/template.js
@@ -27,7 +27,7 @@ const templatesMap = {
     askWhyParticipated: 'askWhyParticipated',
     askYesNo: 'askYesNo',
     autoReply: 'autoReply',
-    changeTopic: 'changeTopic',
+    autoReplyTransition: 'autoReplyTransition',
     completedPhotoPost: 'completedPhotoPost',
     completedPhotoPostAutoReply: 'completedPhotoPostAutoReply',
     completedTextPost: 'completedTextPost',

--- a/config/lib/helpers/topic.js
+++ b/config/lib/helpers/topic.js
@@ -1,14 +1,35 @@
 'use strict';
 
+// TODO: Merge template config here to DRY.
+const templateConfig = require('./template');
+
+const topicTemplates = templateConfig.templatesMap.topicTemplates;
+
 module.exports = {
   types: {
-    askVotingPlanStatus: 'askVotingPlanStatus',
-    askYesNo: 'askYesNo',
-    autoReply: 'autoReply',
-    photoPostConfig: 'photoPostConfig',
-    textPostConfig: 'textPostConfig',
+    askVotingPlanStatus: {
+      type: 'askVotingPlanStatus',
+    },
+    askYesNo: {
+      type: 'askYesNo',
+    },
+    autoReply: {
+      type: 'autoReply',
+      transitionTemplate: topicTemplates.autoReplyTransition,
+    },
+    photoPostConfig: {
+      type: 'photoPostConfig',
+      transitionTemplate: topicTemplates.startPhotoPost,
+    },
+    textPostConfig: {
+      type: 'textPostConfig',
+      transitionTemplate: topicTemplates.askText,
+    },
     // To be deprecated by autoReply:
-    externalPostConfig: 'externalPostConfig',
+    externalPostConfig: {
+      type: 'externalPostConfig',
+      transitionTemplate: topicTemplates.startExternalPost,
+    },
   },
   rivescriptTopics: {
     askSubscriptionStatus: {

--- a/lib/helpers/request.js
+++ b/lib/helpers/request.js
@@ -53,20 +53,17 @@ function changeTopicByCampaign(req, campaign) {
 
 /**
  * @param {Object} req
+ * @param {Object} topic
+ * @param {String} signupDetails
  * @return {Promise}
  */
-async function executeRivescriptTopicChange(req) {
-  const topicId = req.rivescriptReplyTopicId;
-  logger.info('executeRivescriptTopicChange', { topicId, userId: req.userId }, req);
-
-  const topic = await helpers.topic.getById(topicId);
-  logger.debug('helpers.topic.getById success', { topicId }, req);
-
+async function executeInboundTopicChange(req, topic, signupDetails = null) {
+  // An inbound topic change should create a signup if campaign topic.
   if (helpers.topic.hasCampaign(topic)) {
     await helpers.user.fetchOrCreateSignup(req.user, {
       campaignId: topic.campaign.id,
       source: req.platform,
-      details: `keyword/${req.rivescriptMatch}`,
+      details: signupDetails,
     });
   }
 
@@ -383,7 +380,7 @@ function setMobileNumber(req, mobileNumber) {
 module.exports = {
   changeTopic,
   changeTopicByCampaign,
-  executeRivescriptTopicChange,
+  executeInboundTopicChange,
   executeSaidNoMacro,
   executeSaidYesMacro,
   getCampaignActivityPayload,

--- a/lib/helpers/request.js
+++ b/lib/helpers/request.js
@@ -72,6 +72,7 @@ async function executeInboundTopicChange(req, topic, signupDetails = null) {
 
 /**
  * Changes conversation topic to the saidNo template topic.
+ * TODO: Deprecate this function by calling executeInboundTopicChange from the askYesNo catchall.
  *
  * @param {Object} req
  * @return {Promise}
@@ -95,6 +96,7 @@ async function executeSaidNoMacro(req, res) {
 /**
  * Changes conversation topic to the saidYes template topic, and creates the saidYes topic contains
  * a campaign id.
+ * TODO: Deprecate this function by calling executeInboundTopicChange from the askYesNo catchall.
  *
  * @param {Object} req
  * @return {Promise}

--- a/lib/helpers/rivescript.js
+++ b/lib/helpers/rivescript.js
@@ -115,7 +115,7 @@ function parseRivescript(defaultTopicTrigger) {
   // Triggers that directly reference a topic entry won't have a reply set.
   // TODO: Remove this logic once they are updated to reference transition entries instead.
   if (!replyText && topicId) {
-    replyText = helpers.topic.getStartTemplateText(topic);
+    replyText = helpers.topic.getTransitionTemplateText(topic);
   }
 
   /**

--- a/lib/helpers/topic.js
+++ b/lib/helpers/topic.js
@@ -79,25 +79,17 @@ function getTopicTemplateText(topic, templateName) {
 }
 
 /**
- * TODO: Remove this function once all default topic triggers are backfilled with transitions.
+ * TODO: Remove this function once all default topic triggers are backfilled with transitions, as
+ * the transition message text wil be sourced from the transition entry.
  * @see lib/helpers/rivescript.getReplyRivescript
  *
  * @param {Object} topic
  * @return {String}
  */
 function getTransitionTemplateText(topic) {
-  const type = topic.type;
-  const templates = topic.templates;
-  if (type === 'photoPostConfig') {
-    return templates.startPhotoPost.text;
-  }
-  if (type === 'textPostConfig') {
-    return templates.askText.text;
-  }
-  if (type === 'externalPostConfig') {
-    return templates.startExternalPost.text;
-  }
-  return null;
+  const topicTypeConfig = config.types[topic.type];
+  const topicTemplate = topic.templates[topicTypeConfig.transitionTemplate];
+  return topicTemplate ? topicTemplate.text : null;
 }
 
 /**
@@ -111,21 +103,9 @@ function getSupportTopic() {
  * Return the outbound template name to use for triggers that transition to this topic.
  */
 function getTransitionTemplateName(topic) {
-  const type = topic.type;
-  const topicTemplates = templateConfig.templatesMap.topicTemplates;
-  if (type === 'autoReply') {
-    return topicTemplates.autoReplyTransition;
-  }
-  // TODO: Remove this once any defaultTopicTriggers referencing externalPostConfig entries as a
-  // a reference are backfilled with transition types.
-  if (type === 'externalPostConfig') {
-    return topicTemplates.startExternalPost;
-  }
-  if (type === 'photoPostConfig') {
-    return topicTemplates.startPhotoPost;
-  }
-  if (type === 'textPostConfig') {
-    return topicTemplates.askText;
+  const topicTypeConfig = config.types[topic.type];
+  if (topicTypeConfig && topicTypeConfig.transitionTemplate) {
+    return topicTypeConfig.transitionTemplate;
   }
   return templateConfig.templatesMap.rivescriptReply;
 }
@@ -151,7 +131,7 @@ function isAskSubscriptionStatus(topic) {
  * @return {Boolean}
  */
 function isAskVotingPlanStatus(topic) {
-  return topic.type === config.types.askVotingPlanStatus;
+  return topic.type === config.types.askVotingPlanStatus.type;
 }
 
 /**
@@ -159,7 +139,7 @@ function isAskVotingPlanStatus(topic) {
  * @return {Boolean}
  */
 function isAskYesNo(topic) {
-  return topic.type === config.types.askYesNo;
+  return topic.type === config.types.askYesNo.type;
 }
 
 /**
@@ -167,7 +147,7 @@ function isAskYesNo(topic) {
  * @return {Boolean}
  */
 function isAutoReply(topic) {
-  return topic.type === config.types.autoReply;
+  return topic.type === config.types.autoReply.type;
 }
 
 /**
@@ -204,8 +184,8 @@ module.exports = {
   getDefaultTopicId,
   getTopicTemplateText,
   getTransitionTemplateName,
-  getRivescriptTopicById,
   getTransitionTemplateText,
+  getRivescriptTopicById,
   getSupportTopic,
   hasCampaign,
   isAskSubscriptionStatus,

--- a/lib/helpers/topic.js
+++ b/lib/helpers/topic.js
@@ -5,6 +5,7 @@ const helpers = require('../helpers');
 const logger = require('../logger');
 const config = require('../../config/lib/helpers/topic');
 const broadcastConfig = require('../../config/lib/helpers/broadcast');
+const templateConfig = require('../../config/lib/helpers/template');
 
 /**
  * @param {String} topicId
@@ -84,7 +85,7 @@ function getTopicTemplateText(topic, templateName) {
  * @param {Object} topic
  * @return {String}
  */
-function getStartTemplateText(topic) {
+function getTransitionTemplateText(topic) {
   const type = topic.type;
   const templates = topic.templates;
   if (type === 'photoPostConfig') {
@@ -104,6 +105,29 @@ function getStartTemplateText(topic) {
  */
 function getSupportTopic() {
   return config.rivescriptTopics.support;
+}
+
+/**
+ * Return the outbound template name to use for transition entries that reference this topic. 
+ */
+function getTransitionTemplateName(topic) {
+  const type = topic.type;
+  const topicTemplates = templateConfig.templatesMap.topicTemplates;
+  if (type === 'autoReply') {
+    return topicTemplates.autoReplyTransition;
+  }
+  // This will get phased out eventually by autoReplyTransition entries:
+  if (type === 'externalPostConfig') {
+    return topicTemplates.startExternalPost;
+  }
+  if (type === 'photoPostConfig') {
+    return topicTemplates.startPhotoPost;
+  }
+  if (type === 'textPostConfig') {
+    return topicTemplates.askText;
+  }
+  // We shouldn't be able to reference 
+  return templateConfig.templatesMap.rivescriptReply;
 }
 
 /**
@@ -179,8 +203,9 @@ module.exports = {
   getDefaultTopic,
   getDefaultTopicId,
   getTopicTemplateText,
+  getTransitionTemplateName,
   getRivescriptTopicById,
-  getStartTemplateText,
+  getTransitionTemplateText,
   getSupportTopic,
   hasCampaign,
   isAskSubscriptionStatus,

--- a/lib/helpers/topic.js
+++ b/lib/helpers/topic.js
@@ -108,7 +108,7 @@ function getSupportTopic() {
 }
 
 /**
- * Return the outbound template name to use for transition entries that reference this topic. 
+ * Return the outbound template name to use for triggers that transition to this topic.
  */
 function getTransitionTemplateName(topic) {
   const type = topic.type;
@@ -116,7 +116,8 @@ function getTransitionTemplateName(topic) {
   if (type === 'autoReply') {
     return topicTemplates.autoReplyTransition;
   }
-  // This will get phased out eventually by autoReplyTransition entries:
+  // TODO: Remove this once any defaultTopicTriggers referencing externalPostConfig entries as a
+  // a reference are backfilled with transition types.
   if (type === 'externalPostConfig') {
     return topicTemplates.startExternalPost;
   }
@@ -126,7 +127,6 @@ function getTransitionTemplateName(topic) {
   if (type === 'textPostConfig') {
     return topicTemplates.askText;
   }
-  // We shouldn't be able to reference 
   return templateConfig.templatesMap.rivescriptReply;
 }
 

--- a/lib/middleware/messages/member/rivescript-reply-parse.js
+++ b/lib/middleware/messages/member/rivescript-reply-parse.js
@@ -13,7 +13,8 @@ module.exports = function parseRivescriptReply() {
       if (req.rivescriptReplyTopicId) {
         await helpers.request.executeRivescriptTopicChange(req);
       }
-      const templateName = req.rivescriptReplyTopicId ? 'changeTopic' : 'quickReply';
+      const templateName = req.topic ? helpers.topic
+        .getTransitionTemplateName(req.topic) : 'quickReply';
       return await helpers.replies.sendReply(req, res, req.rivescriptReplyText, templateName);
     } catch (error) {
       return helpers.sendErrorResponse(res, error);

--- a/lib/middleware/messages/member/rivescript-reply-parse.js
+++ b/lib/middleware/messages/member/rivescript-reply-parse.js
@@ -10,11 +10,16 @@ module.exports = function parseRivescriptReply() {
     }
     // Else send Rivescript reply.
     try {
+      let newTopic = null;
       if (req.rivescriptReplyTopicId) {
-        await helpers.request.executeRivescriptTopicChange(req);
+        newTopic = await helpers.topic.getById(req.rivescriptReplyTopicId);
+        await helpers.request
+          .executeInboundTopicChange(req, newTopic, `keyword/${req.rivescriptMatch}`);
       }
-      const templateName = req.topic ? helpers.topic
-        .getTransitionTemplateName(req.topic) : 'quickReply';
+
+      const templateName = newTopic ? helpers.topic
+        .getTransitionTemplateName(newTopic) : 'quickReply';
+
       return await helpers.replies.sendReply(req, res, req.rivescriptReplyText, templateName);
     } catch (error) {
       return helpers.sendErrorResponse(res, error);

--- a/test/helpers/factories/topic.js
+++ b/test/helpers/factories/topic.js
@@ -36,12 +36,12 @@ function getValidTopicWithoutCampaign() {
 }
 
 function getValidAutoReply() {
-  return getValidTopic(config.types.autoReply, { autoReply: getTemplate() });
+  return getValidTopic(config.types.autoReply.type, { autoReply: getTemplate() });
 }
 
 // TODO: Remove this function once we deprecate externalPostConfig type entirely.
 function getValidExternalPostConfig() {
-  return getValidTopic(config.types.externalPostConfig, { startExternalPost: getTemplate() });
+  return getValidTopic(config.types.externalPostConfig.type, { startExternalPost: getTemplate() });
 }
 
 function getValidPhotoPostConfig() {
@@ -54,7 +54,7 @@ function getValidPhotoPostConfig() {
     // TODO: Cleanup config/lib/helpers/template, possibly move into config/lib/helpers/topic
     // and use it to define the various templates per topic here.
   };
-  return getValidTopic(config.types.photoPostConfig, templates);
+  return getValidTopic(config.types.photoPostConfig.type, templates);
 }
 
 function getValidTextPostConfig() {
@@ -65,7 +65,7 @@ function getValidTextPostConfig() {
     completedTextPost: getTemplate(),
     completedTextPostAutoReply: getTemplate(),
   };
-  return getValidTopic(config.types.textPostConfig, templates);
+  return getValidTopic(config.types.textPostConfig.type, templates);
 }
 
 module.exports = {

--- a/test/unit/lib/lib-helpers/request.test.js
+++ b/test/unit/lib/lib-helpers/request.test.js
@@ -150,17 +150,14 @@ test('changeTopicByCampaign should call setCampaign and return changeTopic if ca
   requestHelper.changeTopic.should.have.been.calledWith(t.context.req, campaign.topics[0]);
 });
 
-// executeRivescriptTopicChange
-test('executeRivescriptTopicChange get topic, create signup if topic has campaign, and return changeTopic', async (t) => {
+// executeInboundTopicChange
+test('executeInboundTopicChange get topic, create signup if topic has campaign, and return changeTopic', async (t) => {
   const keyword = 'dragon';
   t.context.req.rivescriptReplyTopicId = stubs.getContentfulId();
   t.context.req.macro = stubs.getRandomWord();
-  t.context.req.rivescriptMatch = keyword;
   t.context.req.platform = stubs.getPlatform();
   sandbox.stub(requestHelper, 'changeTopic')
     .returns(Promise.resolve(true));
-  sandbox.stub(helpers.topic, 'getById')
-    .returns(Promise.resolve(topic));
   sandbox.stub(requestHelper, 'hasCampaign')
     .returns(true);
   sandbox.stub(helpers.user, 'fetchOrCreateSignup')
@@ -168,14 +165,13 @@ test('executeRivescriptTopicChange get topic, create signup if topic has campaig
   t.context.req.user = userFactory.getValidUser();
   t.context.req.conversation = conversation;
 
-  await requestHelper.executeRivescriptTopicChange(t.context.req);
+  await requestHelper.executeInboundTopicChange(t.context.req, topic, keyword);
 
-  helpers.topic.getById.should.have.been.calledWith(t.context.req.rivescriptReplyTopicId);
   helpers.user.fetchOrCreateSignup
     .should.have.been.calledWith(t.context.req.user, {
       campaignId: topic.campaign.id,
       source: t.context.req.platform,
-      details: `keyword/${keyword}`,
+      details: keyword,
     });
   requestHelper.changeTopic
     .should.have.been.calledWith(t.context.req, topic);

--- a/test/unit/lib/lib-helpers/rivescript.test.js
+++ b/test/unit/lib/lib-helpers/rivescript.test.js
@@ -321,7 +321,7 @@ test('parseRivescript calls replyRivescript with defaultTopicTrigger.reply if se
   result.should.equal(mockRivescript);
 });
 
-test('parseRivescript calls replyRivescript with getStartTemplateText if reply is not set', () => {
+test('parseRivescript calls replyRivescript with getTransitionTemplateText if reply is not set', () => {
   const trigger = stubs.getRandomWord();
   const startText = stubs.getRandomWord();
   const reply = stubs.getRandomMessageText();
@@ -331,7 +331,7 @@ test('parseRivescript calls replyRivescript with getStartTemplateText if reply i
     .returns(trigger);
   sandbox.stub(rivescriptHelper, 'formatReplyRivescript')
     .returns(reply);
-  sandbox.stub(helpers.topic, 'getStartTemplateText')
+  sandbox.stub(helpers.topic, 'getTransitionTemplateText')
     .returns(startText);
   sandbox.stub(rivescriptHelper, 'joinRivescriptLines')
     .returns(mockRivescript);

--- a/test/unit/lib/lib-helpers/topic.test.js
+++ b/test/unit/lib/lib-helpers/topic.test.js
@@ -13,6 +13,7 @@ const broadcastFactory = require('../../../helpers/factories/broadcast');
 const campaignFactory = require('../../../helpers/factories/campaign');
 const topicFactory = require('../../../helpers/factories/topic');
 const config = require('../../../../config/lib/helpers/topic');
+const templateConfig = require('../../../../config/lib/helpers/template');
 
 chai.should();
 chai.use(sinonChai);
@@ -175,8 +176,21 @@ test('getTopicTemplateText throws when template undefined', (t) => {
   t.throws(() => topicHelper.getTopicTemplateText(topic, templateName));
 });
 
+// getTransitionTemplateName
+test('getTransitionTemplateName returns transitionTemplate if defined in config.types ', () => {
+  const topic = topicFactory.getValidTextPostConfig();
+  const result = topicHelper.getTransitionTemplateName(topic);
+  result.should.equal(config.types.textPostConfig.transitionTemplate);
+});
+
+test('getTransitionTemplateName returns rivescript template if config.types undefined', () => {
+  const topic = { type: stubs.getRandomWord() };
+  const result = topicHelper.getTransitionTemplateName(topic);
+  result.should.equal(templateConfig.templatesMap.rivescriptReply);
+});
+
 // getTransitionTemplateText
-test('getTransitionTemplateText returns askText text for textPostConfig topics ', () => {
+test('getTransitionTemplateText returns askText text for textPostConfig topics', () => {
   const topic = topicFactory.getValidTextPostConfig();
   const result = topicHelper.getTransitionTemplateText(topic);
   result.should.equal(topic.templates.askText.text);

--- a/test/unit/lib/lib-helpers/topic.test.js
+++ b/test/unit/lib/lib-helpers/topic.test.js
@@ -175,27 +175,27 @@ test('getTopicTemplateText throws when template undefined', (t) => {
   t.throws(() => topicHelper.getTopicTemplateText(topic, templateName));
 });
 
-// getStartTemplateText
-test('getStartTemplateText returns askText text for textPostConfig topics ', () => {
+// getTransitionTemplateText
+test('getTransitionTemplateText returns askText text for textPostConfig topics ', () => {
   const topic = topicFactory.getValidTextPostConfig();
-  const result = topicHelper.getStartTemplateText(topic);
+  const result = topicHelper.getTransitionTemplateText(topic);
   result.should.equal(topic.templates.askText.text);
 });
 
-test('getStartTemplateText returns startExternalPost text for externalPostConfig topics ', () => {
+test('getTransitionTemplateText returns startExternalPost text for externalPostConfig topics ', () => {
   const topic = topicFactory.getValidExternalPostConfig();
-  const result = topicHelper.getStartTemplateText(topic);
+  const result = topicHelper.getTransitionTemplateText(topic);
   result.should.equal(topic.templates.startExternalPost.text);
 });
 
-test('getStartTemplateText returns startPhotoPost text for photoPostConfig topics ', () => {
+test('getTransitionTemplateText returns startPhotoPost text for photoPostConfig topics ', () => {
   const topic = topicFactory.getValidPhotoPostConfig();
-  const result = topicHelper.getStartTemplateText(topic);
+  const result = topicHelper.getTransitionTemplateText(topic);
   result.should.equal(topic.templates.startPhotoPost.text);
 });
 
-test('getStartTemplateText returns null if topic type not externalPostConfig, photoPostConfig, or textPostConfig', (t) => {
+test('getTransitionTemplateText returns null if topic type not externalPostConfig, photoPostConfig, or textPostConfig', (t) => {
   const topic = topicFactory.getValidAutoReply();
-  const result = topicHelper.getStartTemplateText(topic);
+  const result = topicHelper.getTransitionTemplateText(topic);
   t.is(result, null);
 });


### PR DESCRIPTION
#### What's this PR do?

Fixes bug introduced in #434 by adding `changeTopic` to the list of topic templates. The bug occurs when user's topic is set to random. If the next message from the user doesn't match any triggers, Gambit interprets the inbound message as continuing the current topic. Because the topic is random, Gambit finds whatever topic the user was in last, sets it, and posts the inbound message as campaign activity.  Example screen shot is below. 

* This PR adds a `getTransitionTemplateName` function to the topic helper to restore the original template names expected within conversation: `startPhotoPost`, `askText`, and now a new template `autoReplyTransition` -- removing the `changeTopic` template name completely. 

* Refactors `executeRivescriptTopicChange` request helper as `executeInboundTopicChange`, leaving TODO's about DRY in the `askYesNo` catchAll middleware

#### How should this be reviewed?

Can test campaign keywords, and test transition from TMI flow into random. Upon finishing the TMI flow, you should be asked to continue the last campaign you were in (or get a `noCampaign` reply if your conversation doesn't have a campaign Id set)

#### Any background context you want to provide?

Example of the bug:

<img width="808" alt="screen shot 2018-11-08 at 1 22 14 pm" src="https://user-images.githubusercontent.com/1236811/48228321-b8fd4280-e359-11e8-9a5f-e080cd12ed50.png">

#### Relevant tickets
#434 

#### Checklist
- [ ] Tests added/updated for new features/bug fixes.
- [x] Tested on staging.
