### PR TITLE
Cleanup askYesNo catchAll

### DIFF
--- a/lib/helpers/request.js
+++ b/lib/helpers/request.js
@@ -4,8 +4,6 @@ const helpers = require('../helpers');
 const gambitCampaigns = require('../gambit-campaigns');
 const logger = require('../logger');
 const analytics = require('./analytics');
-const UnprocessableEntityError = require('../../app/exceptions/UnprocessableEntityError');
-
 const config = require('../../config/lib/helpers/request');
 
 /**
@@ -66,61 +64,7 @@ async function executeInboundTopicChange(req, topic, signupDetails = null) {
       details: signupDetails,
     });
   }
-
   return module.exports.changeTopic(req, topic);
-}
-
-/**
- * Changes conversation topic to the saidNo template topic.
- * TODO: Deprecate this function by calling executeInboundTopicChange from the askYesNo catchall.
- *
- * @param {Object} req
- * @return {Promise}
- */
-async function executeSaidNoMacro(req, res) {
-  // Ideally we'd want to set req.broadcastId here to record a saidNo macro stat, but the trouble
-  // is then the next inbound message will have a req.broadcastId set because the last outbound
-  // had one, which feels like some logic we may be outgrowing soon.
-  const saidNoTemplate = req.topic.templates.saidNo;
-  // Although saidNoTopic is a required field, check that an id exists (it may not if this is a
-  // draft entry and we're using the Preview API.
-  if (!saidNoTemplate.topic.id) {
-    throw new UnprocessableEntityError('saidNo topic is undefined');
-  }
-
-  await module.exports.changeTopic(req, saidNoTemplate.topic);
-
-  return helpers.replies.saidNo(req, res, saidNoTemplate.text);
-}
-
-/**
- * Changes conversation topic to the saidYes template topic, and creates the saidYes topic contains
- * a campaign id.
- * TODO: Deprecate this function by calling executeInboundTopicChange from the askYesNo catchall.
- *
- * @param {Object} req
- * @return {Promise}
- */
-async function executeSaidYesMacro(req, res) {
-  const broadcastId = req.topic.id;
-  const saidYesTemplate = req.topic.templates.saidYes;
-  // Although saidYesTopic is a required field, check that an id exists (it may not if this is a
-  // draft entry and we're using the Preview API.
-  if (!saidYesTemplate.topic.id) {
-    throw new UnprocessableEntityError('saidYes topic is undefined');
-  }
-
-  if (helpers.topic.hasCampaign(saidYesTemplate.topic)) {
-    await helpers.user.fetchOrCreateSignup(req.user, {
-      campaignId: saidYesTemplate.topic.campaign.id,
-      source: req.platform,
-      details: `broadcast/${broadcastId}`,
-    });
-  }
-
-  await module.exports.changeTopic(req, saidYesTemplate.topic);
-
-  return helpers.replies.saidYes(req, res, saidYesTemplate.text);
 }
 
 /**
@@ -383,8 +327,6 @@ module.exports = {
   changeTopic,
   changeTopicByCampaign,
   executeInboundTopicChange,
-  executeSaidNoMacro,
-  executeSaidYesMacro,
   getCampaignActivityPayload,
   getRivescriptReply,
   getUserIdParamFromReq,

--- a/lib/middleware/messages/member/catchAll-askYesNo.js
+++ b/lib/middleware/messages/member/catchAll-askYesNo.js
@@ -34,7 +34,7 @@ module.exports = function catchAllAskYesNo() {
         }
         await helpers.request
           .executeInboundTopicChange(req, saidNoTemplate.topic, sourceDetails);
-        return helpers.replies.saidYes(req, res, saidNoTemplate.text);
+        return helpers.replies.saidNo(req, res, saidNoTemplate.text);
       }
 
       return helpers.replies.invalidAskYesNoResponse(req, res);

--- a/lib/middleware/messages/member/catchAll-askYesNo.js
+++ b/lib/middleware/messages/member/catchAll-askYesNo.js
@@ -2,6 +2,7 @@
 
 const helpers = require('../../../helpers');
 const logger = require('../../../logger');
+const UnprocessableEntityError = require('../../../../app/exceptions/UnprocessableEntityError');
 
 module.exports = function catchAllAskYesNo() {
   return async (req, res, next) => {
@@ -10,19 +11,32 @@ module.exports = function catchAllAskYesNo() {
         return next();
       }
 
-      logger.debug('parsing askYesNo response for topic', { topicId: req.topic.id });
+      const broadcastId = req.topic.id;
+      logger.debug('parsing askYesNo response for topic', { topicId: broadcastId });
+      const sourceDetails = `broadcast/${broadcastId}`;
+
       await helpers.request.parseAskYesNoResponse(req);
 
       if (helpers.request.isSaidYesMacro(req)) {
-        return helpers.request.executeSaidYesMacro(req, res);
+        const saidYesTemplate = req.topic.templates.saidYes;
+        if (!saidYesTemplate.topic.id) {
+          throw new UnprocessableEntityError('saidYes topic is undefined');
+        }
+        await helpers.request
+          .executeInboundTopicChange(req, saidYesTemplate.topic, sourceDetails);
+        return helpers.replies.saidYes(req, res, saidYesTemplate.text);
       }
 
       if (helpers.request.isSaidNoMacro(req)) {
-        return helpers.request.executeSaidNoMacro(req, res);
+        const saidNoTemplate = req.topic.templates.saidNo;
+        if (!saidNoTemplate.topic.id) {
+          throw new UnprocessableEntityError('saidNo topic is undefined');
+        }
+        await helpers.request
+          .executeInboundTopicChange(req, saidNoTemplate.topic, sourceDetails);
+        return helpers.replies.saidYes(req, res, saidNoTemplate.text);
       }
 
-      // If we're still in this topic and the inbound is neither a yes or no, re-prompt for another
-      // yes no response.
       return helpers.replies.invalidAskYesNoResponse(req, res);
     } catch (err) {
       return helpers.sendErrorResponse(res, err);

--- a/test/unit/lib/middleware/messages/member/catchAll-askYesNo.test.js
+++ b/test/unit/lib/middleware/messages/member/catchAll-askYesNo.test.js
@@ -87,7 +87,7 @@ test('askYesNoCatchAll should changeTopic and send saidYes template if askYesNo 
     .returns(Promise.resolve());
   sandbox.stub(helpers.request, 'isSaidYesMacro')
     .returns(true);
-  sandbox.stub(helpers.request, 'executeSaidYesMacro')
+  sandbox.stub(helpers.request, 'executeInboundTopicChange')
     .returns(Promise.resolve());
 
   // test
@@ -95,11 +95,13 @@ test('askYesNoCatchAll should changeTopic and send saidYes template if askYesNo 
 
   helpers.request.parseAskYesNoResponse.should.have.been.calledWith(t.context.req);
   next.should.not.have.been.called;
-  helpers.request.executeSaidYesMacro.should.have.been.calledWith(t.context.req);
+  const details = `broadcast/${askYesNoBroadcast.id}`;
+  helpers.request.executeInboundTopicChange
+    .should.have.been.calledWith(t.context.req, askYesNoBroadcast.templates.saidYes.topic, details);
   helpers.sendErrorResponse.should.not.been.called;
 });
 
-test('askYesNoCatchAll should call sendErrorResponse if request isSaidYesMacro but executeSaidYesMacro fails', async (t) => {
+test('askYesNoCatchAll should call sendErrorResponse if request isSaidYesMacro but executeInboundTopicChange fails', async (t) => {
   const next = sinon.stub();
   const middleware = askYesNoCatchAll();
   t.context.req.topic = askYesNoBroadcast;
@@ -107,10 +109,8 @@ test('askYesNoCatchAll should call sendErrorResponse if request isSaidYesMacro b
     .returns(Promise.resolve());
   sandbox.stub(helpers.request, 'isSaidYesMacro')
     .returns(true);
-  sandbox.stub(helpers.request, 'executeSaidYesMacro')
+  sandbox.stub(helpers.request, 'executeInboundTopicChange')
     .throws();
-  sandbox.stub(helpers.request, 'changeTopic')
-    .returns(Promise.resolve());
 
   // test
   await middleware(t.context.req, t.context.res, next);
@@ -131,15 +131,16 @@ test('askYesNoCatchAll should execute saidNo macro if askYesNo and request isSai
     .returns(false);
   sandbox.stub(helpers.request, 'isSaidNoMacro')
     .returns(true);
-  sandbox.stub(helpers.request, 'executeSaidNoMacro')
+  sandbox.stub(helpers.request, 'executeInboundTopicChange')
     .returns(Promise.resolve());
 
   // test
   await middleware(t.context.req, t.context.res, next);
 
   helpers.request.parseAskYesNoResponse.should.have.been.calledWith(t.context.req);
-  next.should.not.have.been.called;
-  helpers.request.executeSaidNoMacro.should.have.been.called;
+  const details = `broadcast/${askYesNoBroadcast.id}`;
+  helpers.request.executeInboundTopicChange
+    .should.have.been.calledWith(t.context.req, askYesNoBroadcast.templates.saidNo.topic, details);
   helpers.sendErrorResponse.should.not.been.called;
 });
 
@@ -153,10 +154,8 @@ test('askYesNoCatchAll should call sendErrorResponse if request isSaidNoMacro bu
     .returns(false);
   sandbox.stub(helpers.request, 'isSaidNoMacro')
     .returns(true);
-  sandbox.stub(helpers.request, 'executeSaidNoMacro')
+  sandbox.stub(helpers.request, 'executeInboundTopicChange')
     .throws();
-  sandbox.stub(helpers.request, 'changeTopic')
-    .returns(Promise.resolve());
 
   // test
   await middleware(t.context.req, t.context.res, next);
@@ -166,7 +165,6 @@ test('askYesNoCatchAll should call sendErrorResponse if request isSaidNoMacro bu
   helpers.replies.sendReply.should.not.have.been.called;
   helpers.sendErrorResponse.should.have.been.called;
 });
-
 
 test('askYesNoCatchAll should not changeTopic and send invalidAskYesNoResponse template if askYesNo and request is neither saidYes or saidNo macro', async (t) => {
   const next = sinon.stub();
@@ -178,7 +176,7 @@ test('askYesNoCatchAll should not changeTopic and send invalidAskYesNoResponse t
     .returns(false);
   sandbox.stub(helpers.request, 'isSaidNoMacro')
     .returns(false);
-  sandbox.stub(helpers.request, 'changeTopic')
+  sandbox.stub(helpers.request, 'executeInboundTopicChange')
     .returns(Promise.resolve());
 
   // test
@@ -186,7 +184,7 @@ test('askYesNoCatchAll should not changeTopic and send invalidAskYesNoResponse t
 
   helpers.request.parseAskYesNoResponse.should.have.been.calledWith(t.context.req);
   next.should.not.have.been.called;
-  helpers.request.changeTopic.should.not.have.been.called;
+  helpers.request.executeInboundTopicChange.should.not.have.been.called;
   helpers.replies.invalidAskYesNoResponse.should.have.been.called;
   helpers.sendErrorResponse.should.not.been.called;
 });


### PR DESCRIPTION
#### What's this PR do?

This PR completes TODOs from #436 to refactor the `catchAll-askYesNo` middleware to use the new `executeInboundTopicChange` request helper function to DRY.

#### How should this be reviewed?
Verify expected behavior for responding to an `askYesNo` -- upon topic change, a signup should be created if the new topic has a campaign and signup doesn't exist for user. e.g. [5q56wA4uJ2SoAi6uAS4uYK](https://gambit-admin-staging.herokuapp.com/broadcasts/5q56wA4uJ2SoAi6uAS4uYK)

#### Relevant tickets
#436 

#### Checklist
- [ ] Tests added/updated for new features/bug fixes.
- [ ] Tested on staging.
