### PR TITLE
Include run id when creating a Rogue signup

### DIFF
--- a/lib/helpers/request.js
+++ b/lib/helpers/request.js
@@ -60,6 +60,7 @@ async function executeInboundTopicChange(req, topic, signupDetails = null) {
   if (helpers.topic.hasCampaign(topic)) {
     await helpers.user.fetchOrCreateSignup(req.user, {
       campaignId: topic.campaign.id,
+      campaignRunId: topic.campaign.currentCampaignRun.id,
       source: req.platform,
       details: signupDetails,
     });

--- a/lib/helpers/user.js
+++ b/lib/helpers/user.js
@@ -19,6 +19,7 @@ async function createSignup(user, args) {
   const payload = {
     northstar_id: user.id,
     campaign_id: args.campaignId,
+    campaign_run_id: args.campaignRunId,
     source: args.source,
     details: args.details,
   };

--- a/test/helpers/factories/topic.js
+++ b/test/helpers/factories/topic.js
@@ -24,6 +24,9 @@ function getValidTopic(type = 'photoPostConfig', templates) {
     postType: stubs.getPostType(),
     campaign: {
       id: stubs.getCampaignId(),
+      currentCampaignRun: {
+        id: stubs.getCampaignRunId(),
+      },
     },
     templates,
   };

--- a/test/unit/lib/lib-helpers/request.test.js
+++ b/test/unit/lib/lib-helpers/request.test.js
@@ -168,6 +168,7 @@ test('executeInboundTopicChange get topic, create signup if topic has campaign, 
   helpers.user.fetchOrCreateSignup
     .should.have.been.calledWith(t.context.req.user, {
       campaignId: topic.campaign.id,
+      campaignRunId: topic.campaign.currentCampaignRun.id,
       source: t.context.req.platform,
       details: keyword,
     });

--- a/test/unit/lib/lib-helpers/user.test.js
+++ b/test/unit/lib/lib-helpers/user.test.js
@@ -29,8 +29,9 @@ const messageFactory = require('../../../helpers/factories/message');
 const userFactory = require('../../../helpers/factories/user');
 
 const campaignId = stubs.getCampaignId();
-const mockPost = { id: stubs.getCampaignRunId() };
-const mockSignup = { id: stubs.getCampaignRunId() };
+const campaignRunId = stubs.getCampaignRunId();
+const mockPost = { id: 890332 };
+const mockSignup = { id: 251696 };
 const mockUser = userFactory.getValidUser();
 const userLookupStub = () => Promise.resolve(mockUser);
 const platformUserAddressStub = {
@@ -50,15 +51,17 @@ test.afterEach((t) => {
 });
 
 // createSignup
-test('createSignup passes user.id, campaignId and source args to rogue.createSignup', async () => {
+test('createSignup passes user.id, campaignId, campaignRunId source args to rogue.createSignup', async () => {
   const signup = { id: campaignId, campaign_id: campaignId };
   const details = 'test';
   sandbox.stub(rogue, 'createSignup')
     .returns(Promise.resolve(signup));
 
-  const result = await userHelper.createSignup(mockUser, { campaignId, source, details });
+  const result = await userHelper
+    .createSignup(mockUser, { campaignId, campaignRunId, source, details });
   rogue.createSignup.should.have.been.calledWith({
     campaign_id: campaignId,
+    campaign_run_id: campaignRunId,
     northstar_id: mockUser.id,
     source,
     details,


### PR DESCRIPTION
#### What's this PR do?

Passes the `campaign_run_id` when creating a signup to avoid duplicate signups, fixing the bug found while testing https://github.com/DoSomething/gambit-conversations/pull/437#issuecomment-438285808. 

#### How should this be reviewed?

Signup for a campaign and complete a post, verify only one signup is created as expected.

#### Any background context you want to provide?
We aimed to stop sending the run id completely per https://www.pivotaltracker.com/story/show/161494958, but we're blocked by not having a campaign ID available that uniquely identifies the campaign, see [Slack thread](https://dosomething.slack.com/archives/C03T8SDJG/p1542131914032300?thread_ts=1542060436.007800&cid=C03T8SDJG)

#### Relevant tickets

* https://www.pivotaltracker.com/story/show/161494958
* https://github.com/DoSomething/gambit-campaigns/pull/1096

#### Checklist
- [x] Tests added/updated for new features/bug fixes.
- [x] Tested on staging.
