### PR TITLE
Adds support for user.addrState tag

### DIFF
--- a/lib/helpers/tags.js
+++ b/lib/helpers/tags.js
@@ -87,6 +87,7 @@ function getUserLinkQueryParams(req) {
 function getUserTag(user) {
   return {
     id: user.id,
+    addrState: user.addr_state,
     votingPlan: module.exports.getVotingPlan(user),
   };
 }


### PR DESCRIPTION
#### What's this PR do?

Adds support for `user.addrState` to embed a user's `addr_state` property within an outbound message.

#### How should this be reviewed?

Test broadcast `5wC5BaBrhctCnRcwU1XZf6` to verify that your `addr_state` property is rendered within the `from DC to {{user.addrState}}` copy:

<img width="500" alt="screen shot 2019-01-30 at 3 35 26 pm" src="https://user-images.githubusercontent.com/1236811/52020043-b156c100-24a4-11e9-9d10-defe7a3e871a.png">

#### Any background context you want to provide?
It seemed too messy to have snakecase  and camelcase properties per the `votingPlan` tag introduced in https://github.com/DoSomething/gambit-conversations/pull/427, which is why the full user was refactored as just `id` and `votingPlan`. Will update the [Gambit Admin wiki](https://github.com/dosomething/gambit-admin/wiki/tags) accordingly.

#### Checklist
- [ ] Documentation added for new features/changed endpoints.
- [ ] Tests added/updated for new features/bug fixes.
- [x] Tested on staging.
