### PR TITLE
Adds deprecated Rivescript topics to config

### DIFF
--- a/config/lib/helpers/topic.js
+++ b/config/lib/helpers/topic.js
@@ -62,5 +62,24 @@ module.exports = {
     unsubscribed: {
       id: 'unsubscribed',
     },
+    /**
+     * Deprecated topics.
+     *
+     * The campaign topic was used before we began supporting multiple types of conversations for a
+     * a campaign. This topic no longer gets saved, and has been deprecated by saving Contentful IDs
+     * as the conversation topic.
+     */
+    campaign: {
+      id: 'campaign',
+      deprecated: true,
+    },
+    /**
+     * The survey_response topic has been deprecated by the autoReply and autoReplyBroadcast content
+     * types.
+     */
+    surveyResponse: {
+      id: 'survey_response',
+      deprecated: true,
+    },
   },
 };

--- a/lib/helpers/topic.js
+++ b/lib/helpers/topic.js
@@ -173,6 +173,14 @@ function isBroadcastable(topic) {
  * @param {Object} topic
  * @return {Boolean}
  */
+function isDeprecated(topic) {
+  return topic.deprecated === true;
+}
+
+/**
+ * @param {Object} topic
+ * @return {Boolean}
+ */
 function isPhotoPostConfig(topic) {
   return topic.type === config.types.photoPostConfig.type;
 }
@@ -222,6 +230,7 @@ module.exports = {
   isAutoReply,
   isBroadcastable,
   isDefaultTopicId,
+  isDeprecated,
   isPhotoPostConfig,
   isRivescriptTopicId,
   isTextPostConfig,

--- a/lib/middleware/messages/member/topic-get.js
+++ b/lib/middleware/messages/member/topic-get.js
@@ -1,17 +1,26 @@
 'use strict';
 
 const helpers = require('../../../helpers');
+const logger = require('../../../logger');
 
 module.exports = function getCurrentTopic() {
   /**
    * If we've made it this far - we haven't found a reply to send yet.
    * Get the current topic to determine the reply later.
    */
-  return (req, res, next) => helpers.topic.getById(req.currentTopicId)
-    .then((topic) => {
+  return async (req, res, next) => {
+    try {
+      const topic = await helpers.topic.getById(req.currentTopicId);
       helpers.request.setTopic(req, topic);
-      return next();
-    })
-    .catch(error => helpers.sendErrorResponse(res, error));
-};
 
+      if (helpers.topic.isDeprecated(topic)) {
+        logger.debug('topic is deprecated', { topicId: topic.id }, req);
+        return await helpers.replies.noCampaign(req, res);
+      }
+
+      return next();
+    } catch (error) {
+      return helpers.sendErrorResponse(res, error);
+    }
+  };
+};

--- a/test/unit/lib/lib-helpers/topic.test.js
+++ b/test/unit/lib/lib-helpers/topic.test.js
@@ -201,6 +201,12 @@ test('isBroadcastable returns whether topic is rivescriptTopics.askVotingPlanSta
   t.falsy(topicHelper.isBroadcastable(mockTopic));
 });
 
+// isDeprecated
+test('isDeprecated should return true when topic.deprecated property is set to true', (t) => {
+  t.falsy(topicHelper.isDeprecated(config.rivescriptTopics.unsubscribed));
+  t.truthy(topicHelper.isDeprecated(config.rivescriptTopics.campaign));
+});
+
 // isRivescriptTopicId
 test('isRivescriptTopicId should return whether topicId exists deparsed rivescript topics', (t) => {
   t.truthy(topicHelper.isRivescriptTopicId(mockRivescriptTopicId));

--- a/test/unit/lib/middleware/messages/member/topic-get.test.js
+++ b/test/unit/lib/middleware/messages/member/topic-get.test.js
@@ -29,6 +29,8 @@ const error = stubs.getError();
 test.beforeEach((t) => {
   sandbox.stub(helpers, 'sendErrorResponse')
     .returns(underscore.noop);
+  sandbox.stub(helpers.replies, 'noCampaign')
+    .returns(underscore.noop);
   t.context.req = httpMocks.createRequest();
   t.context.req.currentTopicId = stubs.getContentfulId();
   t.context.res = httpMocks.createResponse();
@@ -39,21 +41,39 @@ test.afterEach((t) => {
   t.context = {};
 });
 
-test('getTopic calls request.setTopic on topic.getById success', async (t) => {
+test('getTopic calls next if topic.getById result is not deprecated', async (t) => {
   const next = sinon.stub();
   const middleware = getTopic();
   sandbox.stub(helpers.topic, 'getById')
     .returns(Promise.resolve(topic));
   sandbox.stub(helpers.request, 'setTopic')
     .returns(underscore.noop);
+  sandbox.stub(helpers.topic, 'isDeprecated')
+    .returns(false);
 
   await middleware(t.context.req, t.context.res, next);
   helpers.topic.getById.should.have.been.calledWith(t.context.req.currentTopicId);
   helpers.request.setTopic.should.have.been.calledWith(t.context.req, topic);
+  helpers.replies.noCampaign.should.not.have.been.called;
   next.should.have.been.called;
 });
 
-test('getTopic calls sendErrorResponse on topic.getById error', async (t) => {
+test('getTopic sends noCampaign reply if topic.getById result is deprecated', async (t) => {
+  const next = sinon.stub();
+  const middleware = getTopic();
+  sandbox.stub(helpers.topic, 'getById')
+    .returns(Promise.resolve(topic));
+  sandbox.stub(helpers.request, 'setTopic')
+    .returns(underscore.noop);
+  sandbox.stub(helpers.topic, 'isDeprecated')
+    .returns(true);
+
+  await middleware(t.context.req, t.context.res, next);
+  helpers.replies.noCampaign.should.have.been.calledWith(t.context.req, t.context.res);
+  next.should.not.have.been.called;
+});
+
+test('getTopic calls sendErrorResponse if topic.getById returns error', async (t) => {
   const next = sinon.stub();
   const middleware = getTopic();
   sandbox.stub(helpers.topic, 'getById')


### PR DESCRIPTION
#### What's this PR do?

Adds a check for deprecated Rivescript topic id's, which will prevent 404 errors when Gambit receives an inbound message from a user in a conversation in older topics like `campaign` and `survey_response`.

#### How should this be reviewed?

Manually update your conversation topic to `campaign` and `survey_response` and verify the `noCampaign` reply is returned for an inbound message that doesn't match any Rivescript triggers.

#### Relevant tickets
https://dosomething.slack.com/archives/C2C8NLNAY/p1543330022163500

#### Checklist
- [ ] Tests added/updated for new features/bug fixes.
- [ ] Tested on staging.
