### PR TITLE
Submits photo posts [pr]

### DIFF
--- a/config/lib/helpers/user.js
+++ b/config/lib/helpers/user.js
@@ -50,6 +50,9 @@ const userFields = {
 module.exports = {
   fields: userFields,
   posts: {
+    photo: {
+      type: 'photo',
+    },
     text: {
       type: 'text',
     },

--- a/lib/helpers/user.js
+++ b/lib/helpers/user.js
@@ -8,6 +8,7 @@ const helpers = require('../helpers');
 const statuses = require('./subscription').statuses;
 const config = require('../../config/lib/helpers/user');
 
+const rogueClientConfig = rogue.getConfig();
 const votingPlanPostConfig = config.posts.votingPlan;
 
 /**
@@ -27,6 +28,26 @@ async function createSignup(user, args) {
   const signup = await rogue.createSignup(payload);
   logger.debug('rogue.createSignup success', { signup });
   return signup;
+}
+
+/**
+ * @param {Object} user
+ * @param {Object} args
+ * @return {Promise}
+ */
+async function createPhotoPost(user, args) {
+  const payload = {
+    northstar_id: user.id,
+    campaign_id: args.campaignId,
+    campaign_run_id: args.campaignRunId,
+    source: args.source,
+    text: args.text,
+    type: config.posts.photo.type,
+    why_participated: args.whyParticipated,
+  };
+  payload[rogueClientConfig.photoPostCreation.fileProperty] = args.file;
+  logger.debug('rogue.createPost post', { payload });
+  return rogue.createPost(payload);
 }
 
 /**
@@ -187,6 +208,7 @@ async function updateByMemberMessageReq(req) {
 }
 
 module.exports = {
+  createPhotoPost,
   createSignup,
   createTextPost,
   createVotingPlan,

--- a/lib/helpers/user.js
+++ b/lib/helpers/user.js
@@ -38,6 +38,7 @@ async function createPhotoPost(user, args) {
     northstar_id: user.id,
     campaign_id: args.campaignId,
     campaign_run_id: args.campaignRunId,
+    quantity: args.quantity,
     source: args.source,
     text: args.text,
     type: config.posts.photo.type,

--- a/lib/helpers/user.js
+++ b/lib/helpers/user.js
@@ -25,9 +25,7 @@ async function createSignup(user, args) {
     details: args.details,
   };
   logger.debug('rogue.createSignup post', { payload });
-  const signup = await rogue.createSignup(payload);
-  logger.debug('rogue.createSignup success', { signup });
-  return signup;
+  return rogue.createSignup(payload);
 }
 
 /**

--- a/lib/helpers/util.js
+++ b/lib/helpers/util.js
@@ -41,7 +41,8 @@ function containsAtLeastOneLetter(string) {
 }
 
 /**
- * {String}
+ * @param {String} url
+ * @return {Promise}
  */
 function fetchImageFileFromUrl(url) {
   return superagent.get(url)

--- a/lib/helpers/util.js
+++ b/lib/helpers/util.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { PhoneNumberFormat, PhoneNumberUtil } = require('google-libphonenumber');
+const superagent = require('superagent');
 const underscore = require('underscore');
 const Promise = require('bluebird');
 
@@ -37,6 +38,17 @@ function containsAtLeastOneLetter(string) {
     return false;
   }
   return /[a-zA-Z]/.test(string);
+}
+
+/**
+ * {String}
+ */
+function fetchImageFileFromUrl(url) {
+  return superagent.get(url)
+    .buffer(true)
+    // @see https://github.com/visionmedia/superagent/issues/871#issuecomment-286199206
+    .parse(superagent.parse.image)
+    .then(res => res.body);
 }
 
 /**
@@ -121,6 +133,7 @@ module.exports = {
       resolve(result);
     });
   },
+  fetchImageFileFromUrl,
   formatMobileNumber: function formatMobileNumber(mobile, format = 'E164', countryCode = 'US') {
     logger.debug('formatMobileNumber params', { mobile });
     if (!mobile) {

--- a/lib/middleware/messages/member/topics/posts/photo/create.js
+++ b/lib/middleware/messages/member/topics/posts/photo/create.js
@@ -11,12 +11,16 @@ module.exports = function createPhotoPost() {
         return next();
       }
 
-      // TODO: Fetch file from url property to submit a photo post.
-      const createPostRes = await helpers.user.createTextPost(req.user, {
+      const values = req.draftSubmission.values;
+      const file = await helpers.util.fetchImageFileFromUrl(values.url);
+
+      const createPostRes = await helpers.user.createPhotoPost(req.user, {
         campaignId: req.topic.campaign.id,
         campaignRunId: req.topic.campaign.currentCampaignRun.id,
-        text: JSON.stringify(req.draftSubmission.toObject().values),
+        file,
         source: req.platform,
+        text: values.whyParticipated,
+        whyParticipated: values.whyParticipated,
       });
       logger.debug('created post', { id: createPostRes.data.id });
 

--- a/lib/middleware/messages/member/topics/posts/photo/create.js
+++ b/lib/middleware/messages/member/topics/posts/photo/create.js
@@ -22,6 +22,7 @@ module.exports = function createPhotoPost() {
         campaignId: req.topic.campaign.id,
         campaignRunId: req.topic.campaign.currentCampaignRun.id,
         file,
+        quantity: values.quantity,
         source: req.platform,
         text: values.whyParticipated,
         whyParticipated: values.whyParticipated,

--- a/lib/middleware/messages/member/topics/posts/photo/create.js
+++ b/lib/middleware/messages/member/topics/posts/photo/create.js
@@ -11,6 +11,10 @@ module.exports = function createPhotoPost() {
         return next();
       }
 
+      if (!req.draftSubmission) {
+        throw new Error('req.draftSubmission undefined');
+      }
+
       const values = req.draftSubmission.values;
       const file = await helpers.util.fetchImageFileFromUrl(values.url);
 
@@ -22,6 +26,7 @@ module.exports = function createPhotoPost() {
         text: values.whyParticipated,
         whyParticipated: values.whyParticipated,
       });
+
       logger.debug('created post', { id: createPostRes.data.id });
 
       await DraftSubmission.deleteOne({ _id: req.draftSubmission._id });

--- a/lib/rogue.js
+++ b/lib/rogue.js
@@ -11,6 +11,10 @@ function getClient() {
   return rogueClient;
 }
 
+function getConfig() {
+  return getClient().config;
+}
+
 /**
  * createPost
  *
@@ -53,6 +57,7 @@ function fetchPosts(query) {
 
 module.exports = {
   getClient,
+  getConfig,
   createPost,
   createSignup,
   fetchPosts,

--- a/test/helpers/factories/draftSubmission.js
+++ b/test/helpers/factories/draftSubmission.js
@@ -1,0 +1,44 @@
+'use strict';
+
+const ObjectID = require('mongoose').Types.ObjectId;
+const DraftSubmission = require('../../../app/models/DraftSubmission');
+const stubs = require('../stubs');
+
+/**
+ * @param {Object} values
+ * @return {Object}
+ */
+function getRawDraftSubmissionData(values = {}) {
+  const id = new ObjectID();
+  return {
+    id,
+    _id: id,
+    conversationId: new ObjectID(),
+    platformUserId: stubs.getMobileNumber(),
+    topicId: stubs.getContentfulId(),
+    values,
+  };
+}
+
+/**
+ * @return {DraftSubmission}
+ */
+function getValidCompletePhotoPostDraftSubmission() {
+  return DraftSubmission(getRawDraftSubmissionData({
+    quantity: 4,
+    url: 'http://placekitten.com/g/300/300',
+    whyParticipated: stubs.getRandomMessageText(),
+  }));
+}
+
+/**
+ * @return {DraftSubmission}
+ */
+function getValidEmptyDraftSubmission() {
+  return new DraftSubmission(getRawDraftSubmissionData());
+}
+
+module.exports = {
+  getValidCompletePhotoPostDraftSubmission,
+  getValidEmptyDraftSubmission,
+};

--- a/test/helpers/stubs.js
+++ b/test/helpers/stubs.js
@@ -234,6 +234,9 @@ module.exports = {
   getPlatformUserId(valid) {
     return module.exports.getMobileNumber(valid);
   },
+  getPostId() {
+    return { id: chance.integer({ min: 200, max: 2000000 }) };
+  },
   getPostType() {
     return 'text';
   },

--- a/test/unit/lib/lib-helpers/user.test.js
+++ b/test/unit/lib/lib-helpers/user.test.js
@@ -55,7 +55,8 @@ test('createPhotoPost passes user.id, campaignId, campaignRunId, file, source, t
   const file = stubs.getRandomMessageText();
   const text = stubs.getRandomMessageText();
   const whyParticipated = stubs.getRandomMessageText();
-
+  sandbox.stub(rogue, 'getClient')
+    .returns({ photoPostCreation: { fileProperty: 'file' } });
 
   const result = await userHelper
     .createPhotoPost(mockUser, { campaignId, campaignRunId, file, source, text, whyParticipated });

--- a/test/unit/lib/lib-helpers/user.test.js
+++ b/test/unit/lib/lib-helpers/user.test.js
@@ -51,19 +51,21 @@ test.afterEach((t) => {
 });
 
 // createPhotoPost
-test('createPhotoPost passes user.id, campaignId, campaignRunId, file, source, text, and whyParticipated args to rogue.createSignup', async () => {
+test('createPhotoPost passes user.id, campaignId, campaignRunId, file, quantity, source, text, and whyParticipated args to rogue.createSignup', async () => {
   const file = stubs.getRandomMessageText();
+  const quantity = 240;
   const text = stubs.getRandomMessageText();
   const whyParticipated = stubs.getRandomMessageText();
   sandbox.stub(rogue, 'getClient')
     .returns({ photoPostCreation: { fileProperty: 'file' } });
+  const args = { campaignId, campaignRunId, file, quantity, source, text, whyParticipated };
 
-  const result = await userHelper
-    .createPhotoPost(mockUser, { campaignId, campaignRunId, file, source, text, whyParticipated });
+  const result = await userHelper.createPhotoPost(mockUser, args);
   rogue.createPost.should.have.been.calledWith({
     campaign_id: campaignId,
     campaign_run_id: campaignRunId,
     file,
+    quantity,
     northstar_id: mockUser.id,
     source,
     text,

--- a/test/unit/lib/lib-helpers/user.test.js
+++ b/test/unit/lib/lib-helpers/user.test.js
@@ -50,6 +50,28 @@ test.afterEach((t) => {
   sandbox.restore();
 });
 
+// createPhotoPost
+test('createPhotoPost passes user.id, campaignId, campaignRunId, file, source, text, and whyParticipated args to rogue.createSignup', async () => {
+  const file = stubs.getRandomMessageText();
+  const text = stubs.getRandomMessageText();
+  const whyParticipated = stubs.getRandomMessageText();
+
+
+  const result = await userHelper
+    .createPhotoPost(mockUser, { campaignId, campaignRunId, file, source, text, whyParticipated });
+  rogue.createPost.should.have.been.calledWith({
+    campaign_id: campaignId,
+    campaign_run_id: campaignRunId,
+    file,
+    northstar_id: mockUser.id,
+    source,
+    text,
+    type: config.posts.photo.type,
+    why_participated: whyParticipated,
+  });
+  result.should.deep.equal(mockPost);
+});
+
 // createSignup
 test('createSignup passes user.id, campaignId, campaignRunId source args to rogue.createSignup', async () => {
   const signup = { id: campaignId, campaign_id: campaignId };

--- a/test/unit/lib/lib-helpers/util.test.js
+++ b/test/unit/lib/lib-helpers/util.test.js
@@ -7,8 +7,10 @@ const sinon = require('sinon');
 const sinonChai = require('sinon-chai');
 const httpMocks = require('node-mocks-http');
 
+const superagent = require('superagent');
 const InternalServerError = require('../../../../app/exceptions/InternalServerError');
 const UnprocessableEntityError = require('../../../../app/exceptions/UnprocessableEntityError');
+
 const stubs = require('../../../helpers/stubs');
 
 chai.should();
@@ -93,6 +95,23 @@ test('isValidTextPost should return true if trimmed string arg has letters and l
   t.truthy(utilHelper.isValidTextPost('1 a'));
   t.falsy(utilHelper.isValidTextPost('a'));
   t.falsy(utilHelper.isValidTextPost('1231231'));
+});
+
+// fetchImageFileFromUrl
+test('fetchImageFileFromUrl should return parsed response of superagent.get', async () => {
+  const url = 'test';
+  const mockFile = 'abc123';
+  const mockResponse = { body: mockFile };
+  sandbox.stub(superagent, 'get')
+    .returns({
+      buffer: sinon.stub().returns({
+        parse: sinon.stub().returns(Promise.resolve(mockResponse)),
+      }),
+    });
+
+  const result = await utilHelper.fetchImageFileFromUrl(url);
+  superagent.get.should.have.been.calledWith(url);
+  result.should.equal(mockFile);
 });
 
 // parseStatusAndMessageFromError

--- a/test/unit/lib/middleware/messages/member/topics/posts/photo/create.test.js
+++ b/test/unit/lib/middleware/messages/member/topics/posts/photo/create.test.js
@@ -1,0 +1,101 @@
+'use strict';
+
+require('dotenv').config();
+
+const test = require('ava');
+const chai = require('chai');
+const sinon = require('sinon');
+const sinonChai = require('sinon-chai');
+const httpMocks = require('node-mocks-http');
+const underscore = require('underscore');
+
+const helpers = require('../../../../../../../../../lib/helpers');
+const stubs = require('../../../../../../../../helpers/stubs');
+const draftSubmissionFactory = require('../../../../../../../../helpers/factories/draftSubmission');
+const topicFactory = require('../../../../../../../../helpers/factories/topic');
+const userFactory = require('../../../../../../../../helpers/factories/user');
+
+chai.should();
+chai.use(sinonChai);
+
+const completeDraft = draftSubmissionFactory.getValidCompletePhotoPostDraftSubmission();
+const mockPost = { id: stubs.getPostId() };
+
+// module to be tested
+const createPhotoPost = require('../../../../../../../../../lib/middleware/messages/member/topics/posts/photo/create');
+
+const sandbox = sinon.sandbox.create();
+
+test.beforeEach((t) => {
+  sandbox.stub(helpers, 'sendErrorResponse')
+    .returns(underscore.noop);
+  t.context.req = httpMocks.createRequest();
+  t.context.res = httpMocks.createResponse();
+  t.context.req.topic = topicFactory.getValidPhotoPostConfig();
+  t.context.req.user = userFactory.getValidUser();
+  t.context.req.inboundMessageText = stubs.getRandomMessageText();
+  t.context.req.platform = stubs.getPlatform();
+});
+
+test.afterEach((t) => {
+  sandbox.restore();
+  t.context = {};
+});
+
+test('createPhotoPost should call next if topic is not a photoPostConfig', async (t) => {
+  const next = sinon.stub();
+  const middleware = createPhotoPost();
+  sandbox.stub(helpers.topic, 'isPhotoPostConfig')
+    .returns(false);
+  sandbox.stub(helpers.replies, 'completedPhotoPost')
+    .returns(underscore.noop);
+
+  // test
+  await middleware(t.context.req, t.context.res, next);
+
+  helpers.topic.isPhotoPostConfig.should.have.been.calledWith(t.context.req.topic);
+  next.should.have.been.called;
+  helpers.replies.completedPhotoPost.should.not.have.been.called;
+});
+
+test('createPhotoPost should call sendErrorResponse if req.draftSubmission is undefined', async (t) => {
+  const next = sinon.stub();
+  const middleware = createPhotoPost();
+  sandbox.stub(helpers.topic, 'isPhotoPostConfig')
+    .returns(true);
+  sandbox.stub(helpers.user, 'createPhotoPost')
+    .returns(Promise.resolve(mockPost));
+  sandbox.stub(helpers.replies, 'completedPhotoPost')
+    .returns(underscore.noop);
+
+  // test
+  await middleware(t.context.req, t.context.res, next);
+
+  helpers.topic.isPhotoPostConfig.should.have.been.calledWith(t.context.req.topic);
+  next.should.not.have.been.called;
+  helpers.user.createPhotoPost.should.not.have.been.called;
+  helpers.replies.completedPhotoPost.should.not.have.been.called;
+  helpers.sendErrorResponse.should.have.been.called;
+});
+
+test('createPhotoPost should call sendErrorResponse if createPhotoPost fails', async (t) => {
+  const next = sinon.stub();
+  const middleware = createPhotoPost();
+  const error = stubs.getError();
+  sandbox.stub(helpers.topic, 'isPhotoPostConfig')
+    .returns(true);
+  sandbox.stub(helpers.user, 'createPhotoPost')
+    .returns(Promise.reject(error));
+  sandbox.stub(helpers.replies, 'completedPhotoPost')
+    .returns(underscore.noop);
+  t.context.req.draftSubmission = completeDraft;
+
+  // test
+  await middleware(t.context.req, t.context.res, next);
+
+  helpers.topic.isPhotoPostConfig.should.have.been.calledWith(t.context.req.topic);
+  next.should.not.have.been.called;
+  helpers.user.createPhotoPost.should.have.been.called;
+  helpers.replies.completedPhotoPost.should.not.have.been.called;
+  helpers.sendErrorResponse.should.have.been.calledWith(t.context.res, error);
+});


### PR DESCRIPTION
#### What's this PR do?

Continues #443, submitting a photo post to the Rogue API via new `createPhotoPost` user heper, and starts on unit tests for photo post middleware.

#### How should this be reviewed?

Upon setting `DS_GAMBIT_CONVERSATIONS_DRAFT_SUBMISSION_ENABLED` to `true`, verify a photo post is created upon completing a photo post conversation (e.g. text `lock` to submit a photo for Friends On Lock)

#### Any background context you want to provide?

Once this goes live and the config variable is set on production, we'll be in great shape to exclude Campaign Run Id's to Rogue requests in a single app/deploy, as the Gambit Campaigns app will no longer post to Rogue.

#### Relevant tickets

https://www.pivotaltracker.com/story/show/161494958

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tests added/updated for new features/bug fixes.
- [x] Tested on staging.
