### PR TITLE
Send text posts to Rogue [pr]

### DIFF
--- a/app/routes/messages/member.js
+++ b/app/routes/messages/member.js
@@ -27,6 +27,7 @@ const catchAllAskVotingPlanStatusMiddleware = require('../../../lib/middleware/m
 const catchAllAskYesNoMiddleware = require('../../../lib/middleware/messages/member/catchAll-askYesNo');
 const catchAllAutoReplyMiddleware = require('../../../lib/middleware/messages/member/catchAll-autoReply');
 const catchAllDefaultMiddleware = require('../../../lib/middleware/messages/member/catchAll');
+const catchAllTextPostMiddleware = require('../../../lib/middleware/messages/member/catchAll-textPost');
 
 router.use(paramsMiddleware());
 
@@ -72,8 +73,11 @@ router.use(catchAllAskVotingPlanStatusMiddleware());
 // Handles replies for askYesNo topics.
 router.use(catchAllAskYesNoMiddleware());
 
-// Checks whether to send an autoReply template.
+// Handles autoReply topics.
 router.use(catchAllAutoReplyMiddleware());
+
+// Handles textPostConfig topics.
+router.use(catchAllTextPostMiddleware());
 
 // Determines whether to start or continue conversation for the current topic.
 router.use(catchAllDefaultMiddleware());

--- a/config/lib/helpers/user.js
+++ b/config/lib/helpers/user.js
@@ -50,6 +50,9 @@ const userFields = {
 module.exports = {
   fields: userFields,
   posts: {
+    text: {
+      type: 'text',
+    },
     votingPlan: {
       type: 'text',
       campaignId: process.env.DS_GAMBIT_CONVERSATIONS_VOTING_PLAN_CAMPAIGN_ID || 7077,

--- a/lib/helpers/replies.js
+++ b/lib/helpers/replies.js
@@ -119,6 +119,10 @@ module.exports.campaignClosed = function (req, res) {
   return exports.sendReplyWithTopicTemplate(req, res, 'campaignClosed');
 };
 
+module.exports.completedTextPost = function (req, res) {
+  return exports.sendReplyWithTopicTemplate(req, res, 'completedTextPost');
+};
+
 module.exports.confirmedContinue = function (req, res) {
   // TODO: Use this to include the "Picking up where you left off" prefix in the reply message.
   req.keyword = 'continue';
@@ -132,6 +136,10 @@ module.exports.declinedContinue = function (req, res) {
 
 module.exports.invalidAskContinueResponse = function (req, res) {
   return exports.sendReplyWithTopicTemplate(req, res, 'invalidAskContinueResponse');
+};
+
+module.exports.invalidText = function (req, res) {
+  return exports.sendReplyWithTopicTemplate(req, res, 'invalidText');
 };
 
 module.exports.invalidAskYesNoResponse = function (req, res) {

--- a/lib/helpers/topic.js
+++ b/lib/helpers/topic.js
@@ -168,6 +168,14 @@ function isRivescriptTopicId(topicId) {
 }
 
 /**
+ * @param {Object} topic
+ * @return {Boolean}
+ */
+function isTextPostConfig(topic) {
+  return topic.type === config.types.textPostConfig.type;
+}
+
+/**
  * @param {String} topicId
  * @return {Boolean}
  */
@@ -195,4 +203,5 @@ module.exports = {
   isBroadcastable,
   isDefaultTopicId,
   isRivescriptTopicId,
+  isTextPostConfig,
 };

--- a/lib/helpers/user.js
+++ b/lib/helpers/user.js
@@ -41,11 +41,10 @@ async function createTextPost(user, args) {
     campaign_run_id: args.campaignRunId,
     source: args.source,
     text: args.text,
-    type: 'text',
+    type: config.posts.text.type,
   };
   logger.debug('rogue.createPost post', { payload });
-  const post = await rogue.createPost(payload);
-  return post;
+  return rogue.createPost(payload);
 }
 
 /**

--- a/lib/helpers/user.js
+++ b/lib/helpers/user.js
@@ -31,6 +31,25 @@ async function createSignup(user, args) {
 
 /**
  * @param {Object} user
+ * @param {Object} args
+ * @return {Promise}
+ */
+async function createTextPost(user, args) {
+  const payload = {
+    northstar_id: user.id,
+    campaign_id: args.campaignId,
+    campaign_run_id: args.campaignRunId,
+    source: args.source,
+    text: args.text,
+    type: 'text',
+  };
+  logger.debug('rogue.createPost post', { payload });
+  const post = await rogue.createPost(payload);
+  return post;
+}
+
+/**
+ * @param {Object} user
  * @param {String} source
  * @return {Promise}
  */
@@ -170,6 +189,7 @@ async function updateByMemberMessageReq(req) {
 
 module.exports = {
   createSignup,
+  createTextPost,
   createVotingPlan,
   fetchOrCreateSignup,
   fetchOrCreateVotingPlan,

--- a/lib/helpers/util.js
+++ b/lib/helpers/util.js
@@ -29,10 +29,7 @@ function isValidTextPost(string) {
   if (!string) {
     return false;
   }
-  // TODO: I think we strip emoji because they break Rogue.
-  const result = string.length > 2 && module.exports.containsAlphanumeric(string);
-  logger.debug('isValidTextPost', { result });
-  return result;
+  return string.trim().length > 2 && /[a-zA-Z]/.test(string);
 }
 
 /**

--- a/lib/helpers/util.js
+++ b/lib/helpers/util.js
@@ -27,7 +27,7 @@ function containsAlphanumeric(string = '') {
  */
 function containsAtLeastOneLetter(string) {
   if (!string) {
-    return null;
+    return false;
   }
   return /[a-zA-Z]/.test(string);
 }

--- a/lib/helpers/util.js
+++ b/lib/helpers/util.js
@@ -22,6 +22,20 @@ function containsAlphanumeric(string = '') {
 }
 
 /**
+ * @param {Object} req
+ * @return {Boolean}
+ */
+function isValidTextPost(string) {
+  if (!string) {
+    return false;
+  }
+  // TODO: I think we strip emoji because they break Rogue.
+  const result = string.length > 2 && module.exports.containsAlphanumeric(string);
+  logger.debug('isValidTextPost', { result });
+  return result;
+}
+
+/**
  * @param {Object|Error}
  * @return {Object}
  */
@@ -45,6 +59,7 @@ function parseStatusAndMessageFromError(error = new InternalServerError()) {
 }
 
 module.exports = {
+  containsAlphanumeric,
   /**
    * deepUpdateWithDotNotationParser - Non-blocking recursive function to update documents with
    * nested objects in a way that mimics deep extending the object instead of replacing it.
@@ -102,6 +117,6 @@ module.exports = {
     logger.debug('formatMobileNumber return', { result });
     return result;
   },
-  containsAlphanumeric,
+  isValidTextPost,
   parseStatusAndMessageFromError,
 };

--- a/lib/helpers/util.js
+++ b/lib/helpers/util.js
@@ -18,7 +18,18 @@ function containsAlphanumeric(string = '') {
   if (!string) {
     return false;
   }
-  return /\d/.test(string) || /[a-zA-Z]/.test(string);
+  return /\d/.test(string) || module.exports.containsAtLeastOneLetter(string);
+}
+
+/**
+ * @param {String} string
+ * @return {Boolean}
+ */
+function containsAtLeastOneLetter(string) {
+  if (!string) {
+    return null;
+  }
+  return /[a-zA-Z]/.test(string);
 }
 
 /**
@@ -29,7 +40,7 @@ function isValidTextPost(string) {
   if (!string) {
     return false;
   }
-  return string.trim().length > 2 && /[a-zA-Z]/.test(string);
+  return string.trim().length > 2 && module.exports.containsAtLeastOneLetter(string);
 }
 
 /**
@@ -57,6 +68,7 @@ function parseStatusAndMessageFromError(error = new InternalServerError()) {
 
 module.exports = {
   containsAlphanumeric,
+  containsAtLeastOneLetter,
   /**
    * deepUpdateWithDotNotationParser - Non-blocking recursive function to update documents with
    * nested objects in a way that mimics deep extending the object instead of replacing it.

--- a/lib/middleware/messages/member/catchAll-textPost.js
+++ b/lib/middleware/messages/member/catchAll-textPost.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const helpers = require('../../../helpers');
+const logger = require('../../../logger');
+
+module.exports = function catchAllTextPost() {
+  return async (req, res, next) => {
+    try {
+      if (!helpers.topic.isTextPostConfig(req.topic)) {
+        return next();
+      }
+
+      if (!helpers.util.isValidTextPost(req.inboundMessageText)) {
+        return helpers.replies.invalidText(req, res);
+      }
+
+      const campaign = req.topic.campaign;
+      const createPostRes = await helpers.user.createTextPost(req.user, {
+        campaignId: campaign.id,
+        campaignRunId: campaign.currentCampaignRun.id,
+        text: req.inboundMessageText,
+        source: req.platform,
+      });
+      logger.debug('created post', { id: createPostRes.data.id }, req);
+
+      return helpers.replies.completedTextPost(req, res);
+    } catch (err) {
+      return helpers.sendErrorResponse(res, err);
+    }
+  };
+};

--- a/lib/middleware/messages/member/catchAll-textPost.js
+++ b/lib/middleware/messages/member/catchAll-textPost.js
@@ -23,7 +23,7 @@ module.exports = function catchAllTextPost() {
       });
       logger.debug('created post', { id: createPostRes.data.id }, req);
 
-      return helpers.replies.completedTextPost(req, res);
+      return await helpers.replies.completedTextPost(req, res);
     } catch (err) {
       return helpers.sendErrorResponse(res, err);
     }

--- a/test/unit/lib/lib-helpers/replies.test.js
+++ b/test/unit/lib/lib-helpers/replies.test.js
@@ -237,6 +237,11 @@ test('campaignClosed(): should call sendReplyWithTopicTemplate', async (t) => {
   await assertSendingReplyWithTopicTemplate(t.context.req, t.context.res, template);
 });
 
+test('completedTextPost(): should call sendReplyWithTopicTemplate', async (t) => {
+  const template = templates.topicTemplates.completedTextPost;
+  await assertSendingReplyWithTopicTemplate(t.context.req, t.context.res, template);
+});
+
 test('confirmedContinue(): should call continueTopic', async (t) => {
   sandbox.stub(repliesHelper, 'continueTopic')
     .returns(resolvedPromise);
@@ -259,6 +264,11 @@ test('invalidAskYesNoResponse(): should call sendReplyWithTopicTemplate', async 
 
 test('invalidAskContinueResponse(): should call sendReplyWithTopicTemplate', async (t) => {
   const template = templates.askContinueTemplates.invalidAskContinueResponse;
+  await assertSendingReplyWithTopicTemplate(t.context.req, t.context.res, template);
+});
+
+test('invalidText(): should call sendReplyWithTopicTemplate', async (t) => {
+  const template = templates.topicTemplates.invalidText;
   await assertSendingReplyWithTopicTemplate(t.context.req, t.context.res, template);
 });
 

--- a/test/unit/lib/lib-helpers/topic.test.js
+++ b/test/unit/lib/lib-helpers/topic.test.js
@@ -162,6 +162,12 @@ test('isDefaultTopicId should return whether topicId is config.defaultTopicId', 
   t.falsy(topicHelper.isDefaultTopicId(stubs.getContentfulId()));
 });
 
+// isTextPostConfig
+test('isTextPostConfig returns whether topic type is textPostConfig', (t) => {
+  t.truthy(topicHelper.isTextPostConfig(topicFactory.getValidTextPostConfig()));
+  t.falsy(topicHelper.isTextPostConfig(topicFactory.getValidAutoReply()));
+});
+
 // getTopicTemplateText
 test('getTopicTemplateText returns a string when template exists', () => {
   const topic = topicFactory.getValidPhotoPostConfig();

--- a/test/unit/lib/lib-helpers/user.test.js
+++ b/test/unit/lib/lib-helpers/user.test.js
@@ -69,6 +69,23 @@ test('createSignup passes user.id, campaignId, campaignRunId source args to rogu
   result.should.deep.equal(signup);
 });
 
+// createTextPost
+test('createTextPost passes user.id, campaignId, campaignRunId, source, and text args to rogue.createSignup', async () => {
+  const text = 'test';
+
+  const result = await userHelper
+    .createTextPost(mockUser, { campaignId, campaignRunId, source, text });
+  rogue.createPost.should.have.been.calledWith({
+    campaign_id: campaignId,
+    campaign_run_id: campaignRunId,
+    northstar_id: mockUser.id,
+    source,
+    text,
+    type: config.posts.text.type,
+  });
+  result.should.deep.equal(mockPost);
+});
+
 // createVotingPlan
 test('createVotingPlan passes user voting plan info to rogue.createPost', async () => {
   const mockValues = { test: stubs.getRandomWord() };

--- a/test/unit/lib/lib-helpers/util.test.js
+++ b/test/unit/lib/lib-helpers/util.test.js
@@ -78,6 +78,16 @@ test('containsAlphanumeric should return when alphanumeric, false if not', (t) =
   t.falsy(utilHelper.containsAlphanumeric(null));
 });
 
+test('isValidTextPost should return true if trimmed string arg has letters and length greater than 2', (t) => {
+  t.truthy(utilHelper.isValidTextPost('Hey'));
+  t.falsy(utilHelper.isValidTextPost('😎 😎'));
+  t.truthy(utilHelper.isValidTextPost('This is neat 😎 😎'));
+  t.falsy(utilHelper.isValidTextPost('12342342'));
+  t.truthy(utilHelper.isValidTextPost('Totally cool 12342342'));
+  t.falsy(utilHelper.containsAlphanumeric('  '));
+  t.falsy(utilHelper.containsAlphanumeric(null));
+});
+
 // parseStatusAndMessageFromError
 test('parseStatusAndMessageFromError(anyString): should respond with error status 500 and anyString\'s value as message', () => {
   const errorString = 'omgError';

--- a/test/unit/lib/lib-helpers/util.test.js
+++ b/test/unit/lib/lib-helpers/util.test.js
@@ -78,13 +78,21 @@ test('containsAlphanumeric should return when alphanumeric, false if not', (t) =
   t.falsy(utilHelper.containsAlphanumeric(null));
 });
 
+// containsAtLeastOneLetter
+test('containsAtLeastOneLetter should return true when string has at least one letter', (t) => {
+  t.truthy(utilHelper.containsAtLeastOneLetter('Hey'));
+  t.falsy(utilHelper.containsAtLeastOneLetter('😎 😎'));
+  t.truthy(utilHelper.containsAtLeastOneLetter('This is neat 😎 😎'));
+  t.falsy(utilHelper.containsAtLeastOneLetter('1'));
+  t.falsy(utilHelper.containsAtLeastOneLetter('  '));
+  t.falsy(utilHelper.containsAtLeastOneLetter(null));
+});
+
 // isValidTextPost
 test('isValidTextPost should return true if trimmed string arg has letters and length greater than 2', (t) => {
-  t.truthy(utilHelper.isValidTextPost('Music'));
-  t.falsy(utilHelper.isValidTextPost('😎 😎'));
-  t.truthy(utilHelper.isValidTextPost('I luv music 😎 😎'));
-  t.falsy(utilHelper.isValidTextPost('12342342'));
-  t.truthy(utilHelper.isValidTextPost('Totally cool 12342342'));
+  t.truthy(utilHelper.isValidTextPost('1 a'));
+  t.falsy(utilHelper.isValidTextPost('a'));
+  t.falsy(utilHelper.isValidTextPost('1231231'));
 });
 
 // parseStatusAndMessageFromError

--- a/test/unit/lib/lib-helpers/util.test.js
+++ b/test/unit/lib/lib-helpers/util.test.js
@@ -78,14 +78,13 @@ test('containsAlphanumeric should return when alphanumeric, false if not', (t) =
   t.falsy(utilHelper.containsAlphanumeric(null));
 });
 
+// isValidTextPost
 test('isValidTextPost should return true if trimmed string arg has letters and length greater than 2', (t) => {
-  t.truthy(utilHelper.isValidTextPost('Hey'));
+  t.truthy(utilHelper.isValidTextPost('Music'));
   t.falsy(utilHelper.isValidTextPost('😎 😎'));
-  t.truthy(utilHelper.isValidTextPost('This is neat 😎 😎'));
+  t.truthy(utilHelper.isValidTextPost('I luv music 😎 😎'));
   t.falsy(utilHelper.isValidTextPost('12342342'));
   t.truthy(utilHelper.isValidTextPost('Totally cool 12342342'));
-  t.falsy(utilHelper.containsAlphanumeric('  '));
-  t.falsy(utilHelper.containsAlphanumeric(null));
 });
 
 // parseStatusAndMessageFromError

--- a/test/unit/lib/middleware/messages/member/catchAll-autoReply.test.js
+++ b/test/unit/lib/middleware/messages/member/catchAll-autoReply.test.js
@@ -32,7 +32,7 @@ test.afterEach((t) => {
   t.context = {};
 });
 
-test('autoReplyCatchAll should call replies.autoReply if topic.isAutoReply is false', async (t) => {
+test('autoReplyCatchAll should call next if topic.isAutoReply is false', async (t) => {
   const next = sinon.stub();
   const middleware = autoReplyCatchAll();
   t.context.req.topic = topicFactory.getValidTextPostConfig();

--- a/test/unit/lib/middleware/messages/member/catchAll-textPost.test.js
+++ b/test/unit/lib/middleware/messages/member/catchAll-textPost.test.js
@@ -40,7 +40,7 @@ test.afterEach((t) => {
   t.context = {};
 });
 
-test('textPostCatchAll should call next if topic.isAutoReply is false', async (t) => {
+test('textPostCatchAll should call next if topic.isTextPostConfig is false', async (t) => {
   const next = sinon.stub();
   const middleware = textPostCatchAll();
   sandbox.stub(helpers.topic, 'isTextPostConfig')

--- a/test/unit/lib/middleware/messages/member/catchAll-textPost.test.js
+++ b/test/unit/lib/middleware/messages/member/catchAll-textPost.test.js
@@ -108,3 +108,24 @@ test('textPostCatchAll should send create text post and completedTextPost reply 
   helpers.replies.invalidText.should.not.have.been.called;
   helpers.replies.completedTextPost.should.have.been.calledWith(t.context.req, t.context.res);
 });
+
+test('textPostCatchAll should send error response post if completedTextPost reply fails', async (t) => {
+  const next = sinon.stub();
+  const middleware = textPostCatchAll();
+  const error = { message: 'Epic fail' };
+  sandbox.stub(helpers.topic, 'isTextPostConfig')
+    .returns(true);
+  sandbox.stub(helpers.util, 'isValidTextPost')
+    .returns(true);
+  sandbox.stub(helpers.replies, 'invalidText')
+    .returns(underscore.noop);
+  sandbox.stub(helpers.user, 'createTextPost')
+    .returns(Promise.resolve({ data: mockPost }));
+  sandbox.stub(helpers.replies, 'completedTextPost')
+    .returns(Promise.reject(error));
+
+  // test
+  await middleware(t.context.req, t.context.res, next);
+
+  helpers.sendErrorResponse.should.have.been.calledWith(t.context.res, error);
+});

--- a/test/unit/lib/middleware/messages/member/catchAll-textPost.test.js
+++ b/test/unit/lib/middleware/messages/member/catchAll-textPost.test.js
@@ -1,0 +1,110 @@
+'use strict';
+
+require('dotenv').config();
+
+const test = require('ava');
+const chai = require('chai');
+const sinon = require('sinon');
+const sinonChai = require('sinon-chai');
+const httpMocks = require('node-mocks-http');
+const underscore = require('underscore');
+
+const helpers = require('../../../../../../lib/helpers');
+const stubs = require('../../../../../helpers/stubs');
+const topicFactory = require('../../../../../helpers/factories/topic');
+const userFactory = require('../../../../../helpers/factories/user');
+
+const mockPost = { id: 23121 };
+
+chai.should();
+chai.use(sinonChai);
+
+// module to be tested
+const textPostCatchAll = require('../../../../../../lib/middleware/messages/member/catchAll-textPost');
+
+const sandbox = sinon.sandbox.create();
+
+test.beforeEach((t) => {
+  sandbox.stub(helpers, 'sendErrorResponse')
+    .returns(underscore.noop);
+  t.context.req = httpMocks.createRequest();
+  t.context.res = httpMocks.createResponse();
+  t.context.req.topic = topicFactory.getValidTextPostConfig();
+  t.context.req.user = userFactory.getValidUser();
+  t.context.req.inboundMessageText = stubs.getRandomMessageText();
+  t.context.req.platform = stubs.getPlatform();
+});
+
+test.afterEach((t) => {
+  sandbox.restore();
+  t.context = {};
+});
+
+test('textPostCatchAll should call next if topic.isAutoReply is false', async (t) => {
+  const next = sinon.stub();
+  const middleware = textPostCatchAll();
+  sandbox.stub(helpers.topic, 'isTextPostConfig')
+    .returns(false);
+  sandbox.stub(helpers.replies, 'invalidText')
+    .returns(underscore.noop);
+  sandbox.stub(helpers.replies, 'completedTextPost')
+    .returns(underscore.noop);
+
+  // test
+  await middleware(t.context.req, t.context.res, next);
+
+  helpers.topic.isTextPostConfig.should.have.been.calledWith(t.context.req.topic);
+  next.should.have.been.called;
+  helpers.replies.invalidText.should.not.have.been.called;
+  helpers.replies.completedTextPost.should.not.have.been.called;
+});
+
+test('textPostCatchAll should send invalidText reply if inboundMessageText is not valid text post', async (t) => {
+  const next = sinon.stub();
+  const middleware = textPostCatchAll();
+  sandbox.stub(helpers.topic, 'isTextPostConfig')
+    .returns(true);
+  sandbox.stub(helpers.util, 'isValidTextPost')
+    .returns(false);
+  sandbox.stub(helpers.replies, 'invalidText')
+    .returns(underscore.noop);
+  sandbox.stub(helpers.replies, 'completedTextPost')
+    .returns(underscore.noop);
+
+  // test
+  await middleware(t.context.req, t.context.res, next);
+
+  helpers.topic.isTextPostConfig.should.have.been.calledWith(t.context.req.topic);
+  next.should.not.have.been.called;
+  helpers.replies.invalidText.should.have.been.calledWith(t.context.req, t.context.res);
+  helpers.replies.completedTextPost.should.not.have.been.called;
+});
+
+test('textPostCatchAll should send create text post and completedTextPost reply if inboundMessageText is valid text post', async (t) => {
+  const next = sinon.stub();
+  const middleware = textPostCatchAll();
+  sandbox.stub(helpers.topic, 'isTextPostConfig')
+    .returns(true);
+  sandbox.stub(helpers.util, 'isValidTextPost')
+    .returns(true);
+  sandbox.stub(helpers.replies, 'invalidText')
+    .returns(underscore.noop);
+  sandbox.stub(helpers.user, 'createTextPost')
+    .returns(Promise.resolve({ data: mockPost }));
+  sandbox.stub(helpers.replies, 'completedTextPost')
+    .returns(underscore.noop);
+
+  // test
+  await middleware(t.context.req, t.context.res, next);
+
+  helpers.topic.isTextPostConfig.should.have.been.calledWith(t.context.req.topic);
+  next.should.not.have.been.called;
+  helpers.user.createTextPost.should.have.been.calledWith(t.context.req.user, {
+    campaignId: t.context.req.topic.campaign.id,
+    campaignRunId: t.context.req.topic.campaign.currentCampaignRun.id,
+    source: t.context.req.platform,
+    text: t.context.req.inboundMessageText,
+  });
+  helpers.replies.invalidText.should.not.have.been.called;
+  helpers.replies.completedTextPost.should.have.been.calledWith(t.context.req, t.context.res);
+});


### PR DESCRIPTION
#### What's this PR do?

Now that this app is executing create signup and voting plan post requests to Rogue, this PR moves handling text posts into this repo -- deprecating the [text post middleware in the Gambit Campaigns `POST /campaignActivity` route](https://github.com/DoSomething/gambit-campaigns/tree/5.15.1/lib/middleware/campaignActivity/text), and taking a step towards deprecating the route entirely, in favor of a single Gambit app integrating with Rogue.

#### How should this be reviewed?

Text `poll` to verify expected text post behavior. Can test locally with gambit-campaigns to verify the `POST /campaignActivity` resource is not requested while in a textPostConfig topic.

#### Any background context you want to provide?

Having a single app integrate with Rogue instead of two will help make big changes like excluding run id's (see #439), but there's still one last post type Gambit Campaigns will handle for now,  `photoPostConfig` topics. The `externalPostConfig` topics will soon be deprecated when all triggers that reference them are backfilled with new `autoReply` topics.

#### Relevant tickets

* https://www.pivotaltracker.com/story/show/161494958

#### Checklist
- [x] Tests added/updated for new features/bug fixes.
- [x] Tested on staging.

