### PR TITLE
Fix keywords for closed campaigns [pr]

### DIFF
--- a/config/lib/helpers/replies.js
+++ b/config/lib/helpers/replies.js
@@ -6,6 +6,8 @@ const commands = {
   stop: 'STOP',
 };
 
+const supportText = `Text ${commands.support} if you have a question.`;
+
 module.exports = {
   badWords: {
     name: 'badWords',
@@ -13,11 +15,11 @@ module.exports = {
   },
   campaignClosed: {
     name: 'campaignClosed',
-    text: process.env.GAMBIT_CONVERSATIONS_CAMPAIGN_CLOSED_TEXT || 'Sorry, {{topic.campaign.title}} is no longer available.',
+    text: process.env.GAMBIT_CONVERSATIONS_CAMPAIGN_CLOSED_TEXT || `Sorry, {{topic.campaign.title}} is no longer available. ${supportText}`,
   },
   noCampaign: {
     name: 'noCampaign',
-    text: `Sorry, I'm not sure how to respond to that.\n\nText ${commands.support} if you have a question.`,
+    text: `Sorry, I'm not sure how to respond to that.\n\n${supportText}`,
   },
   noReply: {
     name: 'noReply',

--- a/config/lib/helpers/replies.js
+++ b/config/lib/helpers/replies.js
@@ -1,0 +1,8 @@
+'use strict';
+
+module.exports = {
+  campaignClosed: {
+    name: 'campaignClosed',
+    text: process.env.GAMBIT_CONVERSATIONS_CAMPAIGN_CLOSED_TEXT || 'Sorry, {{topic.campaign.title}} is no longer available.',
+  },
+};

--- a/config/lib/helpers/replies.js
+++ b/config/lib/helpers/replies.js
@@ -1,8 +1,26 @@
 'use strict';
 
+const commands = {
+  less: 'LESS',
+  support: 'Q',
+  stop: 'STOP',
+};
+
 module.exports = {
+  badWords: {
+    name: 'badWords',
+    text: `Not cool. I'm a real person & that offends me. I send out these texts to help young ppl take action. If you don't want my texts, text ${commands.stop} or ${commands.less} to get less.`,
+  },
   campaignClosed: {
     name: 'campaignClosed',
     text: process.env.GAMBIT_CONVERSATIONS_CAMPAIGN_CLOSED_TEXT || 'Sorry, {{topic.campaign.title}} is no longer available.',
+  },
+  noCampaign: {
+    name: 'noCampaign',
+    text: `Sorry, I'm not sure how to respond to that.\n\nText ${commands.support} if you have a question.`,
+  },
+  noReply: {
+    name: 'noReply',
+    text: '',
   },
 };

--- a/config/lib/helpers/template.js
+++ b/config/lib/helpers/template.js
@@ -2,8 +2,6 @@
 
 const underscore = require('underscore');
 
-const supportCommand = 'Q';
-
 const templatesMap = {
   campaignClosed: 'campaignClosed',
   declinedSignup: 'declinedSignup',
@@ -52,16 +50,7 @@ const templatesMap = {
   },
   // TODO: Move these into the replies helper config, or set on config via middleware that checks
   // for each condition.
-  gambitConversationsTemplates: {
-    badWords: {
-      name: 'badWords',
-      text: 'Not cool. I\'m a real person & that offends me. I send out these texts to help young ppl take action. If you don\'t want my texts, text STOP or LESS to get less.',
-    },
-    noCampaign: {
-      name: 'noCampaign',
-      text: `Sorry, I'm not sure how to respond to that.\n\nText ${supportCommand} if you have a question.`,
-    },
-  },
+  gambitConversationsTemplates: {},
 };
 
 module.exports = {

--- a/config/lib/helpers/template.js
+++ b/config/lib/helpers/template.js
@@ -48,20 +48,10 @@ const templatesMap = {
     votingPlanStatusVoted: 'votingPlanStatusVoted',
     webSignup: 'webSignup',
   },
-  // TODO: Move these into the replies helper config, or set on config via middleware that checks
-  // for each condition.
-  gambitConversationsTemplates: {},
 };
 
 module.exports = {
   templatesMap,
-
-  /**
-   * Example structure of this property
-   * { badWords: 'Not cool... text STOP or LESS to get less.', }
-   */
-  conversationsTemplatesText: underscore.mapObject(
-    templatesMap.gambitConversationsTemplates, val => val.text),
   askContinueTemplates: underscore.values(templatesMap.askContinueTemplates),
   askSignupTemplates: underscore.values(templatesMap.askSignupTemplates),
   gambitConversationsTemplates: underscore.pluck(underscore.values(templatesMap.gambitConversationsTemplates), 'name'),

--- a/config/lib/helpers/template.js
+++ b/config/lib/helpers/template.js
@@ -54,6 +54,5 @@ module.exports = {
   templatesMap,
   askContinueTemplates: underscore.values(templatesMap.askContinueTemplates),
   askSignupTemplates: underscore.values(templatesMap.askSignupTemplates),
-  gambitConversationsTemplates: underscore.pluck(underscore.values(templatesMap.gambitConversationsTemplates), 'name'),
   topicTemplates: underscore.values(templatesMap.topicTemplates),
 };

--- a/lib/helpers/replies.js
+++ b/lib/helpers/replies.js
@@ -4,27 +4,11 @@ const helpers = require('../helpers');
 const logger = require('../logger');
 const config = require('../../config/lib/helpers/replies');
 
-/**
- * @param {Object} req
- * @param {Object} res
- * @return {Promise}
- */
-function campaignClosed(req, res) {
-  const template = module.exports.getCampaignClosed();
-  return module.exports.sendReply(req, res, template.text, template.name);
-}
 
 /**
  * @return {Object}
  */
-function getCampaignClosed() {
-  return config.campaignClosed;
-}
-
-module.exports = {
-  campaignClosed,
-  getCampaignClosed,
-};
+module.exports.templates = config;
 
 /**
  * Creates and sends outbound-reply Message with given messageText and messageTemplate.
@@ -112,6 +96,11 @@ module.exports.autoReply = function (req, res) {
   return exports.sendReplyWithTopicTemplate(req, res, 'autoReply');
 };
 
+module.exports.campaignClosed = function (req, res) {
+  const template = config.campaignClosed;
+  return module.exports.sendReply(req, res, template.text, template.name);
+};
+
 module.exports.completedTextPost = function (req, res) {
   return exports.sendReplyWithTopicTemplate(req, res, 'completedTextPost');
 };
@@ -136,22 +125,23 @@ module.exports.saidYes = function (req, res, messageText) {
   return exports.sendReply(req, res, messageText, 'saidYes');
 };
 
-// TODO: Rename and refactor this. Deprecate the template lib and define the message text for these
-// non-macro non-topic static messages to live in a new replies config.
-module.exports.sendGambitConversationsTemplate = function (req, res, template) {
-  logger.debug('sendGambitConversationsTemplate', { template });
-  const text = helpers.template.getTextForTemplate(template);
-  return exports.sendReply(req, res, text, template);
+module.exports.sendReplyWithStaticTemplate = function (req, res, templateName) {
+  const text = config[templateName].text;
+  return exports.sendReply(req, res, text, templateName);
 };
 
 module.exports.badWords = function (req, res) {
-  return exports.sendGambitConversationsTemplate(req, res, 'badWords');
+  return exports.sendReplyWithStaticTemplate(req, res, 'badWords');
+};
+
+module.exports.campaignClosed = function (req, res) {
+  return exports.sendReplyWithStaticTemplate(req, res, 'campaignClosed');
 };
 
 module.exports.noCampaign = function (req, res) {
-  return exports.sendGambitConversationsTemplate(req, res, 'noCampaign');
+  return exports.sendReplyWithStaticTemplate(req, res, 'noCampaign');
 };
 
 module.exports.noReply = function (req, res) {
-  return exports.sendReply(req, res, '', 'noReply');
+  return exports.sendReplyWithStaticTemplate(req, res, 'noReply');
 };

--- a/lib/helpers/replies.js
+++ b/lib/helpers/replies.js
@@ -4,7 +4,6 @@ const helpers = require('../helpers');
 const logger = require('../logger');
 const config = require('../../config/lib/helpers/replies');
 
-
 /**
  * @return {Object}
  */
@@ -94,11 +93,6 @@ module.exports.sendReplyWithTopicTemplate = function (req, res, messageTemplate)
 
 module.exports.autoReply = function (req, res) {
   return exports.sendReplyWithTopicTemplate(req, res, 'autoReply');
-};
-
-module.exports.campaignClosed = function (req, res) {
-  const template = config.campaignClosed;
-  return module.exports.sendReply(req, res, template.text, template.name);
 };
 
 module.exports.completedTextPost = function (req, res) {

--- a/lib/helpers/replies.js
+++ b/lib/helpers/replies.js
@@ -2,6 +2,29 @@
 
 const helpers = require('../helpers');
 const logger = require('../logger');
+const config = require('../../config/lib/helpers/replies');
+
+/**
+ * @param {Object} req
+ * @param {Object} res
+ * @return {Promise}
+ */
+function campaignClosed(req, res) {
+  const template = module.exports.getCampaignClosed();
+  return module.exports.sendReply(req, res, template.text, template.name);
+}
+
+/**
+ * @return {Object}
+ */
+function getCampaignClosed() {
+  return config.campaignClosed;
+}
+
+module.exports = {
+  campaignClosed,
+  getCampaignClosed,
+};
 
 /**
  * Creates and sends outbound-reply Message with given messageText and messageTemplate.
@@ -87,10 +110,6 @@ module.exports.sendReplyWithTopicTemplate = function (req, res, messageTemplate)
 
 module.exports.autoReply = function (req, res) {
   return exports.sendReplyWithTopicTemplate(req, res, 'autoReply');
-};
-
-module.exports.campaignClosed = function (req, res) {
-  return exports.sendReplyWithTopicTemplate(req, res, 'campaignClosed');
 };
 
 module.exports.completedTextPost = function (req, res) {

--- a/lib/helpers/request.js
+++ b/lib/helpers/request.js
@@ -34,8 +34,7 @@ function changeTopic(req, topic) {
  * @return {Promise}
  */
 async function executeInboundTopicChange(req, topic, signupDetails = null) {
-  // An inbound topic change should create a signup if campaign topic.
-  if (helpers.topic.hasCampaign(topic)) {
+  if (helpers.topic.hasActiveCampaign(topic)) {
     await helpers.user.fetchOrCreateSignup(req.user, {
       campaignId: topic.campaign.id,
       campaignRunId: topic.campaign.currentCampaignRun.id,

--- a/lib/helpers/rivescript.js
+++ b/lib/helpers/rivescript.js
@@ -118,7 +118,7 @@ function parseRivescript(defaultTopicTrigger) {
     replyText = helpers.topic.getTransitionTemplateText(topic);
   }
 
-  if (topicId && helpers.topic.hasCampaign(topic) && !helpers.topic.hasActiveCampaign(topic)) {
+  if (topicId && helpers.topic.hasClosedCampaign(topic)) {
     replyText = helpers.replies.templates.campaignClosed.text;
   }
 

--- a/lib/helpers/rivescript.js
+++ b/lib/helpers/rivescript.js
@@ -110,7 +110,7 @@ function parseRivescript(defaultTopicTrigger) {
    * @see https://www.rivescript.com/docs/tutorial#topics
    */
   const topic = defaultTopicTrigger.topic;
-  let topicId = topic && topic.id ? topic.id : null;
+  const topicId = topic && topic.id ? topic.id : null;
 
   // Triggers that directly reference a topic entry won't have a reply set.
   // TODO: Remove this logic once they are updated to reference transition entries instead.
@@ -118,11 +118,8 @@ function parseRivescript(defaultTopicTrigger) {
     replyText = helpers.topic.getTransitionTemplateText(topic);
   }
 
-  const hasCampaign = topicId && topic.campaign && topic.campaign.id;
-  if (hasCampaign && helpers.campaign.isClosedCampaign(topic.campaign)) {
-    replyText = helpers.replies.getCampaignClosed().text;
-    // We don't want to change a topic with a closed campaign (it would trigger a signup).
-    topicId = null;
+  if (topicId && helpers.topic.hasCampaign(topic) && !helpers.topic.hasActiveCampaign(topic)) {
+    replyText = helpers.replies.templates.campaignClosed.text;
   }
 
   /**

--- a/lib/helpers/rivescript.js
+++ b/lib/helpers/rivescript.js
@@ -110,12 +110,19 @@ function parseRivescript(defaultTopicTrigger) {
    * @see https://www.rivescript.com/docs/tutorial#topics
    */
   const topic = defaultTopicTrigger.topic;
-  const topicId = topic && topic.id ? topic.id : null;
+  let topicId = topic && topic.id ? topic.id : null;
 
   // Triggers that directly reference a topic entry won't have a reply set.
   // TODO: Remove this logic once they are updated to reference transition entries instead.
   if (!replyText && topicId) {
     replyText = helpers.topic.getTransitionTemplateText(topic);
+  }
+
+  const hasCampaign = topicId && topic.campaign && topic.campaign.id;
+  if (hasCampaign && helpers.campaign.isClosedCampaign(topic.campaign)) {
+    replyText = helpers.replies.getCampaignClosed().text;
+    // We don't want to change a topic with a closed campaign (it would trigger a signup).
+    topicId = null;
   }
 
   /**

--- a/lib/helpers/tags.js
+++ b/lib/helpers/tags.js
@@ -61,6 +61,7 @@ function getTags(req) {
   return {
     broadcast: module.exports.getBroadcastTag(req),
     links: module.exports.getLinksTag(req),
+    topic: req.topic ? req.topic : {},
     user: req.user ? module.exports.getUserTag(req.user) : {},
   };
 }

--- a/lib/helpers/template.js
+++ b/lib/helpers/template.js
@@ -22,9 +22,6 @@ function isTopicTemplate(templateName) {
 
 module.exports = {
   getSubscriptionStatusActive,
-  getTextForTemplate: function getTextForTemplate(templateName) {
-    return config.conversationsTemplatesText[templateName];
-  },
   isAskContinueTemplate: function isAskContinueTemplate(templateName) {
     return config.askContinueTemplates.includes(templateName);
   },

--- a/lib/helpers/topic.js
+++ b/lib/helpers/topic.js
@@ -109,6 +109,14 @@ function getTransitionTemplateName(topic) {
  * @param {Object} topic
  * @return {Boolean}
  */
+function hasActiveCampaign(topic) {
+  return module.exports.hasCampaign(topic) && !helpers.campaign.isClosedCampaign(topic.campaign);
+}
+
+/**
+ * @param {Object} topic
+ * @return {Boolean}
+ */
 function hasCampaign(topic) {
   return topic.campaign && topic.campaign.id;
 }
@@ -197,6 +205,7 @@ module.exports = {
   getTransitionTemplateText,
   getRivescriptTopicById,
   getSupportTopic,
+  hasActiveCampaign,
   hasCampaign,
   isAskSubscriptionStatus,
   isAskVotingPlanStatus,

--- a/lib/helpers/topic.js
+++ b/lib/helpers/topic.js
@@ -6,6 +6,7 @@ const logger = require('../logger');
 const config = require('../../config/lib/helpers/topic');
 const broadcastConfig = require('../../config/lib/helpers/broadcast');
 const repliesConfig = require('../../config/lib/helpers/replies');
+// TODO: Move templateConfig into repliesConfig.
 const templateConfig = require('../../config/lib/helpers/template');
 
 /**
@@ -92,9 +93,12 @@ function getSupportTopic() {
 
 /**
  * Return the outbound template name to use for triggers that transition to this topic.
+ *
+ * @param {Object} topic
+ * @return {String}
  */
 function getTransitionTemplateName(topic) {
-  if (topic.campaign && topic.campaign.id && helpers.campaign.isClosedCampaign(topic.campaign)) {
+  if (module.exports.hasClosedCampaign(topic)) {
     return repliesConfig.campaignClosed.name;
   }
 
@@ -102,6 +106,7 @@ function getTransitionTemplateName(topic) {
   if (topicTypeConfig && topicTypeConfig.transitionTemplate) {
     return topicTypeConfig.transitionTemplate;
   }
+
   return templateConfig.templatesMap.rivescriptReply;
 }
 
@@ -120,6 +125,16 @@ function hasActiveCampaign(topic) {
 function hasCampaign(topic) {
   return topic.campaign && topic.campaign.id;
 }
+
+/**
+ * @param {Object} topic
+ * @return {Boolean}
+ */
+function hasClosedCampaign(topic) {
+  return module.exports.hasCampaign(topic) && helpers.campaign.isClosedCampaign(topic.campaign);
+}
+
+/**
 
 /**
  * @param {Object} topic
@@ -207,6 +222,7 @@ module.exports = {
   getSupportTopic,
   hasActiveCampaign,
   hasCampaign,
+  hasClosedCampaign,
   isAskSubscriptionStatus,
   isAskVotingPlanStatus,
   isAskYesNo,

--- a/lib/helpers/topic.js
+++ b/lib/helpers/topic.js
@@ -5,6 +5,7 @@ const helpers = require('../helpers');
 const logger = require('../logger');
 const config = require('../../config/lib/helpers/topic');
 const broadcastConfig = require('../../config/lib/helpers/broadcast');
+const repliesConfig = require('../../config/lib/helpers/replies');
 const templateConfig = require('../../config/lib/helpers/template');
 
 /**
@@ -93,6 +94,10 @@ function getSupportTopic() {
  * Return the outbound template name to use for triggers that transition to this topic.
  */
 function getTransitionTemplateName(topic) {
+  if (topic.campaign && topic.campaign.id && helpers.campaign.isClosedCampaign(topic.campaign)) {
+    return repliesConfig.campaignClosed.name;
+  }
+
   const topicTypeConfig = config.types[topic.type];
   if (topicTypeConfig && topicTypeConfig.transitionTemplate) {
     return topicTypeConfig.transitionTemplate;

--- a/test/unit/lib/lib-helpers/tags.test.js
+++ b/test/unit/lib/lib-helpers/tags.test.js
@@ -13,6 +13,7 @@ const logger = require('../../../../lib/logger');
 const stubs = require('../../../helpers/stubs');
 const broadcastFactory = require('../../../helpers/factories/broadcast');
 const conversationFactory = require('../../../helpers/factories/conversation');
+const topicFactory = require('../../../helpers/factories/topic');
 const userFactory = require('../../../helpers/factories/user');
 
 const config = require('../../../../config/lib/helpers/tags');
@@ -34,6 +35,7 @@ const sandbox = sinon.sandbox.create();
 // stubs
 const mockBroadcast = broadcastFactory.getValidAutoReplyBroadcast();
 const mockText = stubs.getRandomMessageText();
+const mockTopic = topicFactory.getValidTopic();
 const mockUser = userFactory.getValidUser();
 const mockTags = { season: 'winter' };
 
@@ -123,19 +125,22 @@ test('getTags should return an object', (t) => {
     .returns(linksTag);
   sandbox.stub(tagsHelper, 'getUserTag')
     .returns(userTag);
+  t.context.req.topic = mockTopic;
   t.context.req.user = mockUser;
 
   const result = tagsHelper.getTags(t.context.req);
   result.should.deep.equal({
     broadcast: broadcastTag,
     links: linksTag,
+    topic: mockTopic,
     user: userTag,
   });
 });
 
-test('getTags should return empty object for user if req.user undefined', (t) => {
+test('getTags should return empty object for user and topic if undefined in req', (t) => {
   const result = tagsHelper.getTags(t.context.req);
   result.user.should.deep.equal({});
+  result.topic.should.deep.equal({});
 });
 
 // getBroadcastLinkQueryParams

--- a/test/unit/lib/lib-helpers/template.test.js
+++ b/test/unit/lib/lib-helpers/template.test.js
@@ -35,18 +35,6 @@ test('getSubscriptionStatusActive should return subscriptionStatusActive config 
   result.should.deep.equal(macroConfig.macros.subscriptionStatusActive);
 });
 
-// getTextForTemplate
-test('getTextForTemplate should return text for given template', () => {
-  const template = 'badWords';
-  const templateText = config.conversationsTemplatesText[template];
-  const result = templateHelper.getTextForTemplate(template);
-  templateText.should.equal(result);
-});
-
-test('getTextForTemplate should return falsy for undefined template', (t) => {
-  t.falsy(templateHelper.getTextForTemplate(undefinedTemplateName));
-});
-
 // isAskContinueTemplate
 test('isAskContinueTemplate should return boolean', (t) => {
   t.true(templateHelper.isAskContinueTemplate('askContinue'));

--- a/test/unit/lib/lib-helpers/topic.test.js
+++ b/test/unit/lib/lib-helpers/topic.test.js
@@ -12,6 +12,7 @@ const stubs = require('../../../helpers/stubs');
 const broadcastFactory = require('../../../helpers/factories/broadcast');
 const topicFactory = require('../../../helpers/factories/topic');
 const config = require('../../../../config/lib/helpers/topic');
+const repliesConfig = require('../../../../config/lib/helpers/replies');
 const templateConfig = require('../../../../config/lib/helpers/template');
 
 chai.should();
@@ -239,13 +240,25 @@ test('getTopicTemplateText throws when template undefined', (t) => {
 });
 
 // getTransitionTemplateName
+test('getTransitionTemplateName returns closedCampaign name if topic hasClosedCampaign', () => {
+  sandbox.stub(topicHelper, 'hasClosedCampaign')
+    .returns(true);
+  const topic = { type: stubs.getRandomWord() };
+  const result = topicHelper.getTransitionTemplateName(topic);
+  result.should.equal(repliesConfig.campaignClosed.name);
+});
+
 test('getTransitionTemplateName returns transitionTemplate if defined in config.types ', () => {
+  sandbox.stub(topicHelper, 'hasClosedCampaign')
+    .returns(false);
   const topic = topicFactory.getValidTextPostConfig();
   const result = topicHelper.getTransitionTemplateName(topic);
   result.should.equal(config.types.textPostConfig.transitionTemplate);
 });
 
 test('getTransitionTemplateName returns rivescript template if config.types undefined', () => {
+  sandbox.stub(topicHelper, 'hasClosedCampaign')
+    .returns(false);
   const topic = { type: stubs.getRandomWord() };
   const result = topicHelper.getTransitionTemplateName(topic);
   result.should.equal(templateConfig.templatesMap.rivescriptReply);

--- a/test/unit/lib/lib-helpers/topic.test.js
+++ b/test/unit/lib/lib-helpers/topic.test.js
@@ -95,10 +95,76 @@ test('getSupportTopic should return config.rivescriptTopics.support', () => {
   result.should.deep.equal(config.rivescriptTopics.support);
 });
 
+// hasActiveCampaign
+test('hasActiveCampaign returns true if topic has campaign that is not closed', (t) => {
+  sandbox.stub(topicHelper, 'hasCampaign')
+    .returns(true);
+  sandbox.stub(helpers.campaign, 'isClosedCampaign')
+    .returns(false);
+  const topic = topicFactory.getValidTopic();
+
+  t.truthy(topicHelper.hasActiveCampaign(topic));
+  topicHelper.hasCampaign.should.have.been.calledWith(topic);
+  helpers.campaign.isClosedCampaign.should.have.been.calledWith(topic.campaign);
+});
+
+test('hasActiveCampaign returns false if topic has campaign that is closed', (t) => {
+  sandbox.stub(topicHelper, 'hasCampaign')
+    .returns(true);
+  sandbox.stub(helpers.campaign, 'isClosedCampaign')
+    .returns(true);
+  const topic = topicFactory.getValidTopic();
+
+  t.falsy(topicHelper.hasActiveCampaign(topic));
+});
+
+test('hasActiveCampaign returns false if topic does not have campaign', (t) => {
+  sandbox.stub(topicHelper, 'hasCampaign')
+    .returns(false);
+  sandbox.stub(helpers.campaign, 'isClosedCampaign')
+    .returns(false);
+  const topic = topicFactory.getValidTopic();
+
+  t.falsy(topicHelper.hasActiveCampaign(topic));
+});
+
 // hasCampaign
 test('hasCampaign should return boolean of whether topic.campaign.id exists', (t) => {
   t.truthy(topicHelper.hasCampaign(topicFactory.getValidTextPostConfig()));
   t.falsy(topicHelper.hasCampaign(topicFactory.getValidTopicWithoutCampaign()));
+});
+
+// hasClosedCampaign
+test('hasClosedCampaign returns true if topic has campaign that is closed', (t) => {
+  sandbox.stub(topicHelper, 'hasCampaign')
+    .returns(true);
+  sandbox.stub(helpers.campaign, 'isClosedCampaign')
+    .returns(true);
+  const topic = topicFactory.getValidTopic();
+
+  t.truthy(topicHelper.hasClosedCampaign(topic));
+  topicHelper.hasCampaign.should.have.been.calledWith(topic);
+  helpers.campaign.isClosedCampaign.should.have.been.calledWith(topic.campaign);
+});
+
+test('hasClosedCampaign returns false if topic has campaign that is not closed', (t) => {
+  sandbox.stub(topicHelper, 'hasCampaign')
+    .returns(true);
+  sandbox.stub(helpers.campaign, 'isClosedCampaign')
+    .returns(false);
+  const topic = topicFactory.getValidTopic();
+
+  t.falsy(topicHelper.hasClosedCampaign(topic));
+});
+
+test('hasClosedCampaign returns false if topic does not have campaign', (t) => {
+  sandbox.stub(topicHelper, 'hasCampaign')
+    .returns(false);
+  sandbox.stub(helpers.campaign, 'isClosedCampaign')
+    .returns(true);
+  const topic = topicFactory.getValidTopic();
+
+  t.falsy(topicHelper.hasClosedCampaign(topic));
 });
 
 // isAskSubscriptionStatus


### PR DESCRIPTION
#### What's this PR do?

The transition work in #433 and #434 failed to account for when a keyword is published for a closed campaign, prompting user to begin the closed campaign. Now that Gambit Campaigns is correctly returning a campaign `status` property per https://github.com/DoSomething/gambit-campaigns/pull/1097, this PR adds a check for campaign status when parsing Rivescript from the Content API, returning a `campaignClosed` template instead of a start message.

#### How should this be reviewed?

Texting a closed campaign keyword like `spit` should return a `closedCampaign` template, and change user topic to the closed campaign topic, auto repeating the closed campaign message. 

#### Any background context you want to provide?

* Handles todo of refactoring the  `gambitConversationsTemplates` in the templates helper into a templates reply helper property. Adds TODO about deprecating the template helper entirely in favor of existing replies/macro helpers.

* Per meeting with / approval from Anthony, this PR modifies the `campaignClosed` reply to be sourced from a static template instead of Content API, to send the same message for all closed campaigns. As a result, this PR adds makes a `{{topic}}` tag available to editors to embed a `{{topic.campaign.title}}` within outbound messaging.

* TODO: A few more unit tests

#### Relevant tickets

https://www.pivotaltracker.com/story/show/157369418

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tests added/updated for new features/bug fixes.
- [x] Tested on staging.
