### PR TITLE
Fetch signup by campaign ID instead of run ID

### DIFF
--- a/lib/helpers/user.js
+++ b/lib/helpers/user.js
@@ -136,9 +136,8 @@ async function fetchOrCreateSignup(user, campaign, signupSource, signupSourceDet
  * @return {Promise}
  */
 async function fetchSignup(user, campaign) {
-  // TODO: Pass campaign.id instead of currentCampaignRun.id after Rogue campaigns go live.
   const res = await rogue
-    .fetchSignups(module.exports.getFetchSignupsQuery(user.id, campaign.currentCampaignRun.id));
+    .fetchSignups(module.exports.getFetchSignupsQuery(user.id, campaign.id));
   return res.data && res.data[0] ? res.data[0] : null;
 }
 

--- a/test/unit/lib/lib-helpers/user.test.js
+++ b/test/unit/lib/lib-helpers/user.test.js
@@ -222,6 +222,27 @@ test('fetchFromReq calls fetchByMobile if req.platformUserId', async (t) => {
   userHelper.fetchById.should.not.have.been.called;
 });
 
+// fetchSignup
+test('fetchSignup should call rogue.fetchSignups with getFetchSignupsQuery result and return first result', async () => {
+  sandbox.spy(userHelper, 'getFetchSignupsQuery');
+  sandbox.stub(rogue, 'fetchSignups')
+    .returns(Promise.resolve({ data: [mockSignup, mockPost] }));
+
+  const result = await userHelper.fetchSignup(mockUser, campaign);
+  userHelper.getFetchSignupsQuery.should.have.been.calledWith(mockUser.id, campaign.id);
+  rogue.fetchSignups
+    .should.have.been.calledWith(userHelper.getFetchSignupsQuery(mockUser.id, campaign.id));
+  result.should.deep.equal(mockSignup);
+});
+
+test('fetchSignup should return null if fetchSignup result is empty array', async (t) => {
+  sandbox.stub(rogue, 'fetchSignups')
+    .returns(Promise.resolve({ data: [] }));
+
+  const result = await userHelper.fetchSignup(mockUser, campaign);
+  t.is(result, null);
+});
+
 // fetchVotingPlan
 test('fetchVotingPlan should call rogue.getPosts with query for user voting plan', async () => {
   const mockQuery = { test: '123' };


### PR DESCRIPTION
#### What's this PR do?

Fixes a TODO missed in #456, which caused Gambit to ask `whyParticipated` upon every photo post instead of just the first.

#### How should this be reviewed?

Verify that 1st photo post for a signup triggers asking why participated, 2nd photo post for the signup does not.

#### Any background context you want to provide?
Whoops 🤦‍♂️ 

#### Relevant tickets
https://www.pivotaltracker.com/story/show/161494958

#### Checklist
- [x] Tests added/updated for new features/bug fixes.
- [x] Tested on staging.
