### PR TITLE
Refactors first iteration of the NewRelic `noticeError` implementation [pr]

### DIFF
--- a/config/lib/helpers.js
+++ b/config/lib/helpers.js
@@ -1,5 +1,0 @@
-'use strict';
-
-module.exports = {
-  blinkSuppressHeaders: 'x-blink-retry-suppress',
-};

--- a/config/lib/helpers/response.js
+++ b/config/lib/helpers/response.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = {
+  noRetryHeader: 'x-blink-retry-suppress',
+};

--- a/lib/bertly/index.js
+++ b/lib/bertly/index.js
@@ -6,6 +6,7 @@ const linkify = require('linkify-it')({
   fuzzyEmail: false,
 });
 
+const analyticsHelper = require('../helpers/analytics');
 const logger = require('../logger');
 const restClient = require('./rest-client');
 const config = require('../../config/lib/bertly');
@@ -92,6 +93,8 @@ async function parseLinksInTextIntoRedirects(text = '') {
 
     return parsedMessage;
   } catch (error) {
+    // Expose error metadata in NewRelic
+    analyticsHelper.addHandledError(error);
     logger.error('parseLinksInTextIntoRedirects() Error creating redirects.', {
       error: error.message,
       status: error.status,

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -19,9 +19,9 @@ Object.keys(helpers).forEach((helperName) => {
  *
  * @param  {Object} res
  * @param  {Error} err
- * @param  {Boolean} sendSuppressHeader
+ * @param  {Boolean} retry by default, errors should be retried by Blink
  */
-module.exports.sendErrorResponse = function (res, err, sendSuppressHeader = false) {
+module.exports.sendErrorResponse = function (res, err, retry = true) {
   // Capture error in transaction
   helpers.analytics.addHandledError(err);
   const error = helpers.util.parseStatusAndMessageFromError(err);
@@ -32,8 +32,12 @@ module.exports.sendErrorResponse = function (res, err, sendSuppressHeader = fals
    * We have to also relay the Suppress headers.
    */
   const errHasResponseGet = error.response && error.response.get;
-  if (sendSuppressHeader) {
+  if (!retry) {
     exports.addBlinkSuppressHeaders(res);
+  /**
+   * TODO: deprecate? this check is here because we used to relay errors from G-Campaigns
+   * but since we are deprecating it, we could remove this extra check.
+   */
   } else if (errHasResponseGet && error.response.get(config.blinkSuppressHeaders)) {
     exports.addBlinkSuppressHeaders(res);
   }
@@ -41,8 +45,8 @@ module.exports.sendErrorResponse = function (res, err, sendSuppressHeader = fals
   return this.sendResponseWithStatusCode(res, error.status, error.message);
 };
 
-module.exports.sendErrorResponseWithSuppressHeaders = function (res, err) {
-  return exports.sendErrorResponse(res, err, true);
+module.exports.sendErrorResponseWithNoRetry = function (res, err) {
+  return exports.sendErrorResponse(res, err, false);
 };
 
 /**

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -22,10 +22,7 @@ Object.keys(helpers).forEach((helperName) => {
  * @param  {Boolean} retry by default, errors should be retried by Blink
  */
 module.exports.sendErrorResponse = function (res, err, retry = true) {
-  // Capture error in transaction
-  helpers.analytics.addHandledError(err);
   const error = helpers.util.parseStatusAndMessageFromError(err);
-
   /**
    * If the error has a response and the response contains the Blink Suppress headers,
    * this error is being relayed to Blink from a network request through Conversations.
@@ -93,4 +90,17 @@ module.exports.sendResponseWithMessage = function (res, message) {
 module.exports.addBlinkSuppressHeaders = function addBlinkSuppressHeaders(res) {
   logger.debug('Adding Blink suppress headers', {}, res);
   return res.setHeader('x-blink-retry-suppress', true);
+};
+
+/**
+ * Adds error noticeable versions of the most used response helpers. These methods are decorated
+ * so that they will notice the error to NewRelic.
+ * They exist so we can have flexibility to respond with an error but not log it in New relic. Like
+ * Mobile not found errors in the ?origin=signup route.
+ */
+module.exports.errorNoticeable = {
+  sendErrorResponseWithNoRetry: helpers.analytics
+    .getErrorNoticeableMethod(module.exports.sendErrorResponseWithNoRetry),
+  sendErrorResponse: helpers.analytics
+    .getErrorNoticeableMethod(module.exports.sendErrorResponse),
 };

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -3,7 +3,7 @@
 const { STATUS_CODES } = require('http');
 
 const logger = require('./logger');
-const config = require('../config/lib/helpers');
+const config = require('../config/lib/helpers/response');
 const helpers = require('./helpers/index');
 
 
@@ -17,28 +17,16 @@ Object.keys(helpers).forEach((helperName) => {
 /**
  * Sends response with err code and message.
  *
- * @param  {Object} res
+ * @param  {Response} res
  * @param  {Error} err
  * @param  {Boolean} retry by default, errors should be retried by Blink
  */
 module.exports.sendErrorResponse = function (res, err, retry = true) {
   const error = helpers.util.parseStatusAndMessageFromError(err);
-  /**
-   * If the error has a response and the response contains the Blink Suppress headers,
-   * this error is being relayed to Blink from a network request through Conversations.
-   * We have to also relay the Suppress headers.
-   */
-  const errHasResponseGet = error.response && error.response.get;
-  if (!retry) {
-    exports.addBlinkSuppressHeaders(res);
-  /**
-   * TODO: deprecate? this check is here because we used to relay errors from G-Campaigns
-   * but since we are deprecating it, we could remove this extra check.
-   */
-  } else if (errHasResponseGet && error.response.get(config.blinkSuppressHeaders)) {
-    exports.addBlinkSuppressHeaders(res);
-  }
 
+  if (!retry) {
+    exports.addNoRetryHeaders(res);
+  }
   return this.sendResponseWithStatusCode(res, error.status, error.message);
 };
 
@@ -49,7 +37,7 @@ module.exports.sendErrorResponseWithNoRetry = function (res, err) {
 /**
  * Sends response with custom status code and message
  *
- * @param  {Object} res
+ * @param  {Response} res
  * @param  {Number} code = 200
  * @param  {String} message = 'OK'
  */
@@ -70,26 +58,25 @@ module.exports.sendResponseWithStatusCode = function (res, code = 200, message) 
 
 /**
  * Sends response with Message.
- * @param {object} req
+ * @param {Request} req
  * @param {Message} message
  */
 module.exports.sendResponseWithMessage = function (res, message) {
   logger.debug('sendResponseWithMessage', { messageId: message.id }, res);
-
   const data = { messages: [message] };
 
   return res.send({ data });
 };
 
 /**
- * addBlinkSuppressHeaders
+ * Adds headers to the response that signal our message broker no to retry this request
  *
- * @param  {object} res The response object
- * @return {object}     Response
+ * @param  {Response} res The response object
+ * @return {Response}     Response
  */
-module.exports.addBlinkSuppressHeaders = function addBlinkSuppressHeaders(res) {
+module.exports.addNoRetryHeaders = function addNoRetryHeaders(res) {
   logger.debug('Adding Blink suppress headers', {}, res);
-  return res.setHeader('x-blink-retry-suppress', true);
+  return res.setHeader(config.noRetryHeader, true);
 };
 
 /**

--- a/lib/helpers/analytics.js
+++ b/lib/helpers/analytics.js
@@ -51,7 +51,20 @@ function getErrorNoticeableMethod(fn) {
   };
 }
 
+/**
+ * Record error metadata in NewRelic transaction
+ * @param {Error} error
+ * @param {Object} attributes
+ */
+function addHandledError(error, attributes = {}) {
+  const isError = error instanceof Error;
+  if (isError) {
+    newrelic.noticeError(error, attributes);
+  }
+}
+
 module.exports = {
+  addHandledError,
   addCustomAttributes,
   addTwilioError,
   getErrorNoticeableMethod,

--- a/lib/helpers/analytics.js
+++ b/lib/helpers/analytics.js
@@ -1,27 +1,58 @@
 'use strict';
 
+const lodash = require('lodash');
+
 const logger = require('../logger');
 const newrelic = require('newrelic');
 
 /**
- * addHandledError
+ * Set multiple custom attribute values to be displayed along with the transaction
+ * trace in the New Relic UI.
+ * @see https://docs.newrelic.com/docs/agents/nodejs-agent/api-guides/nodejs-agent-api#add-custom-attributes
+ * @param {*} paramsObject
+ */
+function addCustomAttributes(paramsObject) {
+  logger.debug('analytics.addCustomAttributes', paramsObject);
+  newrelic.addCustomAttributes(paramsObject);
+}
+
+/**
+ * Adds the twilioErrorCode as a transaction parameter
  * @param {Error} error
  */
-function addHandledError(error, attributes = {}) {
-  // @see https://docs.newrelic.com/docs/agents/nodejs-agent/api-guides/nodejs-agent-api#noticeError
-  newrelic.noticeError(error, attributes);
+function addTwilioError(error) {
+  const params = {
+    twilioErrorCode: error.code,
+  };
+  module.exports.addCustomAttributes(params);
+}
+
+/**
+ * Decorates any function and searches for the first passed error in the arguments
+ * to send it to NewRelic. It then calls the function with all passed arguments.
+ *
+ * @param {Function} fn
+ */
+function getErrorNoticeableMethod(fn) {
+  if (typeof fn !== 'function') {
+    return fn;
+  }
+  return function (...args) {
+    const error = lodash.find(args, arg => arg instanceof Error);
+    if (error) {
+      /**
+       * NewRelic does not capture error metadata when we handle them inside a try/catch block.
+       * We have to "notice" them in order to capture the metadata.
+       * @see https://docs.newrelic.com/docs/agents/nodejs-agent/api-guides/nodejs-agent-api#noticeError
+       */
+      newrelic.noticeError(error);
+    }
+    return fn(...args);
+  };
 }
 
 module.exports = {
-  addCustomAttributes: function addCustomAttributes(paramsObject) {
-    logger.debug('analytics.addCustomAttributes', paramsObject);
-    newrelic.addCustomAttributes(paramsObject);
-  },
-  addTwilioError: function addTwilioError(error) {
-    const params = {
-      twilioErrorCode: error.code,
-    };
-    module.exports.addCustomAttributes(params);
-  },
-  addHandledError,
+  addCustomAttributes,
+  addTwilioError,
+  getErrorNoticeableMethod,
 };

--- a/lib/helpers/replies.js
+++ b/lib/helpers/replies.js
@@ -54,7 +54,11 @@ module.exports.sendReply = async function (req, res, messageText, messageTemplat
 
     return helpers.response.sendData(res, { messages });
   } catch (err) {
-    return helpers.sendErrorResponse(res, err);
+    /**
+     * This catches a user update error or post to platform error.
+     * I think we should expose this error metadata in NewRelic.
+     */
+    return helpers.errorNoticeable.sendErrorResponse(res, err);
   }
 };
 

--- a/lib/helpers/twilio.js
+++ b/lib/helpers/twilio.js
@@ -149,6 +149,7 @@ function handleMessageCreationSuccess(twilioResponse, message) {
  * @param {String} failedAt ISO8601 Date
  */
 async function handleMessageCreationFailure(twilioError, message, failedAt) {
+  // Is the status code 400? (Bad Request)
   if (module.exports.isBadRequestError(twilioError)) {
     // We are mutating the message instance.
     message.metadata.delivery.failedAt = failedAt || moment().format();

--- a/lib/helpers/user.js
+++ b/lib/helpers/user.js
@@ -212,6 +212,7 @@ async function updateByMemberMessageReq(req) {
     }
     return user;
   } catch (error) {
+    // TODO: If we are re-throwing, why catch at all?
     throw error;
   }
 }

--- a/lib/middleware/messages/broadcast-lite/message-outbound-validate.js
+++ b/lib/middleware/messages/broadcast-lite/message-outbound-validate.js
@@ -7,7 +7,7 @@ module.exports = function validateOutbound() {
   return (req, res, next) => {
     if (!helpers.user.isSubscriber(req.user)) {
       const error = new UnprocessableEntityError('Northstar User is unsubscribed.');
-      return helpers.sendErrorResponseWithSuppressHeaders(res, error);
+      return helpers.sendErrorResponseWithNoRetry(res, error);
     }
     try {
       /**
@@ -15,8 +15,8 @@ module.exports = function validateOutbound() {
        */
       const mobileNumber = helpers.util.formatMobileNumber(req.mobileNumber);
       helpers.request.setPlatformUserId(req, mobileNumber);
-    } catch (err) {
-      return helpers.sendErrorResponseWithSuppressHeaders(res, err);
+    } catch (error) {
+      return helpers.sendErrorResponseWithNoRetry(res, error);
     }
 
     return next();

--- a/lib/middleware/messages/broadcast-lite/message-outbound-validate.js
+++ b/lib/middleware/messages/broadcast-lite/message-outbound-validate.js
@@ -7,7 +7,8 @@ module.exports = function validateOutbound() {
   return (req, res, next) => {
     if (!helpers.user.isSubscriber(req.user)) {
       const error = new UnprocessableEntityError('Northstar User is unsubscribed.');
-      return helpers.sendErrorResponseWithNoRetry(res, error);
+      // Expose error metadata in NewRelic
+      return helpers.errorNoticeable.sendErrorResponseWithNoRetry(res, error);
     }
     try {
       /**

--- a/lib/middleware/messages/member/params.js
+++ b/lib/middleware/messages/member/params.js
@@ -11,7 +11,7 @@ module.exports = function params() {
     logger.debug(`origin=${origin}`, { params: req.body }, req);
     if (!origin) {
       const error = new UnprocessableEntityError('Missing required origin parameter.');
-      return helpers.sendErrorResponseWithSuppressHeaders(res, error);
+      return helpers.sendErrorResponseWithNoRetry(res, error);
     }
 
     if (helpers.request.isTwilio(req)) {
@@ -27,7 +27,7 @@ module.exports = function params() {
     helpers.request.setUserId(req, userId);
     if (!req.userId) {
       const error = new UnprocessableEntityError('Missing required userId.');
-      return helpers.sendErrorResponseWithSuppressHeaders(res, error);
+      return helpers.sendErrorResponseWithNoRetry(res, error);
     }
     req.platformMessageId = body.messageId;
     req.inboundMessageText = body.text;

--- a/lib/middleware/messages/message-outbound-send.js
+++ b/lib/middleware/messages/message-outbound-send.js
@@ -14,7 +14,7 @@ module.exports = function sendOutboundMessage() {
         if (helpers.twilio.isBadRequestError(error)) {
           helpers.analytics.addTwilioError(error);
           logger.error('sendOutboundMessage: Twilio bad request error', { error }, req);
-          return helpers.sendErrorResponseWithSuppressHeaders(res, error);
+          return helpers.sendErrorResponseWithNoRetry(res, error);
         }
         return helpers.sendErrorResponse(res, error);
       }

--- a/lib/middleware/messages/message-outbound-send.js
+++ b/lib/middleware/messages/message-outbound-send.js
@@ -14,7 +14,8 @@ module.exports = function sendOutboundMessage() {
         if (helpers.twilio.isBadRequestError(error)) {
           helpers.analytics.addTwilioError(error);
           logger.error('sendOutboundMessage: Twilio bad request error', { error }, req);
-          return helpers.sendErrorResponseWithNoRetry(res, error);
+          // Expose error metadata in NewRelic
+          return helpers.errorNoticeable.sendErrorResponseWithNoRetry(res, error);
         }
         return helpers.sendErrorResponse(res, error);
       }

--- a/lib/middleware/messages/message-outbound-validate.js
+++ b/lib/middleware/messages/message-outbound-validate.js
@@ -7,12 +7,14 @@ module.exports = function validateOutbound(config) {
   return (req, res, next) => {
     if (!helpers.user.isSubscriber(req.user)) {
       const error = new UnprocessableEntityError('Northstar User is unsubscribed.');
-      return helpers.sendErrorResponseWithNoRetry(res, error);
+      // Expose error metadata in NewRelic
+      return helpers.errorNoticeable.sendErrorResponseWithNoRetry(res, error);
     }
 
     if (config.shouldSendWhenPaused === false && helpers.user.isPaused(req.user)) {
       const error = new UnprocessableEntityError('Northstar User conversation is paused.');
-      return helpers.sendErrorResponseWithNoRetry(res, error);
+      // Expose error metadata in NewRelic
+      return helpers.errorNoticeable.sendErrorResponseWithNoRetry(res, error);
     }
 
     if (req.platform !== 'sms') {

--- a/lib/middleware/messages/message-outbound-validate.js
+++ b/lib/middleware/messages/message-outbound-validate.js
@@ -7,12 +7,12 @@ module.exports = function validateOutbound(config) {
   return (req, res, next) => {
     if (!helpers.user.isSubscriber(req.user)) {
       const error = new UnprocessableEntityError('Northstar User is unsubscribed.');
-      return helpers.sendErrorResponseWithSuppressHeaders(res, error);
+      return helpers.sendErrorResponseWithNoRetry(res, error);
     }
 
     if (config.shouldSendWhenPaused === false && helpers.user.isPaused(req.user)) {
       const error = new UnprocessableEntityError('Northstar User conversation is paused.');
-      return helpers.sendErrorResponseWithSuppressHeaders(res, error);
+      return helpers.sendErrorResponseWithNoRetry(res, error);
     }
 
     if (req.platform !== 'sms') {
@@ -26,7 +26,7 @@ module.exports = function validateOutbound(config) {
       const mobileNumber = helpers.util.formatMobileNumber(req.user.mobile);
       helpers.request.setPlatformUserId(req, mobileNumber);
     } catch (err) {
-      return helpers.sendErrorResponseWithSuppressHeaders(res, err);
+      return helpers.sendErrorResponseWithNoRetry(res, err);
     }
 
     return next();

--- a/lib/middleware/messages/signup/web-signup-confirmation-get.js
+++ b/lib/middleware/messages/signup/web-signup-confirmation-get.js
@@ -17,7 +17,7 @@ module.exports = function getWebSignupConfirmation() {
        * @see https://github.com/DoSomething/gambit-conversations/pull/423#pullrequestreview-167440897
        */
       if (!template) {
-        helpers.addBlinkSuppressHeaders(res);
+        helpers.addNoRetryHeaders(res);
         return helpers.response.sendNoContent(res, 'Web signup confirmation not found.');
       }
 

--- a/lib/middleware/messages/user-get.js
+++ b/lib/middleware/messages/user-get.js
@@ -16,6 +16,7 @@ module.exports = function fetchUser(config) {
     try {
       let user;
       /**
+       * TODO: deprecate? Are we ever using the feature of making anonymous get user requests?
        * WARNING: Only public properties are returned. Make sure to double check
        * that we are not relaying on some private property down the road in the route when passing
        * shouldFetchUnauthenticated.
@@ -38,7 +39,8 @@ module.exports = function fetchUser(config) {
           return next();
         }
         const userNotFoundError = new NotFoundError('Northstar user not found.');
-        return helpers.sendErrorResponseWithNoRetry(res, userNotFoundError);
+        // Expose error metadata in NewRelic
+        return helpers.errorNoticeable.sendErrorResponseWithNoRetry(res, userNotFoundError);
       }
 
       return helpers.sendErrorResponse(res, error);

--- a/lib/middleware/messages/user-get.js
+++ b/lib/middleware/messages/user-get.js
@@ -38,7 +38,7 @@ module.exports = function fetchUser(config) {
           return next();
         }
         const userNotFoundError = new NotFoundError('Northstar user not found.');
-        return helpers.sendErrorResponseWithSuppressHeaders(res, userNotFoundError);
+        return helpers.sendErrorResponseWithNoRetry(res, userNotFoundError);
       }
 
       return helpers.sendErrorResponse(res, error);

--- a/test/unit/lib/lib-helpers/analytics.test.js
+++ b/test/unit/lib/lib-helpers/analytics.test.js
@@ -32,6 +32,8 @@ test.beforeEach(() => {
   stubs.stubLogger(sandbox, logger);
   sandbox.stub(newrelic, 'addCustomAttributes')
     .returns(underscore.noop);
+  sandbox.stub(newrelic, 'noticeError')
+    .returns(underscore.noop);
 });
 
 // Cleanup!
@@ -56,4 +58,18 @@ test('addTwilioError should call addCustomAttributes', () => {
   const error = stubs.twilio.getPostMessageError();
   analyticsHelper.addTwilioError(error);
   analyticsHelper.addCustomAttributes.should.have.been.called;
+});
+
+test('getErrorNoticeableMethod should return a function that calls newrelic.noticeError if an Error is passed as argument', () => {
+  const dummyFunction = () => true;
+  const decoratedDummyFunction = analyticsHelper.getErrorNoticeableMethod(dummyFunction);
+  decoratedDummyFunction(new Error('boom!'));
+  newrelic.noticeError.should.have.been.called;
+});
+
+test('getErrorNoticeableMethod should return a function that doesn\'t call newrelic.noticeError if no Error is passed as argument', () => {
+  const dummyFunction = () => true;
+  const decoratedDummyFunction = analyticsHelper.getErrorNoticeableMethod(dummyFunction);
+  decoratedDummyFunction('hi', 'my', 'name', 'is');
+  newrelic.noticeError.should.not.have.been.called;
 });

--- a/test/unit/lib/lib-helpers/analytics.test.js
+++ b/test/unit/lib/lib-helpers/analytics.test.js
@@ -42,6 +42,17 @@ test.afterEach(() => {
   sandbox.restore();
 });
 
+test('addHandledError should call newrelic.noticeError if an Error is passed', () => {
+  const error = new Error('Booom!');
+  analyticsHelper.addHandledError(error);
+  newrelic.noticeError.should.have.been.called;
+});
+
+test('addHandledError should not call newrelic.noticeError if an Error is not passed', () => {
+  analyticsHelper.addHandledError('hello world!');
+  newrelic.noticeError.should.not.have.been.called;
+});
+
 test('addCustomAttributes should call newrelic.addCustomAttributes', () => {
   analyticsHelper.addCustomAttributes(mockPayload);
   newrelic.addCustomAttributes.should.have.been.called;

--- a/test/unit/lib/lib-helpers/replies.test.js
+++ b/test/unit/lib/lib-helpers/replies.test.js
@@ -42,6 +42,8 @@ test.beforeEach((t) => {
   t.context.res = httpMocks.createResponse();
   sandbox.stub(helpers, 'sendErrorResponse')
     .returns(() => {});
+  sandbox.stub(helpers.errorNoticeable, 'sendErrorResponse')
+    .returns(() => { });
   t.context.req.campaign = campaignFactory.getValidCampaign();
 });
 
@@ -92,7 +94,7 @@ test('sendReply(): sends error if updateByMemberMessageReq fails', async (t) => 
   await repliesHelper.sendReply(t.context.req, t.context.res, 'text', templates.campaignClosed);
 
   // asserts
-  helpers.sendErrorResponse.should.have.been.calledWith(t.context.res, error);
+  helpers.errorNoticeable.sendErrorResponse.should.have.been.calledWith(t.context.res, error);
 });
 
 test('sendReply(): responds with the inbound and outbound messages', async (t) => {
@@ -187,7 +189,7 @@ test('sendReply(): should call sendErrorResponse on failure', async (t) => {
   await repliesHelper.sendReply(req, t.context.res, 'text line', templates.campaignClosed);
 
   // asserts
-  helpers.sendErrorResponse.should.have.been.called;
+  helpers.errorNoticeable.sendErrorResponse.should.have.been.called;
 });
 
 test('askCaption(): should call sendReplyWithTopicTemplate', async (t) => {

--- a/test/unit/lib/middleware/messages/message-outbound-send.test.js
+++ b/test/unit/lib/middleware/messages/message-outbound-send.test.js
@@ -37,7 +37,7 @@ const outboundMessage = messageFactory.getValidMessage();
 test.beforeEach((t) => {
   sandbox.stub(helpers, 'sendResponseWithMessage')
     .returns(underscore.noop);
-  sandbox.stub(helpers, 'sendErrorResponseWithSuppressHeaders')
+  sandbox.stub(helpers, 'sendErrorResponseWithNoRetry')
     .returns(underscore.noop);
   sandbox.stub(helpers, 'sendErrorResponse')
     .returns(underscore.noop);
@@ -66,7 +66,7 @@ test('sendOutbound calls req.conversation.postLastOutboundMessageToPlatform', as
   helpers.sendResponseWithMessage.should.have.been.calledWith(t.context.res, outboundMessage);
 });
 
-test('sendOutbound calls sendErrorResponseWithSuppressHeaders if Twilio bad request', async (t) => {
+test('sendOutbound calls sendErrorResponseWithNoRetry if Twilio bad request', async (t) => {
   const next = sinon.stub();
   sandbox.stub(conversation, 'postLastOutboundMessageToPlatform')
     .returns(Promise.reject(twilioErrorStub));
@@ -81,7 +81,7 @@ test('sendOutbound calls sendErrorResponseWithSuppressHeaders if Twilio bad requ
   conversation.postLastOutboundMessageToPlatform.should.have.have.been.called;
   helpers.analytics.addTwilioError.should.have.been.called;
   helpers.sendErrorResponse.should.not.have.been.called;
-  helpers.sendErrorResponseWithSuppressHeaders.should.have.been.called;
+  helpers.sendErrorResponseWithNoRetry.should.have.been.called;
   helpers.sendResponseWithMessage.should.not.have.been.called;
 });
 
@@ -100,6 +100,6 @@ test('sendOutbound calls sendErrorResponse if error is not Twilio bad request', 
   conversation.postLastOutboundMessageToPlatform.should.have.been.called;
   helpers.analytics.addTwilioError.should.not.have.been.called;
   helpers.sendErrorResponse.should.have.been.called;
-  helpers.sendErrorResponseWithSuppressHeaders.should.not.have.been.called;
+  helpers.sendErrorResponseWithNoRetry.should.not.have.been.called;
   helpers.sendResponseWithMessage.should.not.have.been.called;
 });

--- a/test/unit/lib/middleware/messages/message-outbound-send.test.js
+++ b/test/unit/lib/middleware/messages/message-outbound-send.test.js
@@ -37,7 +37,7 @@ const outboundMessage = messageFactory.getValidMessage();
 test.beforeEach((t) => {
   sandbox.stub(helpers, 'sendResponseWithMessage')
     .returns(underscore.noop);
-  sandbox.stub(helpers, 'sendErrorResponseWithNoRetry')
+  sandbox.stub(helpers.errorNoticeable, 'sendErrorResponseWithNoRetry')
     .returns(underscore.noop);
   sandbox.stub(helpers, 'sendErrorResponse')
     .returns(underscore.noop);
@@ -80,8 +80,8 @@ test('sendOutbound calls sendErrorResponseWithNoRetry if Twilio bad request', as
   await middleware(t.context.req, t.context.res, next);
   conversation.postLastOutboundMessageToPlatform.should.have.have.been.called;
   helpers.analytics.addTwilioError.should.have.been.called;
+  helpers.errorNoticeable.sendErrorResponseWithNoRetry.should.have.been.called;
   helpers.sendErrorResponse.should.not.have.been.called;
-  helpers.sendErrorResponseWithNoRetry.should.have.been.called;
   helpers.sendResponseWithMessage.should.not.have.been.called;
 });
 
@@ -100,6 +100,6 @@ test('sendOutbound calls sendErrorResponse if error is not Twilio bad request', 
   conversation.postLastOutboundMessageToPlatform.should.have.been.called;
   helpers.analytics.addTwilioError.should.not.have.been.called;
   helpers.sendErrorResponse.should.have.been.called;
-  helpers.sendErrorResponseWithNoRetry.should.not.have.been.called;
+  helpers.errorNoticeable.sendErrorResponseWithNoRetry.should.not.have.been.called;
   helpers.sendResponseWithMessage.should.not.have.been.called;
 });

--- a/test/unit/lib/middleware/messages/message-outbound-validate.test.js
+++ b/test/unit/lib/middleware/messages/message-outbound-validate.test.js
@@ -33,7 +33,7 @@ const supportConfigStub = stubs.config.getMessageOutbound(true);
 test.beforeEach((t) => {
   sandbox.stub(helpers.request, 'setPlatformUserId')
     .returns(underscore.noop);
-  sandbox.stub(helpers, 'sendErrorResponseWithSuppressHeaders')
+  sandbox.stub(helpers, 'sendErrorResponseWithNoRetry')
     .returns(sendErrorResponseStub);
 
   // setup req, res mocks
@@ -50,7 +50,7 @@ test.afterEach((t) => {
   t.context = {};
 });
 
-test('validateOutbound calls sendErrorResponseWithSuppressHeaders if user is not subscriber', (t) => {
+test('validateOutbound calls sendErrorResponseWithNoRetry if user is not subscriber', (t) => {
   // setup
   const next = sinon.stub();
   const middleware = validateOutbound(defaultConfigStub);
@@ -60,7 +60,7 @@ test('validateOutbound calls sendErrorResponseWithSuppressHeaders if user is not
   // test
   middleware(t.context.req, t.context.res, next);
   helpers.user.isSubscriber.should.have.been.called;
-  helpers.sendErrorResponseWithSuppressHeaders.should.have.been.called;
+  helpers.sendErrorResponseWithNoRetry.should.have.been.called;
   next.should.not.have.been.called;
 });
 
@@ -77,11 +77,11 @@ test('validateOutbound sends error if user is paused and config.shouldSendWhenPa
   middleware(t.context.req, t.context.res, next);
   helpers.user.isSubscriber.should.have.been.called;
   helpers.user.isPaused.should.have.been.called;
-  helpers.sendErrorResponseWithSuppressHeaders.should.have.been.called;
+  helpers.sendErrorResponseWithNoRetry.should.have.been.called;
   next.should.not.have.been.called;
 });
 
-test('validateOutbound calls sendErrorResponseWithSuppressHeaders if formatMobileNumber throws', (t) => {
+test('validateOutbound calls sendErrorResponseWithNoRetry if formatMobileNumber throws', (t) => {
   // setup
   const next = sinon.stub();
   const middleware = validateOutbound(defaultConfigStub);
@@ -97,7 +97,7 @@ test('validateOutbound calls sendErrorResponseWithSuppressHeaders if formatMobil
   helpers.user.isSubscriber.should.have.been.called;
   helpers.user.isPaused.should.have.been.called;
   helpers.util.formatMobileNumber.should.have.been.called;
-  helpers.sendErrorResponseWithSuppressHeaders.should.have.been.called;
+  helpers.sendErrorResponseWithNoRetry.should.have.been.called;
   next.should.not.have.been.called;
 });
 
@@ -118,7 +118,7 @@ test('validateOutbound calls next if user validates', (t) => {
   helpers.user.isPaused.should.have.been.called;
   helpers.util.formatMobileNumber.should.have.been.called;
   helpers.request.setPlatformUserId.should.have.been.called;
-  helpers.sendErrorResponseWithSuppressHeaders.should.not.have.been.called;
+  helpers.sendErrorResponseWithNoRetry.should.not.have.been.called;
   next.should.have.been.called;
 });
 
@@ -140,7 +140,7 @@ test('validateOutbound does not call formatMobileNumber if platform is not SMS',
   helpers.user.isPaused.should.have.been.called;
   helpers.util.formatMobileNumber.should.not.have.been.called;
   helpers.request.setPlatformUserId.should.not.have.been.called;
-  helpers.sendErrorResponseWithSuppressHeaders.should.not.have.been.called;
+  helpers.sendErrorResponseWithNoRetry.should.not.have.been.called;
   next.should.have.been.called;
 });
 
@@ -156,6 +156,6 @@ test('validateOutbound calls next if user is paused and config.shouldSendWhenPau
 
   // test
   middleware(t.context.req, t.context.res, next);
-  helpers.sendErrorResponseWithSuppressHeaders.should.not.have.been.called;
+  helpers.sendErrorResponseWithNoRetry.should.not.have.been.called;
   next.should.have.been.called;
 });

--- a/test/unit/lib/middleware/messages/message-outbound-validate.test.js
+++ b/test/unit/lib/middleware/messages/message-outbound-validate.test.js
@@ -35,6 +35,8 @@ test.beforeEach((t) => {
     .returns(underscore.noop);
   sandbox.stub(helpers, 'sendErrorResponseWithNoRetry')
     .returns(sendErrorResponseStub);
+  sandbox.stub(helpers.errorNoticeable, 'sendErrorResponseWithNoRetry')
+    .returns(sendErrorResponseStub);
 
   // setup req, res mocks
   t.context.req = httpMocks.createRequest();
@@ -60,7 +62,7 @@ test('validateOutbound calls sendErrorResponseWithNoRetry if user is not subscri
   // test
   middleware(t.context.req, t.context.res, next);
   helpers.user.isSubscriber.should.have.been.called;
-  helpers.sendErrorResponseWithNoRetry.should.have.been.called;
+  helpers.errorNoticeable.sendErrorResponseWithNoRetry.should.have.been.called;
   next.should.not.have.been.called;
 });
 
@@ -77,7 +79,7 @@ test('validateOutbound sends error if user is paused and config.shouldSendWhenPa
   middleware(t.context.req, t.context.res, next);
   helpers.user.isSubscriber.should.have.been.called;
   helpers.user.isPaused.should.have.been.called;
-  helpers.sendErrorResponseWithNoRetry.should.have.been.called;
+  helpers.errorNoticeable.sendErrorResponseWithNoRetry.should.have.been.called;
   next.should.not.have.been.called;
 });
 
@@ -119,6 +121,7 @@ test('validateOutbound calls next if user validates', (t) => {
   helpers.util.formatMobileNumber.should.have.been.called;
   helpers.request.setPlatformUserId.should.have.been.called;
   helpers.sendErrorResponseWithNoRetry.should.not.have.been.called;
+  helpers.errorNoticeable.sendErrorResponseWithNoRetry.should.not.have.been.called;
   next.should.have.been.called;
 });
 

--- a/test/unit/lib/middleware/messages/signup/web-signup-confirmation-get.test.js
+++ b/test/unit/lib/middleware/messages/signup/web-signup-confirmation-get.test.js
@@ -31,7 +31,7 @@ const getWebSignupConfirmation = require('../../../../../../lib/middleware/messa
 const sandbox = sinon.sandbox.create();
 
 test.beforeEach((t) => {
-  sandbox.stub(helpers, 'addBlinkSuppressHeaders')
+  sandbox.stub(helpers, 'addNoRetryHeaders')
     .returns(underscore.noop);
   sandbox.stub(helpers, 'sendErrorResponse')
     .returns(underscore.noop);

--- a/test/unit/lib/middleware/messages/user-get.test.js
+++ b/test/unit/lib/middleware/messages/user-get.test.js
@@ -39,7 +39,7 @@ test.beforeEach((t) => {
     .returns(underscore.noop);
   sandbox.stub(helpers, 'sendErrorResponse')
     .returns(sendErrorResponseStub);
-  sandbox.stub(helpers, 'sendErrorResponseWithSuppressHeaders')
+  sandbox.stub(helpers, 'sendErrorResponseWithNoRetry')
     .returns(sendErrorResponseStub);
 
   // setup req, res mocks
@@ -80,7 +80,7 @@ test('getUser calls sendErrorResponse if helpers.user.fetchFromReq fails', async
   await middleware(t.context.req, t.context.res, next);
   helpers.request.setUser.should.not.have.been.called;
   helpers.sendErrorResponse.should.have.been.called;
-  helpers.sendErrorResponseWithSuppressHeaders.should.not.have.been.called;
+  helpers.sendErrorResponseWithNoRetry.should.not.have.been.called;
 });
 
 test('getUser calls sendErrorResponse if User not found and config.shouldSendError', async (t) => {
@@ -94,7 +94,7 @@ test('getUser calls sendErrorResponse if User not found and config.shouldSendErr
   await middleware(t.context.req, t.context.res, next);
   helpers.request.setUser.should.not.have.been.called;
   helpers.sendErrorResponse.should.not.have.been.called;
-  helpers.sendErrorResponseWithSuppressHeaders.should.have.been.called;
+  helpers.sendErrorResponseWithNoRetry.should.have.been.called;
   next.should.not.have.been.called;
 });
 
@@ -109,6 +109,6 @@ test('getUser calls next if User not found and config.shouldSendError is false',
   await middleware(t.context.req, t.context.res, next);
   helpers.request.setUser.should.not.have.been.called;
   helpers.sendErrorResponse.should.not.have.been.called;
-  helpers.sendErrorResponseWithSuppressHeaders.should.not.have.been.called;
+  helpers.sendErrorResponseWithNoRetry.should.not.have.been.called;
   next.should.have.been.called;
 });

--- a/test/unit/lib/middleware/messages/user-get.test.js
+++ b/test/unit/lib/middleware/messages/user-get.test.js
@@ -39,7 +39,7 @@ test.beforeEach((t) => {
     .returns(underscore.noop);
   sandbox.stub(helpers, 'sendErrorResponse')
     .returns(sendErrorResponseStub);
-  sandbox.stub(helpers, 'sendErrorResponseWithNoRetry')
+  sandbox.stub(helpers.errorNoticeable, 'sendErrorResponseWithNoRetry')
     .returns(sendErrorResponseStub);
 
   // setup req, res mocks
@@ -80,7 +80,7 @@ test('getUser calls sendErrorResponse if helpers.user.fetchFromReq fails', async
   await middleware(t.context.req, t.context.res, next);
   helpers.request.setUser.should.not.have.been.called;
   helpers.sendErrorResponse.should.have.been.called;
-  helpers.sendErrorResponseWithNoRetry.should.not.have.been.called;
+  helpers.errorNoticeable.sendErrorResponseWithNoRetry.should.not.have.been.called;
 });
 
 test('getUser calls sendErrorResponse if User not found and config.shouldSendError', async (t) => {
@@ -94,7 +94,7 @@ test('getUser calls sendErrorResponse if User not found and config.shouldSendErr
   await middleware(t.context.req, t.context.res, next);
   helpers.request.setUser.should.not.have.been.called;
   helpers.sendErrorResponse.should.not.have.been.called;
-  helpers.sendErrorResponseWithNoRetry.should.have.been.called;
+  helpers.errorNoticeable.sendErrorResponseWithNoRetry.should.have.been.called;
   next.should.not.have.been.called;
 });
 
@@ -109,6 +109,6 @@ test('getUser calls next if User not found and config.shouldSendError is false',
   await middleware(t.context.req, t.context.res, next);
   helpers.request.setUser.should.not.have.been.called;
   helpers.sendErrorResponse.should.not.have.been.called;
-  helpers.sendErrorResponseWithNoRetry.should.not.have.been.called;
+  helpers.errorNoticeable.sendErrorResponseWithNoRetry.should.not.have.been.called;
   next.should.have.been.called;
 });


### PR DESCRIPTION
#### What's this PR do?
It adds a decorated version of each method: `helpers.sendErrorResponse` and `helpers.sendErrorResponseWithNoRetry`. These versions will call `newrelic.noticeError` and log the error metadata in them.

*Usage*: We can use the `helpers.errorNoticeable.sendErrorResponseWithNoRetry` method to send a no reply response with an error, while logging the error metadata in NewRelic. Using the `helpers.sendErrorResponseWithNoRetry` method works the same but won't log the metadata to NewRelic.

#### How should this be reviewed?
- 👀 
- All tests should pass

#### Any background context you want to provide?
We were sending all error metadata to NewRelic, but has become very noisy.

#### Checklist
- [x] Tests added/updated for new features/bug fixes.
- [ ] Tested on staging.
