### PR TITLE
Adds check for null fetchSignup result

### DIFF
--- a/lib/helpers/request.js
+++ b/lib/helpers/request.js
@@ -122,9 +122,8 @@ function hasDraftSubmissionValue(req, key) {
  */
 async function hasSignupWithWhyParticipated(req) {
   const signup = await helpers.user.fetchSignup(req.user, req.topic.campaign);
-  return !!signup.why_participated;
+  return signup && signup.why_participated;
 }
-
 
 /**
  * @param {Object} req

--- a/lib/helpers/user.js
+++ b/lib/helpers/user.js
@@ -150,14 +150,14 @@ async function fetchSignup(user, campaign) {
 
 /**
  * @param {String} userId
- * @param {Number} campaignId
+ * @param {Number} campaignRunId
  * @return {Object}
  */
-function getFetchSignupsQuery(userId, campaignId) {
+function getFetchSignupsQuery(userId, campaignRunId) {
   const query = {};
   query['filter[northstar_id]'] = userId;
   // TODO: Change this filter to campaign_id after Rogue campaigns go live.
-  query['filter[campaign_run_id]'] = campaignId;
+  query['filter[campaign_run_id]'] = campaignRunId;
   return query;
 }
 

--- a/test/unit/lib/lib-helpers/request.test.js
+++ b/test/unit/lib/lib-helpers/request.test.js
@@ -282,6 +282,18 @@ test('hasSignupWithWhyParticipated should return false if fetchSignup result why
     .should.have.been.calledWith(t.context.req.user, t.context.req.topic.campaign);
 });
 
+test('hasSignupWithWhyParticipated should return false if fetchSignup result is null', async (t) => {
+  t.context.req.user = userFactory.getValidUser();
+  t.context.req.topic = topicFactory.getValidPhotoPostConfig();
+  sandbox.stub(helpers.user, 'fetchSignup')
+    .returns(Promise.resolve(null));
+
+  const result = await requestHelper.hasSignupWithWhyParticipated(t.context.req);
+  t.falsy(result);
+  helpers.user.fetchSignup
+    .should.have.been.calledWith(t.context.req.user, t.context.req.topic.campaign);
+});
+
 // isStartCommand
 test('isStartCommand should return true if trimmed lowercase req.inboundMessageText is equal to start command', (t) => {
   t.falsy(requestHelper.isStartCommand(t.context.req));


### PR DESCRIPTION
#### What's this PR do?

This tweaks the `hasSignupWithWhyParticipated` request helper to return `false` if a signup isn't found, but it suggests that our `fetchOrCreateSignup` isn't creating a new signup for TYF on yes responses when a user has a signup for TYF in a previous run.

* Changes parameter name in `getFetchSignupsQuery` for better readability 

#### How should this be reviewed?
👀 

#### Any background context you want to provide?

Tempting to merge as is in order to get the current retries out of the queue (and create posts and send these stuck users a reply), but seems like a bug [somewhere in the askYesNo topic middleware](https://github.com/DoSomething/gambit-conversations/blob/4.0.1/lib/middleware/messages/member/topics/ask-yes-no.js#L25). There's the random chance that the `GET /campaigns/:id` response in the Content API had the old current run cached... but as of investigating the currentCampaignRun.id was the current value, 8291. 

#### Relevant tickets
https://dosomething.slack.com/archives/C1V0M6RPE/p1544040490002800

#### Checklist
- [x] Tests added/updated for new features/bug fixes.
- [x] Tested on staging.
